### PR TITLE
feat: add capability setup for memory locking

### DIFF
--- a/.ci/passless.install
+++ b/.ci/passless.install
@@ -2,6 +2,17 @@ post_install() {
     echo ""
     echo "==> Passless has been installed successfully!"
     echo ""
+
+    # Set capability for memory locking without root
+    if setcap cap_ipc_lock=+ep /usr/bin/passless 2>/dev/null; then
+        echo "    ✓ CAP_IPC_LOCK capability set for memory locking"
+    else
+        echo "    ✗ Failed to set CAP_IPC_LOCK capability"
+        echo "      To enable memory locking without root, run:"
+        echo "        sudo setcap cap_ipc_lock=+ep /usr/bin/passless"
+    fi
+    echo ""
+
     echo "    The 'fido' group has been created. Add your user to it:"
     echo "      sudo usermod -a -G fido \$USER"
     echo ""
@@ -29,6 +40,17 @@ post_upgrade() {
     echo ""
     echo "==> Passless has been upgraded."
     echo ""
+
+    # Re-apply capability for memory locking in case it was removed
+    if setcap cap_ipc_lock=+ep /usr/bin/passless 2>/dev/null; then
+        echo "    ✓ CAP_IPC_LOCK capability set for memory locking"
+    else
+        echo "    ✗ Failed to set CAP_IPC_LOCK capability"
+        echo "      To enable memory locking without root, run:"
+        echo "        sudo setcap cap_ipc_lock=+ep /usr/bin/passless"
+    fi
+    echo ""
+
     echo "    If running as a systemd service, restart it with:"
     echo "      systemctl --user restart passless.service"
     echo ""

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -45,7 +45,7 @@ pub struct SecurityConfig {
     #[arg(
         long = "use-mlock",
         env = "PASSLESS_USE_MLOCK",
-        help = "Lock credential memory to prevent swapping to disk (requires CAP_IPC_LOCK or root)"
+        help = "Lock credential memory to prevent swapping to disk (requires CAP_IPC_LOCK)"
     )]
     #[serde(default)]
     pub use_mlock: Option<bool>,
@@ -97,7 +97,8 @@ impl SecurityConfig {
         if r != 0 {
             // EINVAL, EPERM, ENOMEM possible. Treat as warning: mlockall often requires capabilities or raising RLIMIT_MEMLOCK.
             return Err(format!(
-                "mlockall failed (errno {}). Consider increasing RLIMIT_MEMLOCK or run with appropriate privileges.",
+                "mlockall failed (errno {}). Consider increasing RLIMIT_MEMLOCK.\n\
+                 Hint: grant CAP_IPC_LOCK to the binary with: 'sudo setcap cap_ipc_lock=+ep $(which passless)'",
                 std::io::Error::last_os_error()
             ).into());
         }


### PR DESCRIPTION
Add automatic capability setting and improved user guidance for enabling memory locking without root privileges.

Changes:
- Update --use-mlock help text to mention CAP_IPC_LOCK requirement
- Add helpful hint to mlockall error with setcap command
- Auto-set cap_ipc_lock capability in AUR post_install hook
- Re-apply capability in AUR post_upgrade hook
- Provide clear feedback on success/failure during install

The AUR package now automatically grants CAP_IPC_LOCK to the binary during installation, allowing users to benefit from memory locking security without manual configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)