### PR TITLE
build(deps): update soft-fido2 to 0.16.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,6 +418,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,7 +927,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1369,7 +1380,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1729,7 +1740,7 @@ dependencies = [
  "nix 0.31.3",
  "passless-config-doc",
  "psl",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sha2",
@@ -1767,7 +1778,7 @@ dependencies = [
  "passless-core",
  "passless-uhid",
  "prs-lib",
- "rand",
+ "rand 0.8.5",
  "rpassword",
  "serde",
  "serde_bytes",
@@ -2096,6 +2107,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2210,7 +2232,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2441,9 +2463,9 @@ dependencies = [
 
 [[package]]
 name = "soft-fido2"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b946b2cb7137bda5d85c48cc0698c159e521c02995f4181c7070f9dbbe1c18d9"
+checksum = "6253f1d9accfdb61d9522ccf5b6e1ffca3af6e4dd3b54600f7be427c056d6696"
 dependencies = [
  "aes",
  "cbc",
@@ -2452,7 +2474,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "p256",
- "rand",
+ "rand 0.10.2",
  "secstr",
  "serde",
  "serde_bytes",
@@ -2467,9 +2489,9 @@ dependencies = [
 
 [[package]]
 name = "soft-fido2-crypto"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54d6bbceb745397af684bb34b35282ad0a0829459d9fa38fbf983d5691980add"
+checksum = "4d857eaba0c41a51c298fc8ef6c49a3afe7f0a8f54360c48d8da70154db7aa64"
 dependencies = [
  "aes",
  "cbc",
@@ -2477,7 +2499,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "p256",
- "rand",
+ "rand 0.10.2",
  "sha2",
  "subtle",
  "thiserror",
@@ -2486,12 +2508,12 @@ dependencies = [
 
 [[package]]
 name = "soft-fido2-ctap"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b86de7abfb9216eda04154b1cea2d08dc65c3ecb4422151f4ca3ae8e81775a7"
+checksum = "1475110e56eb7c625badd974e177ec1a7876d705b6d0b89f70877d96e8c4b182"
 dependencies = [
  "cbor4ii",
- "rand",
+ "rand 0.10.2",
  "secstr",
  "serde",
  "serde_bytes",
@@ -2505,9 +2527,9 @@ dependencies = [
 
 [[package]]
 name = "soft-fido2-transport"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7da8b1bd0877f8640bce10a873c5768379c54e54c265c178afa9d39ae51c42e"
+checksum = "8742814d0e2f5dbf71ecad1402e2f6eb8eca3eeb6da25fc0041a38ecc515f970"
 dependencies = [
  "hex",
  "hidapi",
@@ -2625,7 +2647,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3051,7 +3073,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ passless-core = { path = "./passless-core", version = "0.14.0" }
 passless-config-doc = { path = "./passless-config-doc", version = "0.14.0" }
 passless-uhid = { path = "./passless-uhid", version = "0.14.0" }
 
-soft-fido2 = "0.16.0"
-soft-fido2-ctap = "0.16.0"
-soft-fido2-transport = "0.16.0"
+soft-fido2 = "0.16.1"
+soft-fido2-ctap = "0.16.1"
+soft-fido2-transport = "0.16.1"
 
 thiserror = "2.0"
 clap = { version = "4.5", features = ["std", "color", "derive", "cargo", "env"] }

--- a/cmd/passless/src/pin_storage/mod.rs
+++ b/cmd/passless/src/pin_storage/mod.rs
@@ -33,6 +33,9 @@ pub struct SerializablePinConfig {
     /// Force PIN change flag
     #[serde(default)]
     pub force_pin_change: bool,
+    /// Credential wrapping generation, incremented on reset to invalidate wrapped credentials
+    #[serde(default)]
+    pub credential_wrapping_generation: u64,
     /// Modification timestamp in milliseconds since Unix epoch
     /// Used for conflict resolution when syncing across machines
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -71,6 +74,7 @@ impl From<&PinState> for SerializablePinConfig {
             min_pin_length: state.min_pin_length,
             version: state.version,
             force_pin_change: state.force_pin_change,
+            credential_wrapping_generation: state.credential_wrapping_generation,
             modified_at,
         }
     }
@@ -173,6 +177,9 @@ pub struct SerializablePinState {
     /// Force PIN change flag
     #[serde(default)]
     pub force_pin_change: bool,
+    /// Credential wrapping generation, incremented on reset to invalidate wrapped credentials
+    #[serde(default)]
+    pub credential_wrapping_generation: u64,
     /// Auto-lock timestamp in milliseconds since Unix epoch (None = not locked)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub locked_until: Option<u64>,
@@ -187,6 +194,7 @@ impl Default for SerializablePinState {
             min_pin_length: 4,
             version: 0,
             force_pin_change: false,
+            credential_wrapping_generation: 0,
             locked_until: None,
         }
     }
@@ -202,6 +210,7 @@ impl From<&PinState> for SerializablePinState {
             version: state.version,
             force_pin_change: state.force_pin_change,
             locked_until: state.locked_until,
+            credential_wrapping_generation: state.credential_wrapping_generation,
         }
     }
 }
@@ -220,6 +229,7 @@ impl From<SerializablePinState> for PinState {
             version: state.version,
             force_pin_change: state.force_pin_change,
             locked_until: state.locked_until,
+            credential_wrapping_generation: state.credential_wrapping_generation,
         }
     }
 }
@@ -245,6 +255,7 @@ impl SerializablePinState {
             version: config.version,
             force_pin_change: config.force_pin_change,
             locked_until: retries.locked_until,
+            credential_wrapping_generation: config.credential_wrapping_generation,
         }
     }
 }

--- a/cmd/passless/tests/tpm_pin_portable.rs
+++ b/cmd/passless/tests/tpm_pin_portable.rs
@@ -140,6 +140,7 @@ fn make_pin_state(pin: &str) -> PinState {
         version: 1,
         force_pin_change: false,
         locked_until: None,
+        credential_wrapping_generation: 0,
     }
 }
 


### PR DESCRIPTION
Bump soft-fido2, soft-fido2-ctap and soft-fido2-transport from 0.16.0 to 0.16.1.

Persist the new credential_wrapping_generation field added by the upstream reset-invalidation change so wrapped credentials are invalidated on PIN reset and the value survives sync across machines.