### PR TITLE
fix: support userless passkey login

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,8 +19,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66bd29a732b644c0431c6140f370d097879203d79b80c94a6747ba0872adaef8"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -30,8 +41,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
- "aes",
- "cipher",
+ "aes 0.8.4",
+ "cipher 0.4.4",
  "ctr",
  "ghash",
  "subtle",
@@ -320,11 +331,11 @@ dependencies = [
 
 [[package]]
 name = "block-padding"
-version = "0.3.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -357,11 +368,11 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "cbc"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
 dependencies = [
- "cipher",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -431,7 +442,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -559,13 +580,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "core2"
-version = "0.4.0"
+name = "cpubits"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -622,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -635,7 +653,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -759,7 +777,7 @@ checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -857,7 +875,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "hkdf",
+ "hkdf 0.12.4",
  "pem-rfc7468",
  "pkcs8",
  "rand_core",
@@ -929,7 +947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1202,6 +1220,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1366,8 +1393,17 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1400,7 +1436,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2170,7 +2206,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2392,22 +2428,22 @@ dependencies = [
 
 [[package]]
 name = "soft-fido2"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534502693c78d72dd0973bc20d91ccde2ed0daa4fbd73e00741e14add9cb67a4"
+checksum = "85952b3d0bb48adee88e7233af66d196b139076dcb7a82db945426e5421f2fab"
 dependencies = [
- "aes",
+ "aes 0.9.0",
  "cbc",
  "cbor4ii",
  "hex",
- "hkdf",
- "hmac 0.12.1",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
  "p256",
  "rand",
  "secstr",
  "serde",
  "serde_bytes",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "smallvec",
  "soft-fido2-crypto",
  "soft-fido2-ctap",
@@ -2418,18 +2454,18 @@ dependencies = [
 
 [[package]]
 name = "soft-fido2-crypto"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350605009064223ced47149edd51d665c93cdac90d90b659b66010d6be9f3347"
+checksum = "5f74259700b8ce2efd348482ae9369cb2a00ae95cffecdd3714eb8d28a66f0b6"
 dependencies = [
- "aes",
+ "aes 0.9.0",
  "cbc",
  "ed25519-dalek",
- "hkdf",
- "hmac 0.12.1",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
  "p256",
  "rand",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "subtle",
  "thiserror",
  "zeroize",
@@ -2437,17 +2473,16 @@ dependencies = [
 
 [[package]]
 name = "soft-fido2-ctap"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad9ef970bad365837196cb7ea90ebf337a8e2273daeba7b2db384dbce19f49a"
+checksum = "27838bfc975c317e6925ffeb1a85fcab642b14d6b8359ced25ee5d1dd9f06a4d"
 dependencies = [
  "cbor4ii",
- "core2",
  "rand",
  "secstr",
  "serde",
  "serde_bytes",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "smallvec",
  "soft-fido2-crypto",
  "subtle",
@@ -2457,9 +2492,9 @@ dependencies = [
 
 [[package]]
 name = "soft-fido2-transport"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cb39b5ee4463b1804630460ebd6ce5305d185e120d902836f2ccecee5c0c81d"
+checksum = "39e6f7f951c4f273ad3a42dd85040172bc5f491f8d686938963f0d6f10dde14d"
 dependencies = [
  "hex",
  "hidapi",
@@ -2470,9 +2505,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "783f3f6f6b01e295a669edfc402133a5f2553d1f0e81284b3ba4594e80bdd4a2"
 dependencies = [
  "lock_api",
 ]
@@ -2566,7 +2601,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2969,7 +3004,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ repository = "https://github.com/pando85/passless"
 passless-core = { path = "./passless-core", version = "0.10.1" }
 passless-config-doc = { path = "./passless-config-doc", version = "0.10.1" }
 
-soft-fido2 = "0.12.2"
-soft-fido2-ctap = "0.12.2"
-soft-fido2-transport = "0.12.2"
+soft-fido2 = "0.13.0"
+soft-fido2-ctap = "0.13.0"
+soft-fido2-transport = "0.13.0"
 
 thiserror = "2.0"
 clap = { version = "4.5", features = ["std", "color", "derive", "cargo", "env"] }

--- a/cmd/passless/src/authenticator.rs
+++ b/cmd/passless/src/authenticator.rs
@@ -410,7 +410,7 @@ impl<S: CredentialStorage + 'static, P: PinStorage + 'static> AuthenticatorServi
         let options = AuthenticatorOptions {
             rk: true,                      // Resident keys (passkeys)
             up: true,                      // User presence
-            uv: Some(true),                // Built-in UV capability (notification-based)
+            uv: Some(true),                // Notification-based user verification
             plat: true,                    // Platform authenticator
             client_pin: Some(true),        // Client PIN capability
             pin_uv_auth_token: Some(true), // PIN/UV auth token support
@@ -418,7 +418,7 @@ impl<S: CredentialStorage + 'static, P: PinStorage + 'static> AuthenticatorServi
             bio_enroll: None,              // No biometric enrollment
             large_blobs: None,             // No large blob storage
             ep: None,                      // Enterprise attestation not enabled
-            always_uv: Some(security_config.always_uv),
+            always_uv: Some(false),        // Avoid browser userless-login PUAT requirements
             make_cred_uv_not_required: Some(true),
         };
 

--- a/cmd/passless/tests/e2e_client.rs
+++ b/cmd/passless/tests/e2e_client.rs
@@ -166,6 +166,38 @@ fn test_client_info() {
                 assert!(!versions.is_empty(), "No versions");
             }
         }
+
+        let mut saw_options = false;
+        for (k, v) in &map {
+            if let Value::Integer(key) = k
+                && *key == 4.into()
+                && let Value::Map(options) = v
+            {
+                saw_options = true;
+
+                let option_bool = |option_name: &str| {
+                    options.iter().find_map(|(option_key, option_value)| {
+                        if let Value::Text(name) = option_key
+                            && name == option_name
+                            && let Value::Bool(value) = option_value
+                        {
+                            return Some(*value);
+                        }
+
+                        None
+                    })
+                };
+
+                assert_eq!(option_bool("rk"), Some(true));
+                assert_eq!(option_bool("up"), Some(true));
+                assert_eq!(option_bool("plat"), Some(true));
+                assert_eq!(option_bool("uv"), Some(true));
+                assert_eq!(option_bool("clientPin"), Some(false));
+                assert_eq!(option_bool("alwaysUv"), Some(false));
+            }
+        }
+
+        assert!(saw_options, "getInfo response should include options");
     } else {
         panic!("Expected CBOR map");
     }

--- a/cmd/passless/tests/e2e_webauthn.rs
+++ b/cmd/passless/tests/e2e_webauthn.rs
@@ -635,6 +635,126 @@ fn extract_credential_id(attestation_cbor: &[u8]) -> Result<Vec<u8>> {
     Err(soft_fido2::Error::Other)
 }
 
+fn extract_assertion_user_id(assertion_cbor: &[u8]) -> Result<Vec<u8>> {
+    let value: ciborium::value::Value =
+        ciborium::from_reader(assertion_cbor).map_err(|_| soft_fido2::Error::Other)?;
+
+    if let ciborium::value::Value::Map(map) = value {
+        for (key, val) in map {
+            if let ciborium::value::Value::Integer(i) = key {
+                let i_val: i128 = i.into();
+                if i_val == 4
+                    && let ciborium::value::Value::Map(user_map) = val
+                {
+                    for (user_key, user_val) in user_map {
+                        if let ciborium::value::Value::Text(name) = user_key
+                            && name == "id"
+                            && let ciborium::value::Value::Bytes(id) = user_val
+                        {
+                            return Ok(id);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Err(soft_fido2::Error::Other)
+}
+
+fn extract_assertion_credential_count(assertion_cbor: &[u8]) -> Result<Option<usize>> {
+    let value: ciborium::value::Value =
+        ciborium::from_reader(assertion_cbor).map_err(|_| soft_fido2::Error::Other)?;
+
+    if let ciborium::value::Value::Map(map) = value {
+        for (key, val) in map {
+            if let ciborium::value::Value::Integer(i) = key {
+                let i_val: i128 = i.into();
+                if i_val == 5
+                    && let ciborium::value::Value::Integer(count) = val
+                {
+                    let count_i: i128 = count.into();
+                    return Ok(Some(count_i as usize));
+                }
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+/// Core test logic for userless authentication with multiple discoverable credentials.
+fn run_userless_multiple_discoverable_credentials_test() -> Result<()> {
+    println!("\n╔════════════════════════════════════════════════╗");
+    println!("║ E2E Test: Userless Multi-Credential Auth      ║");
+    println!("╚════════════════════════════════════════════════╝\n");
+
+    let mut transport = connect_to_authenticator()?;
+    let rp = RelyingParty {
+        id: RP_ID.to_string(),
+        name: Some("Example Corp".to_string()),
+    };
+
+    let user_a_id = vec![1, 2, 3, 4];
+    let user_b_id = vec![5, 6, 7, 8];
+
+    for (label, user_id, name) in [
+        ("User A", user_a_id.clone(), "user_a@example.com"),
+        ("User B", user_b_id.clone(), "user_b@example.com"),
+    ] {
+        println!("📝 Registering discoverable credential for {label}...");
+        let challenge = generate_challenge();
+        let client_data_hash = generate_client_data_hash_for_registration(&challenge);
+        let user = User {
+            id: user_id,
+            name: Some(name.to_string()),
+            display_name: Some(label.to_string()),
+        };
+
+        let request = MakeCredentialRequest::new(client_data_hash, rp.clone(), user)
+            .with_user_verification(true)
+            .with_resident_key(true)
+            .with_timeout(30000);
+
+        print_operation("Register discoverable credential");
+        let attestation = Client::make_credential(&mut transport, request)?;
+        assert!(!attestation.is_empty());
+    }
+
+    println!("\n🔐 Authenticating without allow list...");
+    let challenge = generate_challenge();
+    let client_data_hash = generate_client_data_hash_for_authentication(&challenge);
+    let request = GetAssertionRequest::new(client_data_hash, RP_ID)
+        .with_user_verification(true)
+        .with_timeout(30000);
+
+    print_operation("Authenticate with multiple discoverable credentials");
+    let first_assertion = Client::get_assertion(&mut transport, request)?;
+    assert_eq!(
+        extract_assertion_credential_count(&first_assertion)?,
+        Some(2),
+        "First assertion should advertise both matching credentials"
+    );
+    let first_user_id = extract_assertion_user_id(&first_assertion)?;
+
+    println!("\n🔁 Requesting next assertion...");
+    let second_assertion = transport.send_ctap_command(0x08, &[], 30000)?;
+    let second_user_id = extract_assertion_user_id(&second_assertion)?;
+
+    assert_ne!(
+        first_user_id, second_user_id,
+        "getNextAssertion should return the other credential"
+    );
+    assert!([user_a_id.as_slice(), user_b_id.as_slice()].contains(&first_user_id.as_slice()));
+    assert!([user_a_id.as_slice(), user_b_id.as_slice()].contains(&second_user_id.as_slice()));
+
+    println!("\n╔════════════════════════════════════════════════╗");
+    println!("║  ✓ Multi-Credential Userless Test Passed!     ║");
+    println!("╚════════════════════════════════════════════════╝\n");
+
+    Ok(())
+}
+
 #[test]
 #[ignore]
 fn test_local_authentication_with_allow_list() -> Result<()> {
@@ -1067,5 +1187,171 @@ fn test_pass_algorithm_preference() -> Result<()> {
 fn test_tpm_algorithm_preference() -> Result<()> {
     with_backend("TPM (swtpm)", AuthenticatorHarness::with_tpm, || {
         run_algorithm_preference_test()
+    })
+}
+
+/// Core test logic for userless discoverable passkey authentication
+fn run_userless_discoverable_passkey_test() -> Result<()> {
+    println!("\n╔════════════════════════════════════════════════╗");
+    println!("║ E2E Test: Userless Discoverable Passkey Auth  ║");
+    println!("╚════════════════════════════════════════════════╝\n");
+
+    let mut transport = connect_to_authenticator()?;
+
+    // Register a resident/discoverable credential with minimal user info
+    println!("📝 Registering discoverable credential (userless)...");
+    let challenge = generate_challenge();
+    let client_data = format!(
+        r#"{{"type":"webauthn.create","challenge":"{}","origin":"{}","crossOrigin":false}}"#,
+        base64_url_encode(&challenge),
+        ORIGIN
+    );
+    let hash = Sha256::digest(client_data.as_bytes());
+    let client_data_hash = ClientDataHash::from_slice(&hash)?;
+
+    let rp = RelyingParty {
+        id: RP_ID.to_string(),
+        name: Some("Example Corp".to_string()),
+    };
+
+    let user_id = vec![99, 88, 77, 66];
+
+    // Create a discoverable credential whose user handle can identify the
+    // account when authentication is started without an allow list.
+    let user = User {
+        id: user_id.clone(),
+        name: None,
+        display_name: None,
+    };
+
+    let request = MakeCredentialRequest::new(client_data_hash, rp, user)
+        .with_user_verification(true)
+        .with_resident_key(true)
+        .with_timeout(30000);
+
+    print_operation("Register discoverable credential (userless)");
+
+    let attestation = Client::make_credential(&mut transport, request)?;
+    println!(
+        "   ✓ Discoverable credential created ({} bytes)",
+        attestation.len()
+    );
+    assert!(!attestation.is_empty());
+
+    // Extract credential ID from the attestation for verification
+    let cred_id = extract_credential_id(&attestation)?;
+    println!("   Credential ID: {} bytes", cred_id.len());
+
+    // Now authenticate WITHOUT an allow list (discoverable flow)
+    println!("\n🔐 Authenticating without allow list (discoverable flow)...");
+    let challenge = generate_challenge();
+    let client_data = format!(
+        r#"{{"type":"webauthn.get","challenge":"{}","origin":"{}"}}"#,
+        base64_url_encode(&challenge),
+        ORIGIN
+    );
+    let hash = Sha256::digest(client_data.as_bytes());
+    let client_data_hash = ClientDataHash::from_slice(&hash)?;
+
+    // No allow list - this should trigger the discoverable flow
+    let request = GetAssertionRequest::new(client_data_hash, RP_ID)
+        .with_user_verification(true)
+        .with_timeout(30000);
+
+    print_operation("Authenticate using discoverable credential (no allow list)");
+
+    let assertion = Client::get_assertion(&mut transport, request)?;
+    println!("   ✓ Authentication successful ({} bytes)", assertion.len());
+    assert!(!assertion.is_empty());
+
+    // Parse the assertion CBOR to validate user information
+    println!("\n🔍 Parsing assertion CBOR to validate user information...");
+    match ciborium::from_reader::<ciborium::value::Value, _>(&assertion[..]) {
+        Ok(ciborium::value::Value::Map(map)) => {
+            println!("   ✓ Valid CBOR response with {} fields", map.len());
+
+            // Check for required fields
+            let has_auth_data = map.iter().any(|(k, _)| {
+                matches!(k, ciborium::value::Value::Integer(i) if Into::<i128>::into(*i) == 2)
+            });
+            let has_signature = map.iter().any(|(k, _)| {
+                matches!(k, ciborium::value::Value::Integer(i) if Into::<i128>::into(*i) == 3)
+            });
+
+            let mut returned_user_id = None;
+            for (k, v) in &map {
+                if let ciborium::value::Value::Integer(i) = k {
+                    let i_val: i128 = (*i).into();
+                    if i_val == 4 {
+                        if let ciborium::value::Value::Map(user_map) = v {
+                            returned_user_id =
+                                user_map.iter().find_map(|(user_key, user_value)| {
+                                    if let ciborium::value::Value::Text(key) = user_key
+                                        && key == "id"
+                                        && let ciborium::value::Value::Bytes(id) = user_value
+                                    {
+                                        return Some(id.clone());
+                                    }
+
+                                    None
+                                });
+                        }
+
+                        break;
+                    }
+                }
+            }
+
+            assert!(has_auth_data, "Response should contain authData");
+            assert!(has_signature, "Response should contain signature");
+            println!("   ✓ Response contains authData and signature");
+
+            assert_eq!(
+                returned_user_id.as_deref(),
+                Some(user_id.as_slice()),
+                "Discoverable authentication should return the registered user handle"
+            );
+            println!("   ✓ User handle matches registered user ID");
+        }
+        Ok(_) => panic!("Response should be a CBOR map"),
+        Err(e) => panic!("Failed to parse CBOR response: {}", e),
+    }
+
+    println!("\n╔════════════════════════════════════════════════╗");
+    println!("║     ✓ Userless Discoverable Passkey Test Passed!    ║");
+    println!("╚════════════════════════════════════════════════╝\n");
+
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn test_local_userless_discoverable_passkey() -> Result<()> {
+    with_backend("local", AuthenticatorHarness::with_local, || {
+        run_userless_discoverable_passkey_test()
+    })
+}
+
+#[test]
+#[ignore]
+fn test_pass_userless_discoverable_passkey() -> Result<()> {
+    with_backend("password-store", AuthenticatorHarness::with_pass, || {
+        run_userless_discoverable_passkey_test()
+    })
+}
+
+#[test]
+#[ignore]
+fn test_tpm_userless_discoverable_passkey() -> Result<()> {
+    with_backend("TPM (swtpm)", AuthenticatorHarness::with_tpm, || {
+        run_userless_discoverable_passkey_test()
+    })
+}
+
+#[test]
+#[ignore]
+fn test_local_userless_multiple_discoverable_credentials() -> Result<()> {
+    with_backend("local", AuthenticatorHarness::with_local, || {
+        run_userless_multiple_discoverable_credentials_test()
     })
 }


### PR DESCRIPTION
## Summary
- Update passless to soft-fido2 0.13.0 so browsers can enumerate multiple discoverable credentials with getNextAssertion.
- Stop advertising alwaysUv in getInfo while preserving notification-based UV support.
- Add E2E regressions for userless discoverable login and multi-credential userless assertions.

## Verification
- cargo test -p passless-rs
- cargo test -p passless-rs --test e2e_client test_client_info -- --ignored --exact --test-threads=1 --nocapture
- cargo test -p passless-rs --test e2e_webauthn test_local_userless_discoverable_passkey -- --ignored --exact --test-threads=1 --nocapture
- cargo test -p passless-rs --test e2e_webauthn test_local_userless_multiple_discoverable_credentials -- --ignored --exact --test-threads=1 --nocapture
- cargo test -p passless-rs --test e2e_webauthn test_local_registration_and_authentication -- --ignored --exact --test-threads=1 --nocapture
- cargo clippy --all-targets --all-features -- -D warnings

## Manual verification
- Verified GitHub userless passkey login with two stored github.com credentials using passless and soft-fido2 0.13.0.