### PR TITLE
release: Version 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.15.0](https://github.com/pando85/passless/tree/v0.15.0) - 2026-08-01
+
+### Added
+
+- Add encrypted credential backup and restore (#383) ([6f707d6](https://github.com/pando85/passless/commit/6f707d6495bb7171dd1440a96288f708a9a086a1))
+
+### Build
+
+- deps: Update Rust crate clap to v4.6.5 (#381) ([e0d8e2d](https://github.com/pando85/passless/commit/e0d8e2d0b507a671fb5823b056497a6d7745b4dc))
+- deps: Update soft-fido2 to 0.16.1 (#387) ([51b6e41](https://github.com/pando85/passless/commit/51b6e419bedbb9f622b4125115a6508cbcac30d6))
+
 ## [v0.14.0](https://github.com/pando85/passless/tree/v0.14.0) - 2026-07-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,7 +1718,7 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "passless-config-doc"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "passless-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "clap",
  "clap-serde-derive",
@@ -1752,7 +1752,7 @@ dependencies = [
 
 [[package]]
 name = "passless-rs"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1799,7 +1799,7 @@ dependencies = [
 
 [[package]]
 name = "passless-uhid"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "libc",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,15 @@ resolver = "2"
 [workspace.package]
 authors = ["Pando85 <pando855@gmail.com>"]
 edition = "2024"
-version = "0.14.0"
+version = "0.15.0"
 license-file = "./LICENSE"
 homepage = "https://github.com/pando85/passless"
 repository = "https://github.com/pando85/passless"
 [workspace.dependencies]
 # Workspace crates
-passless-core = { path = "./passless-core", version = "0.14.0" }
-passless-config-doc = { path = "./passless-config-doc", version = "0.14.0" }
-passless-uhid = { path = "./passless-uhid", version = "0.14.0" }
+passless-core = { path = "./passless-core", version = "0.15.0" }
+passless-config-doc = { path = "./passless-config-doc", version = "0.15.0" }
+passless-uhid = { path = "./passless-uhid", version = "0.15.0" }
 
 soft-fido2 = "0.16.1"
 soft-fido2-ctap = "0.16.1"


### PR DESCRIPTION
## Release 0.15.0

### Features
- add encrypted credential backup and restore (#383)

### Dependencies
- update soft-fido2 to 0.16.1 (#387)
- update Rust crate clap to v4.6.5 (#381)