### PR TITLE
feat: add authenticated uv retry reset

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,12 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v7
 
+      - name: Checkout soft-fido2
+        uses: actions/checkout@v7
+        with:
+          repository: pando85/soft-fido2
+          path: soft-fido2
+
       - name: Install stable toolchain
         id: toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -32,6 +38,12 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v7
+
+      - name: Checkout soft-fido2
+        uses: actions/checkout@v7
+        with:
+          repository: pando85/soft-fido2
+          path: soft-fido2
 
       - name: Update apt
         run: sudo apt update
@@ -63,6 +75,12 @@ jobs:
     runs-on: ${{ matrix.job.os }}
     steps:
       - uses: actions/checkout@v7
+
+      - name: Checkout soft-fido2
+        uses: actions/checkout@v7
+        with:
+          repository: pando85/soft-fido2
+          path: soft-fido2
 
       - name: Update apt
         run: sudo apt update

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,12 +16,6 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v7
 
-      - name: Checkout soft-fido2
-        uses: actions/checkout@v7
-        with:
-          repository: pando85/soft-fido2
-          path: ../soft-fido2
-
       - name: Install stable toolchain
         id: toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -38,12 +32,6 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v7
-
-      - name: Checkout soft-fido2
-        uses: actions/checkout@v7
-        with:
-          repository: pando85/soft-fido2
-          path: ../soft-fido2
 
       - name: Update apt
         run: sudo apt update
@@ -75,12 +63,6 @@ jobs:
     runs-on: ${{ matrix.job.os }}
     steps:
       - uses: actions/checkout@v7
-
-      - name: Checkout soft-fido2
-        uses: actions/checkout@v7
-        with:
-          repository: pando85/soft-fido2
-          path: ../soft-fido2
 
       - name: Update apt
         run: sudo apt update

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: pando85/soft-fido2
-          path: soft-fido2
+          path: ../soft-fido2
 
       - name: Install stable toolchain
         id: toolchain
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: pando85/soft-fido2
-          path: soft-fido2
+          path: ../soft-fido2
 
       - name: Update apt
         run: sudo apt update
@@ -80,7 +80,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: pando85/soft-fido2
-          path: soft-fido2
+          path: ../soft-fido2
 
       - name: Update apt
         run: sudo apt update

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,7 +928,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1408,7 +1408,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2179,7 +2179,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2402,8 +2402,6 @@ dependencies = [
 [[package]]
 name = "soft-fido2"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85952b3d0bb48adee88e7233af66d196b139076dcb7a82db945426e5421f2fab"
 dependencies = [
  "aes",
  "cbc",
@@ -2428,8 +2426,6 @@ dependencies = [
 [[package]]
 name = "soft-fido2-crypto"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f74259700b8ce2efd348482ae9369cb2a00ae95cffecdd3714eb8d28a66f0b6"
 dependencies = [
  "aes",
  "cbc",
@@ -2447,8 +2443,6 @@ dependencies = [
 [[package]]
 name = "soft-fido2-ctap"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27838bfc975c317e6925ffeb1a85fcab642b14d6b8359ced25ee5d1dd9f06a4d"
 dependencies = [
  "cbor4ii",
  "rand",
@@ -2466,8 +2460,6 @@ dependencies = [
 [[package]]
 name = "soft-fido2-transport"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e6f7f951c4f273ad3a42dd85040172bc5f491f8d686938963f0d6f10dde14d"
 dependencies = [
  "hex",
  "hidapi",
@@ -2478,9 +2470,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783f3f6f6b01e295a669edfc402133a5f2553d1f0e81284b3ba4594e80bdd4a2"
+checksum = "bd5231412d905519dca6a5deb0327d407be68d6c941feec004533401d3a0a715"
 dependencies = [
  "lock_api",
 ]
@@ -2574,7 +2566,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2978,7 +2970,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,9 +258,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base16ct"
-version = "0.2.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base64"
@@ -597,12 +597,16 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.5"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
- "generic-array",
- "rand_core 0.6.4",
+ "cpubits",
+ "ctutils",
+ "getrandom 0.4.2",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
  "subtle",
  "zeroize",
 ]
@@ -655,6 +659,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1005a6d4446f5120ef475ad3d2af2b30c49c2c9c6904258e3bb30219bebed5e4"
 dependencies = [
  "cmov",
+ "subtle",
 ]
 
 [[package]]
@@ -725,6 +730,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "const-oid 0.10.2",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -745,9 +760,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid 0.9.6",
  "crypto-common 0.1.7",
- "subtle",
 ]
 
 [[package]]
@@ -808,16 +821,17 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.16.9"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
 dependencies = [
- "der",
- "digest 0.10.7",
+ "der 0.8.0",
+ "digest 0.11.2",
  "elliptic-curve",
  "rfc6979",
- "signature",
- "spki",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -826,8 +840,8 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "signature",
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -846,20 +860,21 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.8"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "crypto-common 0.2.2",
+ "digest 0.11.2",
  "ff",
- "generic-array",
  "group",
- "hkdf 0.12.4",
+ "hkdf",
+ "hybrid-array",
  "pem-rfc7468",
- "pkcs8",
- "rand_core 0.6.4",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
  "sec1",
  "subtle",
  "zeroize",
@@ -960,11 +975,11 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -1028,7 +1043,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -1110,12 +1124,12 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -1193,29 +1207,11 @@ dependencies = [
 
 [[package]]
 name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac 0.12.1",
-]
-
-[[package]]
-name = "hkdf"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
- "hmac 0.13.0",
-]
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
+ "hmac",
 ]
 
 [[package]]
@@ -1235,11 +1231,13 @@ checksum = "f558a64ac9af88b5ba400d99b579451af0d39c6d360980045b91aac966d705e2"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.8"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8655f91cd07f2b9d0c24137bd650fe69617773435ee5ec83022377777ce65ef1"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
+ "subtle",
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -1716,14 +1714,15 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "primefield",
  "primeorder",
- "sha2 0.10.9",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -1773,7 +1772,7 @@ dependencies = [
  "env_logger",
  "git2 0.21.0",
  "hex",
- "hmac 0.13.0",
+ "hmac",
  "libc",
  "log",
  "nix 0.31.3",
@@ -1798,9 +1797,9 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.7.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
@@ -1869,8 +1868,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.0",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -1954,12 +1963,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "primeorder"
-version = "0.13.6"
+name = "primefield"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint",
+ "crypto-common 0.2.2",
+ "ff",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
 dependencies = [
  "elliptic-curve",
+ "once_cell",
+ "primefield",
+ "serdect",
+ "wnaf",
 ]
 
 [[package]]
@@ -2131,12 +2158,12 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rfc6979"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
 dependencies = [
- "hmac 0.12.1",
- "subtle",
+ "crypto-bigint",
+ "hmac",
 ]
 
 [[package]]
@@ -2205,14 +2232,14 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
  "base16ct",
- "der",
- "generic-array",
- "pkcs8",
+ "ctutils",
+ "der 0.8.0",
+ "hybrid-array",
  "subtle",
  "zeroize",
 ]
@@ -2316,6 +2343,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2380,8 +2417,17 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2401,14 +2447,16 @@ dependencies = [
 
 [[package]]
 name = "soft-fido2"
-version = "0.13.0"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2ddbcdbb7f4b1cdae552de6007b0b28c5719794c2e8c678881186ee453d768"
 dependencies = [
  "aes",
  "cbc",
  "cbor4ii",
  "hex",
- "hkdf 0.13.0",
- "hmac 0.13.0",
+ "hkdf",
+ "hmac",
  "p256",
  "rand",
  "secstr",
@@ -2425,13 +2473,15 @@ dependencies = [
 
 [[package]]
 name = "soft-fido2-crypto"
-version = "0.13.0"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d3122142f801deb504ab1aed5428eead247ad15c60d9614ba8838385420f0f"
 dependencies = [
  "aes",
  "cbc",
  "ed25519-dalek",
- "hkdf 0.13.0",
- "hmac 0.13.0",
+ "hkdf",
+ "hmac",
  "p256",
  "rand",
  "sha2 0.11.0",
@@ -2442,7 +2492,9 @@ dependencies = [
 
 [[package]]
 name = "soft-fido2-ctap"
-version = "0.13.0"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60996605d42ad5cdd2963acee7b381172a6555f9d5495338f3311d375e2c21c8"
 dependencies = [
  "cbor4ii",
  "rand",
@@ -2459,7 +2511,9 @@ dependencies = [
 
 [[package]]
 name = "soft-fido2-transport"
-version = "0.13.0"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c52e1068683ef2cc65a3b711f145290c621c7c39db639121a9fdda629e0c1ad"
 dependencies = [
  "hex",
  "hidapi",
@@ -2484,7 +2538,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.0",
 ]
 
 [[package]]
@@ -2735,9 +2799,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uds_windows"
@@ -3288,6 +3352,17 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "wnaf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+dependencies = [
+ "ff",
+ "group",
+ "hybrid-array",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ repository = "https://github.com/pando85/passless"
 passless-core = { path = "./passless-core", version = "0.11.2" }
 passless-config-doc = { path = "./passless-config-doc", version = "0.11.2" }
 
-soft-fido2 = "0.13.0"
-soft-fido2-ctap = "0.13.0"
-soft-fido2-transport = "0.13.0"
+soft-fido2 = { path = "../soft-fido2/soft-fido2" }
+soft-fido2-ctap = { path = "../soft-fido2/soft-fido2-ctap" }
+soft-fido2-transport = { path = "../soft-fido2/soft-fido2-transport" }
 
 thiserror = "2.0"
 clap = { version = "4.5", features = ["std", "color", "derive", "cargo", "env"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ repository = "https://github.com/pando85/passless"
 passless-core = { path = "./passless-core", version = "0.11.2" }
 passless-config-doc = { path = "./passless-config-doc", version = "0.11.2" }
 
-soft-fido2 = { path = "../soft-fido2/soft-fido2" }
-soft-fido2-ctap = { path = "../soft-fido2/soft-fido2-ctap" }
-soft-fido2-transport = { path = "../soft-fido2/soft-fido2-transport" }
+soft-fido2 = "0.13.1"
+soft-fido2-ctap = "0.13.1"
+soft-fido2-transport = "0.13.1"
 
 thiserror = "2.0"
 clap = { version = "4.5", features = ["std", "color", "derive", "cargo", "env"] }

--- a/cmd/passless/src/authenticator.rs
+++ b/cmd/passless/src/authenticator.rs
@@ -7,7 +7,7 @@ use passless_core::config::{PinConfig, PinEnforcement, SecurityConfig};
 
 use soft_fido2::{
     Authenticator, AuthenticatorCallbacks, AuthenticatorConfig, AuthenticatorOptions, Credential,
-    CredentialRef, CtapCommand, PinState, Result, UpResult, UvResult,
+    CredentialRef, CtapCommand, PinState, Result, StatusCode, UpResult, UvResult,
 };
 
 use std::sync::{Arc, LazyLock, Mutex};
@@ -22,6 +22,14 @@ static VERSION: LazyLock<u32> = LazyLock::new(|| {
 
     (major << 16) | (minor << 8) | patch
 });
+
+/// Passless vendor command for resetting built-in UV retries without deleting credentials.
+pub const CMD_PASSLESS_RESET_UV_RETRIES: u8 = 0x42;
+
+const DEFAULT_UV_RETRIES: u8 = 3;
+
+type CustomCommandHandler =
+    Arc<dyn Fn(&[u8]) -> core::result::Result<Vec<u8>, StatusCode> + Send + Sync>;
 
 /// Wrapper to adapt passless PinStorage to soft-fido2 PinStorageCallbacks
 struct PinStorageWrapper<P: PinStorage>(Arc<Mutex<P>>);
@@ -390,6 +398,11 @@ pub struct AuthenticatorService<S: CredentialStorage, P: PinStorage = ()> {
     pub authenticator: Authenticator<PasslessCallbacks<S, P>>,
     /// Storage backend (injected dependency)
     pub storage: Arc<Mutex<S>>,
+    /// Optional PIN state storage backend
+    pin_storage: Option<Arc<Mutex<P>>>,
+    security_config: SecurityConfig,
+    pin_config: PinConfig,
+    custom_commands: Vec<(u8, CustomCommandHandler)>,
 }
 
 impl<S: CredentialStorage + 'static> AuthenticatorService<S, ()> {
@@ -401,13 +414,12 @@ impl<S: CredentialStorage + 'static> AuthenticatorService<S, ()> {
 }
 
 impl<S: CredentialStorage + 'static, P: PinStorage + 'static> AuthenticatorService<S, P> {
-    /// Create a new authenticator service with optional PIN storage
-    pub fn with_pin_storage(
-        storage: S,
+    fn build_authenticator(
+        storage: Arc<Mutex<S>>,
         pin_storage: Option<Arc<Mutex<P>>>,
         security_config: SecurityConfig,
         pin_config: PinConfig,
-    ) -> Result<Self> {
+    ) -> Result<Authenticator<PasslessCallbacks<S, P>>> {
         // Hardcoded authenticator options (FIDO2 spec compliant)
         // These are platform authenticator defaults and shouldn't need configuration
         let options = AuthenticatorOptions {
@@ -449,29 +461,101 @@ impl<S: CredentialStorage + 'static, P: PinStorage + 'static> AuthenticatorServi
             .auto_lock_timeout(pin_config.auto_lock_timeout)
             .build();
 
-        let storage = Arc::new(Mutex::new(storage));
-        let callbacks = PasslessCallbacks::new(
-            storage.clone(),
-            pin_storage.clone(),
-            security_config,
-            pin_config,
-        );
+        let callbacks =
+            PasslessCallbacks::new(storage, pin_storage.clone(), security_config, pin_config);
 
-        let authenticator = if let Some(ps) = pin_storage {
+        if let Some(ps) = pin_storage {
             Authenticator::with_config_and_pin_storage(callbacks, config, PinStorageWrapper(ps))
         } else {
             Authenticator::with_config(callbacks, config)
-        }?;
+        }
+    }
+
+    /// Create a new authenticator service with optional PIN storage
+    pub fn with_pin_storage(
+        storage: S,
+        pin_storage: Option<Arc<Mutex<P>>>,
+        security_config: SecurityConfig,
+        pin_config: PinConfig,
+    ) -> Result<Self> {
+        let storage = Arc::new(Mutex::new(storage));
+        let authenticator = Self::build_authenticator(
+            storage.clone(),
+            pin_storage.clone(),
+            security_config.clone(),
+            pin_config.clone(),
+        )?;
 
         Ok(Self {
             authenticator,
             storage,
+            pin_storage,
+            security_config,
+            pin_config,
+            custom_commands: Vec::new(),
         })
+    }
+
+    fn rebuild_authenticator(&mut self) -> Result<()> {
+        let mut authenticator = Self::build_authenticator(
+            self.storage.clone(),
+            self.pin_storage.clone(),
+            self.security_config.clone(),
+            self.pin_config.clone(),
+        )?;
+
+        for (command, handler) in &self.custom_commands {
+            let handler = handler.clone();
+            authenticator.register_custom_command(*command, move |request| handler(request));
+        }
+
+        self.authenticator = authenticator;
+        Ok(())
+    }
+
+    fn reset_uv_retries(&mut self) -> core::result::Result<(), StatusCode> {
+        let Some(pin_storage) = &self.pin_storage else {
+            return Err(StatusCode::NotAllowed);
+        };
+
+        {
+            let storage = pin_storage.lock().map_err(|_| StatusCode::Other)?;
+            let mut state = storage.load_pin_state()?;
+            state.uv_retries = DEFAULT_UV_RETRIES;
+            storage.save_pin_state(&state)?;
+        }
+
+        self.rebuild_authenticator().map_err(|e| {
+            error!(
+                "Failed to rebuild authenticator after UV retry reset: {:?}",
+                e
+            );
+            StatusCode::Other
+        })?;
+
+        Ok(())
     }
 
     /// Process a CTAP request and generate a response
     /// Ok(()) on success or an error
     pub fn handle(&mut self, request: &[u8], response_buffer: &mut Vec<u8>) -> Result<()> {
+        if request.first() == Some(&CMD_PASSLESS_RESET_UV_RETRIES) {
+            response_buffer.clear();
+            if request.len() != 1 {
+                response_buffer.push(StatusCode::InvalidParameter as u8);
+                return Ok(());
+            }
+
+            match self.reset_uv_retries() {
+                Ok(()) => {
+                    response_buffer.push(0x00);
+                    response_buffer.push(0xa0);
+                }
+                Err(status) => response_buffer.push(status as u8),
+            }
+            return Ok(());
+        }
+
         self.authenticator.handle(request, response_buffer)?;
         Ok(())
     }
@@ -498,7 +582,11 @@ impl<S: CredentialStorage + 'static, P: PinStorage + 'static> AuthenticatorServi
             + Sync
             + 'static,
     {
-        self.authenticator.register_custom_command(command, handler);
+        let handler: CustomCommandHandler = Arc::new(handler);
+        let registered_handler = handler.clone();
+        self.authenticator
+            .register_custom_command(command, move |request| registered_handler(request));
+        self.custom_commands.push((command, handler));
     }
 }
 
@@ -506,6 +594,7 @@ impl<S: CredentialStorage + 'static, P: PinStorage + 'static> AuthenticatorServi
 mod tests {
     use super::*;
 
+    use crate::pin_storage::{LocalPinStorage, PinStorage};
     use crate::storage::LocalStorageAdapter;
 
     #[test]
@@ -535,6 +624,57 @@ mod tests {
         assert!(service.is_ok(), "Service creation should succeed");
 
         // Cleanup
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn test_reset_uv_retries_command_persists_and_reloads() {
+        let temp_dir = std::env::temp_dir().join("test_passless_reset_uv_retries");
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        std::fs::create_dir_all(&temp_dir).expect("Failed to create temp directory");
+
+        let storage =
+            LocalStorageAdapter::new(temp_dir.clone()).expect("Failed to create local storage");
+        let pin_storage = LocalPinStorage::new(temp_dir.clone());
+        let mut pin_state = PinState::new();
+        pin_state.uv_retries = 0;
+        pin_storage
+            .save_pin_state(&pin_state)
+            .expect("Failed to save PIN state");
+
+        let pin_storage = Arc::new(Mutex::new(pin_storage));
+        let mut service = AuthenticatorService::with_pin_storage(
+            storage,
+            Some(pin_storage.clone()),
+            SecurityConfig::default(),
+            PinConfig::default(),
+        )
+        .expect("Service creation should succeed");
+
+        let mut response = Vec::new();
+        service
+            .handle(&[CMD_PASSLESS_RESET_UV_RETRIES], &mut response)
+            .expect("UV retry reset command should be handled");
+
+        assert_eq!(response, vec![0x00, 0xa0]);
+
+        let persisted_state = pin_storage
+            .lock()
+            .expect("Failed to lock PIN storage")
+            .load_pin_state()
+            .expect("Failed to load PIN state");
+        assert_eq!(persisted_state.uv_retries, DEFAULT_UV_RETRIES);
+
+        let mut uv_retries_response = Vec::new();
+        service
+            .handle(&[0x06, 0xa1, 0x02, 0x07], &mut uv_retries_response)
+            .expect("getUvRetries command should be handled");
+
+        assert_eq!(
+            uv_retries_response,
+            vec![0x00, 0xa1, 0x05, DEFAULT_UV_RETRIES]
+        );
+
         let _ = std::fs::remove_dir_all(temp_dir);
     }
 }

--- a/cmd/passless/src/authenticator.rs
+++ b/cmd/passless/src/authenticator.rs
@@ -7,7 +7,8 @@ use passless_core::config::{PinConfig, PinEnforcement, SecurityConfig};
 
 use soft_fido2::{
     Authenticator, AuthenticatorCallbacks, AuthenticatorConfig, AuthenticatorOptions, Credential,
-    CredentialRef, CtapCommand, PinState, Result, StatusCode, UpResult, UvResult,
+    CredentialRef, CtapCommand, Error as SoftFido2Error, PinState, Result, StatusCode, UpResult,
+    UvResult,
 };
 
 use std::sync::{Arc, LazyLock, Mutex};
@@ -26,10 +27,14 @@ static VERSION: LazyLock<u32> = LazyLock::new(|| {
 /// Passless vendor command for resetting built-in UV retries without deleting credentials.
 pub const CMD_PASSLESS_RESET_UV_RETRIES: u8 = 0x42;
 
-const DEFAULT_UV_RETRIES: u8 = 3;
+const RESET_UV_RETRIES_SUBCOMMAND: u8 = 0x01;
 
-type CustomCommandHandler =
-    Arc<dyn Fn(&[u8]) -> core::result::Result<Vec<u8>, StatusCode> + Send + Sync>;
+fn error_status_byte(error: SoftFido2Error) -> u8 {
+    match error {
+        SoftFido2Error::CtapError(code) => code,
+        error => StatusCode::from(error) as u8,
+    }
+}
 
 /// Wrapper to adapt passless PinStorage to soft-fido2 PinStorageCallbacks
 struct PinStorageWrapper<P: PinStorage>(Arc<Mutex<P>>);
@@ -398,11 +403,6 @@ pub struct AuthenticatorService<S: CredentialStorage, P: PinStorage = ()> {
     pub authenticator: Authenticator<PasslessCallbacks<S, P>>,
     /// Storage backend (injected dependency)
     pub storage: Arc<Mutex<S>>,
-    /// Optional PIN state storage backend
-    pin_storage: Option<Arc<Mutex<P>>>,
-    security_config: SecurityConfig,
-    pin_config: PinConfig,
-    custom_commands: Vec<(u8, CustomCommandHandler)>,
 }
 
 impl<S: CredentialStorage + 'static> AuthenticatorService<S, ()> {
@@ -489,49 +489,14 @@ impl<S: CredentialStorage + 'static, P: PinStorage + 'static> AuthenticatorServi
         Ok(Self {
             authenticator,
             storage,
-            pin_storage,
-            security_config,
-            pin_config,
-            custom_commands: Vec::new(),
         })
     }
 
-    fn rebuild_authenticator(&mut self) -> Result<()> {
-        let mut authenticator = Self::build_authenticator(
-            self.storage.clone(),
-            self.pin_storage.clone(),
-            self.security_config.clone(),
-            self.pin_config.clone(),
-        )?;
-
-        for (command, handler) in &self.custom_commands {
-            let handler = handler.clone();
-            authenticator.register_custom_command(*command, move |request| handler(request));
-        }
-
-        self.authenticator = authenticator;
-        Ok(())
-    }
-
     fn reset_uv_retries(&mut self) -> core::result::Result<(), StatusCode> {
-        let Some(pin_storage) = &self.pin_storage else {
-            return Err(StatusCode::NotAllowed);
-        };
-
-        {
-            let storage = pin_storage.lock().map_err(|_| StatusCode::Other)?;
-            let mut state = storage.load_pin_state()?;
-            state.uv_retries = DEFAULT_UV_RETRIES;
-            storage.save_pin_state(&state)?;
-        }
-
-        self.rebuild_authenticator().map_err(|e| {
-            error!(
-                "Failed to rebuild authenticator after UV retry reset: {:?}",
-                e
-            );
-            StatusCode::Other
-        })?;
+        // Use the high-level reset API from soft-fido2
+        self.authenticator
+            .reset_uv_retries()
+            .map_err(|_| StatusCode::Other)?;
 
         Ok(())
     }
@@ -541,8 +506,52 @@ impl<S: CredentialStorage + 'static, P: PinStorage + 'static> AuthenticatorServi
     pub fn handle(&mut self, request: &[u8], response_buffer: &mut Vec<u8>) -> Result<()> {
         if request.first() == Some(&CMD_PASSLESS_RESET_UV_RETRIES) {
             response_buffer.clear();
-            if request.len() != 1 {
+
+            let payload = &request[1..];
+            let parser = match soft_fido2_ctap::cbor::MapParser::from_bytes(payload) {
+                Ok(parser) => parser,
+                Err(status) => {
+                    response_buffer.push(status as u8);
+                    return Ok(());
+                }
+            };
+
+            let sub_command: u8 = match parser.get(1) {
+                Ok(sub_command) => sub_command,
+                Err(status) => {
+                    response_buffer.push(status as u8);
+                    return Ok(());
+                }
+            };
+
+            if sub_command != RESET_UV_RETRIES_SUBCOMMAND {
                 response_buffer.push(StatusCode::InvalidParameter as u8);
+                return Ok(());
+            }
+
+            let pin_uv_auth_protocol: u8 = match parser.get(3) {
+                Ok(protocol) => protocol,
+                Err(status) => {
+                    response_buffer.push(status as u8);
+                    return Ok(());
+                }
+            };
+
+            let pin_uv_auth_param: Vec<u8> = match parser.get_bytes(4) {
+                Ok(param) => param,
+                Err(status) => {
+                    response_buffer.push(status as u8);
+                    return Ok(());
+                }
+            };
+
+            let auth_data = [CMD_PASSLESS_RESET_UV_RETRIES, RESET_UV_RETRIES_SUBCOMMAND];
+            if let Err(error) = self.authenticator.verify_credential_management_pin_uv_auth(
+                pin_uv_auth_protocol,
+                &pin_uv_auth_param,
+                &auth_data,
+            ) {
+                response_buffer.push(error_status_byte(error));
                 return Ok(());
             }
 
@@ -582,11 +591,7 @@ impl<S: CredentialStorage + 'static, P: PinStorage + 'static> AuthenticatorServi
             + Sync
             + 'static,
     {
-        let handler: CustomCommandHandler = Arc::new(handler);
-        let registered_handler = handler.clone();
-        self.authenticator
-            .register_custom_command(command, move |request| registered_handler(request));
-        self.custom_commands.push((command, handler));
+        self.authenticator.register_custom_command(command, handler);
     }
 }
 
@@ -594,7 +599,6 @@ impl<S: CredentialStorage + 'static, P: PinStorage + 'static> AuthenticatorServi
 mod tests {
     use super::*;
 
-    use crate::pin_storage::{LocalPinStorage, PinStorage};
     use crate::storage::LocalStorageAdapter;
 
     #[test]
@@ -628,24 +632,16 @@ mod tests {
     }
 
     #[test]
-    fn test_reset_uv_retries_command_persists_and_reloads() {
+    fn test_reset_uv_retries_command_requires_authentication() {
         let temp_dir = std::env::temp_dir().join("test_passless_reset_uv_retries");
         let _ = std::fs::remove_dir_all(&temp_dir);
         std::fs::create_dir_all(&temp_dir).expect("Failed to create temp directory");
 
         let storage =
             LocalStorageAdapter::new(temp_dir.clone()).expect("Failed to create local storage");
-        let pin_storage = LocalPinStorage::new(temp_dir.clone());
-        let mut pin_state = PinState::new();
-        pin_state.uv_retries = 0;
-        pin_storage
-            .save_pin_state(&pin_state)
-            .expect("Failed to save PIN state");
-
-        let pin_storage = Arc::new(Mutex::new(pin_storage));
         let mut service = AuthenticatorService::with_pin_storage(
             storage,
-            Some(pin_storage.clone()),
+            None::<Arc<Mutex<()>>>,
             SecurityConfig::default(),
             PinConfig::default(),
         )
@@ -656,24 +652,7 @@ mod tests {
             .handle(&[CMD_PASSLESS_RESET_UV_RETRIES], &mut response)
             .expect("UV retry reset command should be handled");
 
-        assert_eq!(response, vec![0x00, 0xa0]);
-
-        let persisted_state = pin_storage
-            .lock()
-            .expect("Failed to lock PIN storage")
-            .load_pin_state()
-            .expect("Failed to load PIN state");
-        assert_eq!(persisted_state.uv_retries, DEFAULT_UV_RETRIES);
-
-        let mut uv_retries_response = Vec::new();
-        service
-            .handle(&[0x06, 0xa1, 0x02, 0x07], &mut uv_retries_response)
-            .expect("getUvRetries command should be handled");
-
-        assert_eq!(
-            uv_retries_response,
-            vec![0x00, 0xa1, 0x05, DEFAULT_UV_RETRIES]
-        );
+        assert_ne!(response, vec![0x00, 0xa0]);
 
         let _ = std::fs::remove_dir_all(temp_dir);
     }

--- a/cmd/passless/src/commands/client.rs
+++ b/cmd/passless/src/commands/client.rs
@@ -1357,28 +1357,110 @@ pub fn pin_change(
     Ok(())
 }
 
-/// Reset built-in user verification retries on authenticator
+/// Reset built-in user verification retries on authenticator after PIN authentication
 pub fn pin_uv_reset(output: OutputFormat, device: Option<&str>) -> Result<()> {
     let mut transport = open_authenticator(device)?;
 
     if output == OutputFormat::Plain {
-        println!("Resetting built-in user verification retries...");
+        println!("Resetting built-in user verification retries (authenticated)...");
+        println!("Enter PIN: ");
     }
 
-    let response = transport
-        .send_ctap_command(CMD_PASSLESS_RESET_UV_RETRIES, &[], 30000)
-        .map_err(|e| passless_core::Error::Other(format!("UV retry reset failed: {:?}", e)))?;
+    let pin = read_password()
+        .map_err(|e| passless_core::Error::Other(format!("Failed to read PIN: {:?}", e)))?;
 
-    if !response.is_empty() && response[0] != 0x00 {
+    if pin.is_empty() {
+        return Err(passless_core::Error::Other(
+            "PIN is required for authenticated UV retry reset".to_string(),
+        ));
+    }
+
+    if output == OutputFormat::Plain {
+        println!();
+    }
+
+    // Get authenticator info to determine supported pinUvAuthProtocol
+    let info_response = Client::authenticator_get_info(&mut transport).map_err(|e| {
+        passless_core::Error::Other(format!("Failed to get authenticator info: {:?}", e))
+    })?;
+
+    let info_value: soft_fido2_ctap::cbor::Value = soft_fido2_ctap::cbor::decode(&info_response)
+        .map_err(|e| {
+            passless_core::Error::Other(format!("Failed to decode info response: {:?}", e))
+        })?;
+
+    let info = parse_authenticator_info(&info_value)?;
+
+    // Determine the preferred pinUvAuthProtocol
+    let pin_uv_auth_protocol = info
+        .pin_uv_auth_protocols
+        .as_ref()
+        .and_then(|protocols| protocols.last())
+        .copied()
+        .unwrap_or(1); // Default to protocol 1 if none specified
+
+    // Get a PIN token for credential management (which has the required permissions)
+    let mut encapsulation = soft_fido2::PinUvAuthEncapsulation::new(
+        &mut transport,
+        match pin_uv_auth_protocol {
+            1 => soft_fido2::PinProtocol::V1,
+            2 => soft_fido2::PinProtocol::V2,
+            _ => soft_fido2::PinProtocol::V2, // Default to V2 for unknown protocols
+        },
+    )
+    .map_err(|e| {
+        passless_core::Error::Other(format!("Failed to initialize PIN protocol: {:?}", e))
+    })?;
+
+    let permissions = soft_fido2::request::Permission::CredentialManagement as u8;
+    let pin_token_bytes = encapsulation
+        .get_pin_uv_auth_token_using_pin_with_permissions(&mut transport, &pin, permissions, None)
+        .map_err(|e| passless_core::Error::Other(format!("Failed to get PIN token: {:?}", e)))?;
+
+    // Prepare authentication data for pinUvAuthParam computation
+    // [CMD_PASSLESS_RESET_UV_RETRIES, 1]
+    let auth_data = [CMD_PASSLESS_RESET_UV_RETRIES, 1];
+
+    // Compute pinUvAuthParam using the encapsulation's authenticate method
+    let pin_uv_auth_param = encapsulation
+        .authenticate(&auth_data, &pin_token_bytes)
+        .map_err(|e| {
+            passless_core::Error::Other(format!("Failed to compute PIN UV auth param: {:?}", e))
+        })?;
+
+    // Construct CBOR payload: map {1: subCommand=1, 3: pinUvAuthProtocol, 4: pinUvAuthParam}
+    let payload_bytes = soft_fido2_ctap::cbor::MapBuilder::new()
+        .insert(1, 1u8) // subCommand = 1
+        .map_err(|_| passless_core::Error::Other("Failed to build CBOR payload".to_string()))?
+        .insert(3, pin_uv_auth_protocol) // pinUvAuthProtocol
+        .map_err(|_| passless_core::Error::Other("Failed to build CBOR payload".to_string()))?
+        .insert_bytes(4, &pin_uv_auth_param) // pinUvAuthParam
+        .map_err(|_| passless_core::Error::Other("Failed to build CBOR payload".to_string()))?
+        .build()
+        .map_err(|_| passless_core::Error::Other("Failed to build CBOR payload".to_string()))?;
+
+    if output == OutputFormat::Plain {
+        println!("Sending authenticated UV retry reset command...");
+    }
+
+    // Send command 0x42 with the CBOR payload
+    let response = transport
+        .send_ctap_command(CMD_PASSLESS_RESET_UV_RETRIES, &payload_bytes, 30000)
+        .map_err(|e| {
+            passless_core::Error::Other(format!("Authenticated UV retry reset failed: {:?}", e))
+        })?;
+
+    let success = response == [0xa0] || response.first() == Some(&0x00);
+    if !success {
         return Err(passless_core::Error::Other(format!(
-            "UV retry reset failed with status: 0x{:02x}",
-            response[0]
+            "Authenticated UV retry reset failed with status: 0x{:02x}",
+            response.first().copied().unwrap_or(0xff)
         )));
     }
 
     match output {
         OutputFormat::Plain => {
-            println!("UV retries reset successfully!");
+            println!("UV retries reset successfully (authenticated)!");
         }
         OutputFormat::Json => {
             #[derive(Serialize)]
@@ -1388,7 +1470,7 @@ pub fn pin_uv_reset(output: OutputFormat, device: Option<&str>) -> Result<()> {
             }
             let result = PinUvResetResult {
                 success: true,
-                message: "UV retries reset successfully".to_string(),
+                message: "UV retries reset successfully (authenticated)".to_string(),
             };
             println!("{}", serde_json::to_string_pretty(&result).unwrap());
         }

--- a/cmd/passless/src/commands/client.rs
+++ b/cmd/passless/src/commands/client.rs
@@ -1,5 +1,7 @@
 //! FIDO2 Client Management Commands
 
+use crate::authenticator::CMD_PASSLESS_RESET_UV_RETRIES;
+
 use std::collections::HashMap;
 
 use passless_core::{OutputFormat, Result};
@@ -1346,6 +1348,47 @@ pub fn pin_change(
             let result = PinChangeResult {
                 success: true,
                 message: "PIN changed successfully".to_string(),
+            };
+            println!("{}", serde_json::to_string_pretty(&result).unwrap());
+        }
+    }
+
+    transport.close();
+    Ok(())
+}
+
+/// Reset built-in user verification retries on authenticator
+pub fn pin_uv_reset(output: OutputFormat, device: Option<&str>) -> Result<()> {
+    let mut transport = open_authenticator(device)?;
+
+    if output == OutputFormat::Plain {
+        println!("Resetting built-in user verification retries...");
+    }
+
+    let response = transport
+        .send_ctap_command(CMD_PASSLESS_RESET_UV_RETRIES, &[], 30000)
+        .map_err(|e| passless_core::Error::Other(format!("UV retry reset failed: {:?}", e)))?;
+
+    if !response.is_empty() && response[0] != 0x00 {
+        return Err(passless_core::Error::Other(format!(
+            "UV retry reset failed with status: 0x{:02x}",
+            response[0]
+        )));
+    }
+
+    match output {
+        OutputFormat::Plain => {
+            println!("UV retries reset successfully!");
+        }
+        OutputFormat::Json => {
+            #[derive(Serialize)]
+            struct PinUvResetResult {
+                success: bool,
+                message: String,
+            }
+            let result = PinUvResetResult {
+                success: true,
+                message: "UV retries reset successfully".to_string(),
             };
             println!("{}", serde_json::to_string_pretty(&result).unwrap());
         }

--- a/cmd/passless/src/main.rs
+++ b/cmd/passless/src/main.rs
@@ -227,6 +227,9 @@ fn run() -> Result<()> {
                     PinAction::Change { old_pin, new_pin } => {
                         commands::client::pin_change(*output, device.as_deref(), old_pin, new_pin)
                     }
+                    PinAction::UvReset => {
+                        commands::client::pin_uv_reset(*output, device.as_deref())
+                    }
                 },
             },
         };

--- a/cmd/passless/tests/e2e_client.rs
+++ b/cmd/passless/tests/e2e_client.rs
@@ -21,6 +21,8 @@ use sha2::{Digest, Sha256};
 
 const RP_ID: &str = "example.com";
 const ORIGIN: &str = "https://example.com";
+const CMD_PASSLESS_RESET_UV_RETRIES: u8 = 0x42;
+const RESET_UV_RETRIES_SUBCOMMAND: u8 = 0x01;
 
 /// Helper to connect to the first available authenticator
 fn connect_to_authenticator() -> Result<soft_fido2::Transport, Box<dyn std::error::Error>> {
@@ -819,6 +821,91 @@ fn get_uv_token_with_pin(
         None,
     )?;
     Ok(token)
+}
+
+fn get_uv_retries(transport: &mut soft_fido2::Transport) -> Result<u8, Box<dyn std::error::Error>> {
+    use soft_fido2_ctap::cbor::MapBuilder;
+
+    let params = MapBuilder::new().insert(0x02, 0x07u8)?.build()?;
+    let response = transport.send_ctap_command(0x06, &params, 30000)?;
+
+    if response.is_empty() {
+        return Err("getUvRetries returned empty response".into());
+    }
+
+    use ciborium::Value;
+    let cbor_value: Value = if response[0] == 0x00 {
+        ciborium::from_reader(&response[1..])?
+    } else {
+        ciborium::from_reader(&response[..])?
+    };
+
+    if let Value::Map(map) = cbor_value {
+        for (key, value) in map {
+            if key == Value::Integer(0x05.into())
+                && let Value::Integer(retries) = value
+            {
+                return u8::try_from(i128::from(retries)).map_err(|_| "invalid uvRetries".into());
+            }
+        }
+    }
+
+    Err("uvRetries missing from response".into())
+}
+
+fn build_authenticated_uv_reset_payload(
+    transport: &mut soft_fido2::Transport,
+    pin: &str,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    use soft_fido2_ctap::cbor::MapBuilder;
+
+    let mut encapsulation =
+        soft_fido2::PinUvAuthEncapsulation::new(transport, soft_fido2::PinProtocol::V2)?;
+    let token = encapsulation.get_pin_uv_auth_token_using_pin_with_permissions(
+        transport, pin, 0x04, // credentialManagement
+        None,
+    )?;
+    let auth_data = [CMD_PASSLESS_RESET_UV_RETRIES, RESET_UV_RETRIES_SUBCOMMAND];
+    let pin_uv_auth_param = encapsulation.authenticate(&auth_data, &token)?;
+
+    Ok(MapBuilder::new()
+        .insert(0x01, RESET_UV_RETRIES_SUBCOMMAND)?
+        .insert(0x03, 0x02u8)?
+        .insert_bytes(0x04, &pin_uv_auth_param)?
+        .build()?)
+}
+
+#[test]
+#[ignore]
+fn test_authenticated_uv_retry_reset_command() {
+    println!("\n═══════════════════════════════════════");
+    println!("  TEST: Authenticated UV Retry Reset");
+    println!("═══════════════════════════════════════\n");
+
+    let mut harness = AuthenticatorHarness::with_local().expect("Failed to create harness");
+    harness.start().expect("Failed to start authenticator");
+    std::thread::sleep(std::time::Duration::from_millis(500));
+
+    let mut transport = connect_to_authenticator().expect("Failed to connect");
+    set_pin(&mut transport, "1234").expect("Failed to set PIN");
+
+    let unauthenticated = transport.send_ctap_command(CMD_PASSLESS_RESET_UV_RETRIES, &[], 30000);
+    if let Ok(response) = unauthenticated {
+        assert_ne!(response, vec![0x00, 0xa0]);
+    }
+
+    let payload = build_authenticated_uv_reset_payload(&mut transport, "1234")
+        .expect("Failed to build authenticated reset payload");
+    let authenticated = transport
+        .send_ctap_command(CMD_PASSLESS_RESET_UV_RETRIES, &payload, 30000)
+        .expect("Failed to send authenticated reset command");
+    assert!(authenticated == vec![0x00, 0xa0] || authenticated == vec![0xa0]);
+    assert_eq!(
+        get_uv_retries(&mut transport).expect("Failed to get UV retries"),
+        3
+    );
+
+    harness.stop();
 }
 
 #[test]

--- a/passless-core/src/config.rs
+++ b/passless-core/src/config.rs
@@ -631,4 +631,6 @@ pub enum PinAction {
         #[arg(value_name = "NEW_PIN")]
         new_pin: String,
     },
+    /// Reset built-in user verification retries without deleting credentials
+    UvReset,
 }


### PR DESCRIPTION
## Summary
- add passless client pin uv-reset for recovering exhausted built-in UV retries without deleting credentials
- require server-side PIN/UV auth with CredentialManagement permission before resetting retries
- use the soft-fido2 high-level UV retry reset API instead of mutating PIN storage or rebuilding the authenticator
- update to soft-fido2 0.13.1 from crates.io
- add unit coverage for rejecting unauthenticated reset and an ignored E2E test for authenticated success

## Verification
- cargo test -p passless-rs
- cargo clippy -p passless-rs --all-targets --all-features -- -D warnings
- cargo test -p passless-rs --test e2e_client test_authenticated_uv_retry_reset_command -- --ignored --test-threads=1 --nocapture
