### PR TITLE
fix: restore always_uv to use security config

### DIFF
--- a/cmd/passless/src/authenticator.rs
+++ b/cmd/passless/src/authenticator.rs
@@ -418,7 +418,7 @@ impl<S: CredentialStorage + 'static, P: PinStorage + 'static> AuthenticatorServi
             bio_enroll: None,              // No biometric enrollment
             large_blobs: None,             // No large blob storage
             ep: None,                      // Enterprise attestation not enabled
-            always_uv: Some(false),        // Avoid browser userless-login PUAT requirements
+            always_uv: Some(security_config.always_uv),
             make_cred_uv_not_required: Some(true),
         };
 


### PR DESCRIPTION
## Problem

v0.11.0 hardcoded `always_uv: Some(false)` (commit a0965dc, PR #265) which broke authentication with existing passkeys on sites like GitHub and Alibaba Cloud.

## Root Cause

With `always_uv=false`, the CTAP2 getAssertion handler skips Step 5 (UV enforcement). This means UV is only performed when the browser explicitly sends `uv=true` in the CTAP options. For conditional mediation or certain WebAuthn flows, browsers may not request UV, so:

1. User verification is never performed
2. `response_state.uv` stays `false`
3. `auth_data` lacks the UV flag
4. Servers reject the assertion (passkeys require UV)

The user sees the UP notification (Step 10) instead of the UV notification (Step 7), making it look like the authenticator is working, but the assertion is rejected.

## Fix

Restore `always_uv` to use `security_config.always_uv` (defaults to `true`) instead of hardcoding `false`.

> [!NOTE]
> The original change was to "avoid browser userless-login PUAT requirements." If that issue resurfaces, it should be addressed separately without breaking UV for all credentials.