### PR TITLE
chore: improve release tooling for shallow clones

### DIFF
--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -3,11 +3,13 @@ set -euo pipefail
 
 ensure_full_history() {
     if git rev-parse --is-shallow-repository 2>/dev/null | grep -q "true"; then
-        echo "Shallow clone detected. Fetching full history..."
+        echo "Shallow clone detected. Fetching full history and tags..."
         git fetch --unshallow --quiet
     fi
-    echo "Fetching tags..."
-    git fetch --tags --quiet
+    if [ -z "$(git tag -l)" ]; then
+        echo "No tags found. Fetching tags..."
+        git fetch --tags --quiet
+    fi
 }
 
 ensure_clean_state() {
@@ -16,24 +18,46 @@ ensure_clean_state() {
         exit 1
     fi
 
-    BRANCH=$(git rev-parse --abbrev-ref HEAD)
-    if [ "$BRANCH" != "master" ]; then
-        echo "Not on master branch. Current branch: $BRANCH"
+    REMOTE="origin"
+
+    if ! git remote | grep -q "^$REMOTE$"; then
+        echo "Remote '$REMOTE' does not exist. Please configure git remote."
         exit 1
     fi
 
-    git pull origin master --quiet
+    git fetch "$REMOTE" --quiet
 
-    if [ "$(git rev-list --count origin/master..HEAD 2>/dev/null || echo 1)" -ne 0 ]; then
-        echo "There are commits ahead of origin/master. Push or merge them first."
-        echo "CHANGELOG template needs master commit ID."
+    DEFAULT_BRANCH=$(git symbolic-ref "refs/remotes/$REMOTE/HEAD" 2>/dev/null | sed 's@^refs/remotes/[^/]*/@@' || git remote show "$REMOTE" 2>/dev/null | grep "HEAD branch" | sed 's/.*: //')
+
+    if [ -z "$DEFAULT_BRANCH" ]; then
+        echo "Could not determine default branch from remote '$REMOTE'."
+        echo "Please ensure git remote is properly configured."
         exit 1
+    fi
+
+    REMOTE_BRANCH="refs/remotes/$REMOTE/$DEFAULT_BRANCH"
+    if ! git show-ref --quiet "$REMOTE_BRANCH"; then
+        echo "Branch '$DEFAULT_BRANCH' does not exist in remote '$REMOTE'."
+        echo "Please ensure the remote has a default branch."
+        exit 1
+    fi
+
+    LOCAL_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    if [ "$LOCAL_BRANCH" = "$DEFAULT_BRANCH" ]; then
+        git pull "$REMOTE" "$DEFAULT_BRANCH" --quiet
+    else
+        COMMIT_COUNT=$(git rev-list --count "$REMOTE_BRANCH"..HEAD 2>/dev/null || echo 1)
+        if [ "$COMMIT_COUNT" -ne 0 ]; then
+            echo "There are $COMMIT_COUNT commits in '$LOCAL_BRANCH' branch that are not in '$REMOTE/$DEFAULT_BRANCH'."
+            echo "Please merge them first. CHANGELOG template needs the latest commit from '$DEFAULT_BRANCH'."
+            exit 1
+        fi
     fi
 }
 
 echo "=== Checking repository state ==="
-ensure_clean_state
 ensure_full_history
+ensure_clean_state
 
 echo ""
 echo "=== Recent commits since last release ==="

--- a/.github/workflows/auto-tag.yaml
+++ b/.github/workflows/auto-tag.yaml
@@ -12,6 +12,7 @@ jobs:
       - name: Checkout repository
         with:
           token: ${{ secrets.PAT }}
+          fetch-depth: 0
         uses: actions/checkout@v7
 
       - name: Get last changelog version

--- a/.opencode/skills/release/SKILL.md
+++ b/.opencode/skills/release/SKILL.md
@@ -24,6 +24,8 @@ Before releasing, verify:
 4. **No commits ahead of origin/master** (output of `git rev-list --count origin/master..HEAD` must be 0)
 5. **Repository is not a shallow clone** — git-cliff needs full history for accurate changelogs
 
+The release script handles shallow/latest-commit checkouts by fetching full history and tags before comparing against the remote default branch.
+
 Check with:
 ```bash
 git status --short
@@ -101,6 +103,8 @@ If this outputs `true`, unshallow the repo before proceeding:
 git fetch --unshallow origin
 git fetch --tags origin
 ```
+
+Alternatively, run `.ci/release.sh`; it performs the shallow-clone and tag fetch checks before preparing the release.
 
 ### Step 2: Determine Version
 


### PR DESCRIPTION
## Summary
- make `.ci/release.sh` fetch full history and tags before validating the release base
- allow the script to work from a latest-commit checkout at the remote default-branch tip
- add full-history checkout to auto-tag workflow
- document shallow/latest-commit behavior in the release skill

## Verification
- bash -n .ci/release.sh
- git diff --check
