### PR TITLE
build(systemd): Tune systemd service hardering

### DIFF
--- a/contrib/systemd/passless.service
+++ b/contrib/systemd/passless.service
@@ -12,9 +12,6 @@ RestartSec=5s
 # Security hardening
 # The application already handles its own memory locking and core dump prevention
 # but we can add additional systemd protections
-ProtectSystem=strict
-ProtectHome=read-only
-PrivateTmp=true
 NoNewPrivileges=true
 
 # Logging

--- a/src/storage/pass.rs
+++ b/src/storage/pass.rs
@@ -178,8 +178,6 @@ impl PassStorageAdapter {
                 Ok(())
             }
             Err(e) => {
-                debug!("Failed to prepare store sync: {:?}", e);
-                // Don't fail the operation if sync fails, just log a warning
                 warn!("Failed to prepare store sync: {:?}", e);
                 Ok(())
             }


### PR DESCRIPTION
We removed:
```
ProtectSystem=strict
ProtectHome=read-only
PrivateTmp=true
```
Because if not we cannot access pass repository and ssh keys.