### PR TITLE
fix(notification): make Dunst UP prompts actionable

### DIFF
--- a/cmd/passless/src/authenticator.rs
+++ b/cmd/passless/src/authenticator.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "agent")]
 use crate::agent::interaction::{AgentInteractionManager, action_from_info};
-use crate::notification::show_verification_notification;
+use crate::notification::{show_user_presence_notification, show_verification_notification};
 use crate::pin_storage::PinStorage;
 use crate::storage::{CredentialFilter, CredentialStorage};
 use crate::util::bytes_to_hex;
@@ -265,7 +265,7 @@ impl<S: CredentialStorage, P: PinStorage> AuthenticatorCallbacks for PasslessCal
             return Ok(UpResult::Accepted);
         }
 
-        match show_verification_notification(
+        match show_user_presence_notification(
             info,
             Some(rp),
             user,
@@ -557,7 +557,7 @@ impl<S: CredentialStorage, P: PinStorage> AuthenticatorCallbacks for PasslessCal
         };
 
         let count = storage.count_credentials();
-        debug!("Total credentials: {}", count);
+        debug!("Total credentials found: {}", count);
         Ok(count)
     }
 

--- a/cmd/passless/src/notification.rs
+++ b/cmd/passless/src/notification.rs
@@ -1,14 +1,14 @@
-//! Desktop notification handling for user verification
+//! Desktop notification handling for user presence and verification
 //!
 //! This module provides desktop notification support with compatibility for
-//! different notification servers (notify-osd, mako, etc.).
+//! different notification servers (notify-osd, mako, Dunst, etc.).
 
 use std::sync::{Arc, Mutex};
 
 use log::{debug, info, warn};
 use notify_rust::{Notification, Timeout, Urgency};
 
-/// Result of user verification via notification
+/// Result of user interaction via notification
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NotificationResult {
     /// User approved the operation
@@ -20,41 +20,101 @@ pub enum NotificationResult {
 /// Result of a yes/no question via notification
 pub type YesNoResult = NotificationResult;
 
-/// Check if the notification server requires special handling
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PromptKind {
+    UserPresence,
+    UserVerification,
+    YesNo,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NotificationActionMode {
+    Explicit,
+    Default,
+    DunstDefault,
+}
+
+impl NotificationActionMode {
+    fn uses_default_action(self) -> bool {
+        matches!(self, Self::Default | Self::DunstDefault)
+    }
+}
+
+/// Determine how actions should be exposed for a notification server.
 ///
-/// Some servers (notify-osd 1.0, mako 0.0.0) don't support action buttons properly
-/// and require using a "default" action instead.
-fn requires_default_action() -> bool {
+/// Legacy compatibility servers use a default action for all prompt types.
+/// Dunst gets that behavior only for CTAP user presence: its actions are
+/// supported but normally invoked through Dunst's interaction model instead
+/// of visible buttons. User verification deliberately keeps explicit actions
+/// so the UP compatibility path cannot silently weaken UV semantics.
+fn action_mode_for_server(
+    server_name: &str,
+    server_version: &str,
+    prompt_kind: PromptKind,
+) -> NotificationActionMode {
+    let server_name = server_name.to_lowercase();
+
+    match (server_name.as_str(), server_version) {
+        ("notify-osd", "1.0") | ("mako", "0.0.0") | ("quickshell", "") => {
+            NotificationActionMode::Default
+        }
+        ("dunst", _) if prompt_kind == PromptKind::UserPresence => {
+            NotificationActionMode::DunstDefault
+        }
+        _ => NotificationActionMode::Explicit,
+    }
+}
+
+fn notification_action_mode(prompt_kind: PromptKind) -> NotificationActionMode {
     notify_rust::get_server_information()
-        .map(|info| {
-            let server_name = info.name.to_lowercase();
+        .map(|server| {
+            let mode = action_mode_for_server(&server.name, &server.version, prompt_kind);
             debug!(
                 "Notification server: {} (version: {})",
-                info.name, info.version
+                server.name, server.version
             );
 
-            match (server_name.as_str(), info.version.as_str()) {
-                ("notify-osd", "1.0") | ("mako", "0.0.0") | ("quickshell", "") => {
-                    info!("Detected {} - using default action mode", server_name);
-                    true
+            match mode {
+                NotificationActionMode::Default => {
+                    info!("Detected {} - using default action mode", server.name);
                 }
-                _ => false,
+                NotificationActionMode::DunstDefault => {
+                    info!("Detected Dunst - using UP-specific default action mode");
+                }
+                NotificationActionMode::Explicit => {}
             }
+
+            mode
         })
         .unwrap_or_else(|e| {
             warn!("Failed to get notification server info: {}", e);
-            false
+            NotificationActionMode::Explicit
         })
 }
 
-/// Show a user verification notification and wait for response
-pub fn show_verification_notification(
+fn action_is_accepted(
+    action: &str,
+    affirmative_action: &str,
+    action_mode: NotificationActionMode,
+) -> bool {
+    if action == affirmative_action {
+        return true;
+    }
+
+    action == "default" && action_mode.uses_default_action()
+}
+
+fn show_confirmation_notification(
     operation: &str,
     relying_party: Option<&str>,
     user: Option<&str>,
     timeout_seconds: u32,
+    prompt_kind: PromptKind,
 ) -> Result<NotificationResult, String> {
-    // Build notification message
+    debug_assert!(prompt_kind != PromptKind::YesNo);
+
+    let action_mode = notification_action_mode(prompt_kind);
+
     let mut message = format!("Operation: {}", operation);
     if let Some(rp) = relying_party {
         message.push_str(&format!("\nRelying Party: {}", rp));
@@ -63,40 +123,43 @@ pub fn show_verification_notification(
         message.push_str(&format!("\nUser: {}", user));
     }
 
-    info!("Showing user verification notification");
+    if action_mode == NotificationActionMode::DunstDefault {
+        message.push_str(
+            "\n\nDunst: confirm by invoking this notification's action \
+             (middle-click by default). Closing the notification denies the request.",
+        );
+    }
 
-    // Check if we need to use default action mode
-    let default_means_user_present = requires_default_action();
+    let summary = match prompt_kind {
+        PromptKind::UserPresence => "👆 User Presence Required",
+        PromptKind::UserVerification => "🔒 User Verification Required",
+        PromptKind::YesNo => unreachable!("yes/no prompts use show_yes_no_notification"),
+    };
 
-    // Shared state to capture the action
+    info!("Showing {} notification", summary);
+
     let action_result = Arc::new(Mutex::new(None));
     let action_result_clone = action_result.clone();
 
-    // Build notification with appropriate actions
     let mut notification = Notification::new();
     notification
-        .summary("🔒 User Verification Required")
+        .summary(summary)
         .body(&message)
         .icon("security-high")
         .timeout(Timeout::Milliseconds(timeout_seconds * 1000))
         .urgency(Urgency::Critical);
 
-    if default_means_user_present {
-        // For servers that don't support action buttons properly,
-        // use a single "default" action that accepts on click
+    if action_mode.uses_default_action() {
         notification.action("default", "");
     } else {
-        // For servers with proper action button support
         notification.action("approve", "Accept");
         notification.action("deny", "Deny");
     }
 
-    // Show the notification
     let handle = notification
         .show()
         .map_err(|e| format!("Failed to show notification: {}", e))?;
 
-    // Wait for user action
     handle.wait_for_action(|action| {
         debug!("User action received: {}", action);
         let mut result = action_result_clone
@@ -105,31 +168,61 @@ pub fn show_verification_notification(
         *result = Some(action.to_string());
     });
 
-    // Process the action taken
     let action = action_result
         .lock()
         .expect("Failed to lock action result")
         .clone()
         .unwrap_or_else(|| "__closed".to_string());
 
-    let user_present = match action.as_str() {
-        "approve" => true,
-        "deny" => false,
-        "default" => default_means_user_present,
-        "__closed" => false,
-        other => {
-            debug!("Unknown action '{}' - treating as denied", other);
-            false
-        }
-    };
-
-    if user_present {
-        info!("User verification accepted via notification");
+    if action_is_accepted(&action, "approve", action_mode) {
+        info!("Notification accepted");
         Ok(NotificationResult::Accepted)
     } else {
-        info!("User verification denied or notification closed");
+        if action != "deny" && action != "__closed" {
+            debug!("Unknown action '{}' - treating as denied", action);
+        }
+        info!("Notification denied or closed");
         Ok(NotificationResult::Denied)
     }
+}
+
+/// Show a CTAP user-presence notification and wait for response.
+///
+/// User presence is a consent gesture (for example, touching a hardware key),
+/// so notification activation may be used as the explicit gesture on daemons
+/// such as Dunst that do not expose action buttons directly.
+pub fn show_user_presence_notification(
+    operation: &str,
+    relying_party: Option<&str>,
+    user: Option<&str>,
+    timeout_seconds: u32,
+) -> Result<NotificationResult, String> {
+    show_confirmation_notification(
+        operation,
+        relying_party,
+        user,
+        timeout_seconds,
+        PromptKind::UserPresence,
+    )
+}
+
+/// Show a user-verification notification and wait for response.
+///
+/// Unlike user presence, Dunst activation is not treated as verification: the
+/// user must invoke the explicit Accept action through Dunst's action UI.
+pub fn show_verification_notification(
+    operation: &str,
+    relying_party: Option<&str>,
+    user: Option<&str>,
+    timeout_seconds: u32,
+) -> Result<NotificationResult, String> {
+    show_confirmation_notification(
+        operation,
+        relying_party,
+        user,
+        timeout_seconds,
+        PromptKind::UserVerification,
+    )
 }
 
 /// Show a yes/no question notification and wait for response
@@ -145,37 +238,30 @@ pub fn show_verification_notification(
 pub fn show_yes_no_notification(title: &str, question: &str) -> Result<YesNoResult, String> {
     info!("Showing yes/no notification: {}", title);
 
-    // Check if we need to use default action mode
-    let default_means_yes = requires_default_action();
+    let action_mode = notification_action_mode(PromptKind::YesNo);
 
-    // Shared state to capture the action
     let action_result = Arc::new(Mutex::new(None));
     let action_result_clone = action_result.clone();
 
-    // Build notification with appropriate actions
     let mut notification = Notification::new();
     notification
         .summary(title)
         .body(question)
         .icon("dialog-question")
-        .timeout(Timeout::Never) // Wait for user action
+        .timeout(Timeout::Never)
         .urgency(Urgency::Critical);
 
-    if default_means_yes {
-        // For servers that don't support action buttons properly
+    if action_mode.uses_default_action() {
         notification.action("default", "");
     } else {
-        // For servers with proper action button support
         notification.action("yes", "Yes");
         notification.action("no", "No");
     }
 
-    // Show the notification
     let handle = notification
         .show()
         .map_err(|e| format!("Failed to show notification: {}", e))?;
 
-    // Wait for user action
     handle.wait_for_action(|action| {
         debug!("User action received: {}", action);
         let mut result = action_result_clone
@@ -184,28 +270,19 @@ pub fn show_yes_no_notification(title: &str, question: &str) -> Result<YesNoResu
         *result = Some(action.to_string());
     });
 
-    // Process the action taken
     let action = action_result
         .lock()
         .expect("Failed to lock action result")
         .clone()
         .unwrap_or_else(|| "__closed".to_string());
 
-    let user_said_yes = match action.as_str() {
-        "yes" => true,
-        "no" => false,
-        "default" => default_means_yes,
-        "__closed" => false,
-        other => {
-            debug!("Unknown action '{}' - treating as no", other);
-            false
-        }
-    };
-
-    if user_said_yes {
+    if action_is_accepted(&action, "yes", action_mode) {
         info!("User answered yes");
         Ok(YesNoResult::Accepted)
     } else {
+        if action != "no" && action != "__closed" {
+            debug!("Unknown action '{}' - treating as no", action);
+        }
         info!("User answered no or closed notification");
         Ok(YesNoResult::Denied)
     }
@@ -271,8 +348,89 @@ mod tests {
     }
 
     #[test]
-    fn test_requires_default_action_doesnt_panic() {
-        // Just ensure the function doesn't panic
-        let _ = requires_default_action();
+    fn test_dunst_default_action_is_up_only() {
+        assert_eq!(
+            action_mode_for_server("dunst", "1.13.0", PromptKind::UserPresence),
+            NotificationActionMode::DunstDefault
+        );
+        assert_eq!(
+            action_mode_for_server("Dunst", "1.13.0", PromptKind::UserPresence),
+            NotificationActionMode::DunstDefault
+        );
+        assert_eq!(
+            action_mode_for_server("dunst", "1.13.0", PromptKind::UserVerification),
+            NotificationActionMode::Explicit
+        );
+        assert_eq!(
+            action_mode_for_server("dunst", "1.13.0", PromptKind::YesNo),
+            NotificationActionMode::Explicit
+        );
+    }
+
+    #[test]
+    fn test_legacy_default_action_servers_are_preserved() {
+        for (name, version) in [
+            ("notify-osd", "1.0"),
+            ("mako", "0.0.0"),
+            ("quickshell", ""),
+        ] {
+            for prompt_kind in [
+                PromptKind::UserPresence,
+                PromptKind::UserVerification,
+                PromptKind::YesNo,
+            ] {
+                assert_eq!(
+                    action_mode_for_server(name, version, prompt_kind),
+                    NotificationActionMode::Default
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_unknown_servers_use_explicit_actions() {
+        assert_eq!(
+            action_mode_for_server("gnome-shell", "47", PromptKind::UserPresence),
+            NotificationActionMode::Explicit
+        );
+    }
+
+    #[test]
+    fn test_default_action_acceptance_is_mode_specific() {
+        assert!(action_is_accepted(
+            "default",
+            "approve",
+            NotificationActionMode::DunstDefault
+        ));
+        assert!(action_is_accepted(
+            "default",
+            "approve",
+            NotificationActionMode::Default
+        ));
+        assert!(!action_is_accepted(
+            "default",
+            "approve",
+            NotificationActionMode::Explicit
+        ));
+        assert!(action_is_accepted(
+            "approve",
+            "approve",
+            NotificationActionMode::Explicit
+        ));
+        assert!(!action_is_accepted(
+            "deny",
+            "approve",
+            NotificationActionMode::DunstDefault
+        ));
+        assert!(!action_is_accepted(
+            "__closed",
+            "approve",
+            NotificationActionMode::DunstDefault
+        ));
+    }
+
+    #[test]
+    fn test_notification_action_mode_doesnt_panic() {
+        let _ = notification_action_mode(PromptKind::UserPresence);
     }
 }

--- a/cmd/passless/src/notification.rs
+++ b/cmd/passless/src/notification.rs
@@ -369,11 +369,7 @@ mod tests {
 
     #[test]
     fn test_legacy_default_action_servers_are_preserved() {
-        for (name, version) in [
-            ("notify-osd", "1.0"),
-            ("mako", "0.0.0"),
-            ("quickshell", ""),
-        ] {
+        for (name, version) in [("notify-osd", "1.0"), ("mako", "0.0.0"), ("quickshell", "")] {
             for prompt_kind in [
                 PromptKind::UserPresence,
                 PromptKind::UserVerification,

--- a/docs/NOTIFICATIONS.md
+++ b/docs/NOTIFICATIONS.md
@@ -1,0 +1,13 @@
+# Desktop notifications
+
+Passless uses desktop notifications for local user interaction during FIDO2 ceremonies. Notification actions depend on the desktop notification daemon because the Freedesktop interface does not require every daemon to render actions as visible buttons.
+
+## Dunst
+
+Dunst supports notification actions, but normally exposes them through its own interaction model instead of inline `Accept` / `Deny` buttons.
+
+For **CTAP user presence (UP)**, Passless sends a single default action on Dunst. Invoke the action on the Passless notification to confirm presence; Dunst uses middle-click for the default action by default, or you can use your configured `do_action` binding. Closing or dismissing the notification denies the request.
+
+For **user verification (UV)** and ordinary yes/no prompts, Passless keeps explicit actions instead of treating notification activation as approval. If Dunst does not render those actions visibly, use its action/context mechanism (for example `dunstctl context`) to choose the intended action.
+
+This distinction is intentional: UP is an explicit presence/consent gesture, while UV has stronger verification semantics and should not be weakened by daemon-specific notification activation behavior.


### PR DESCRIPTION
Fixes #370

## Problem

Passless used the same desktop-notification helper for CTAP user presence (UP) and user verification (UV). Dunst supports Freedesktop notification actions, but normally exposes them through `do_action` / its context mechanism rather than rendering `Accept` / `Deny` buttons. That made UP ceremonies such as recovery/reset appear impossible to confirm.

## Design

- Split the notification entry points at the existing `soft-fido2` callback boundary: `request_up()` now uses a UP-specific notification path, while `request_uv()` keeps the verification path.
- Model notification action compatibility explicitly instead of extending the old shared boolean.
- On Dunst, UP uses a single Freedesktop `default` action. The notification itself explains that middle-click is Dunst's default action gesture and that closing the notification denies the request.
- Preserve the existing default-action compatibility behavior for notify-osd, mako, and quickshell.
- Keep Dunst UV and generic yes/no prompts on explicit actions so the UP compatibility fix cannot silently weaken UV semantics.
- Factor action-result mapping into a pure helper so close, deny, default, and unknown actions can be tested without a live notification daemon.

## Security semantics

UP and UV intentionally differ here. CTAP UP is an explicit presence/consent gesture; invoking the notification's default action can serve as that gesture. UV is stronger, so ordinary Dunst notification activation is not promoted to verification. Closing/dismissing a notification is always negative and never approves the ceremony.

## Tests

Added unit coverage for:

- Dunst default-action mode only for UP, including case-insensitive server detection.
- Dunst UV and yes/no prompts retaining explicit actions.
- Existing notify-osd/mako/quickshell compatibility behavior.
- Unknown servers retaining explicit actions.
- Default action acceptance only in default-action modes.
- Deny and `__closed` never accepting.

## Documentation

Added `docs/NOTIFICATIONS.md` with the Dunst interaction model, UP behavior, UV behavior, and the `dunstctl context` fallback for explicit actions.
