### PR TITLE
fix: advertise dynamic built-in UV state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,7 +927,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1380,7 +1380,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2232,7 +2232,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2463,9 +2463,9 @@ dependencies = [
 
 [[package]]
 name = "soft-fido2"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6253f1d9accfdb61d9522ccf5b6e1ffca3af6e4dd3b54600f7be427c056d6696"
+checksum = "60598574bc8e644e26ba6e029e83cc53e591e50df1d7e367d3f59f80338d9173"
 dependencies = [
  "aes",
  "cbc",
@@ -2489,9 +2489,9 @@ dependencies = [
 
 [[package]]
 name = "soft-fido2-crypto"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d857eaba0c41a51c298fc8ef6c49a3afe7f0a8f54360c48d8da70154db7aa64"
+checksum = "75dfd057c83f789ebfb140d76a29163edb6dba492d08af1028d33c5286a61ccc"
 dependencies = [
  "aes",
  "cbc",
@@ -2508,9 +2508,9 @@ dependencies = [
 
 [[package]]
 name = "soft-fido2-ctap"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1475110e56eb7c625badd974e177ec1a7876d705b6d0b89f70877d96e8c4b182"
+checksum = "e32930ebc71f65c8acb8eb006172d99b8be550ebcf84b1031bcafe717ab68e0f"
 dependencies = [
  "cbor4ii",
  "rand 0.10.2",
@@ -2527,9 +2527,9 @@ dependencies = [
 
 [[package]]
 name = "soft-fido2-transport"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8742814d0e2f5dbf71ecad1402e2f6eb8eca3eeb6da25fc0041a38ecc515f970"
+checksum = "c370dd1c29f054cf9249d4ddc682850104a6484fece89c08fba9eb87ea588902"
 dependencies = [
  "hex",
  "hidapi",
@@ -2647,7 +2647,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3073,7 +3073,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ passless-core = { path = "./passless-core", version = "0.15.0" }
 passless-config-doc = { path = "./passless-config-doc", version = "0.15.0" }
 passless-uhid = { path = "./passless-uhid", version = "0.15.0" }
 
-soft-fido2 = "0.16.1"
-soft-fido2-ctap = "0.16.1"
-soft-fido2-transport = "0.16.1"
+soft-fido2 = "0.16.2"
+soft-fido2-ctap = "0.16.2"
+soft-fido2-transport = "0.16.2"
 
 thiserror = "2.0"
 clap = { version = "4.5", features = ["std", "color", "derive", "cargo", "env"] }

--- a/cmd/passless/src/authenticator.rs
+++ b/cmd/passless/src/authenticator.rs
@@ -13,10 +13,10 @@ use crate::util::bytes_to_hex;
 use passless_core::config::{PinConfig, PinEnforcement, SecurityConfig};
 
 use soft_fido2::{
-    Authenticator, AuthenticatorCallbacks, AuthenticatorConfig, AuthenticatorOptions, Credential,
-    CredentialBackupState, CredentialKeyProvider, CredentialRef, CtapCommand,
-    Error as SoftFido2Error, PinState, Result, SoftwareCredentialKeyProvider, StatusCode, UpResult,
-    UvResult,
+    Authenticator, AuthenticatorCallbacks, AuthenticatorConfig, AuthenticatorOptions,
+    BuiltInUvState, Credential, CredentialBackupState, CredentialKeyProvider, CredentialRef,
+    CtapCommand, Error as SoftFido2Error, PinState, Result, SoftwareCredentialKeyProvider,
+    StatusCode, UpResult, UvResult,
 };
 
 use std::collections::HashMap;
@@ -605,6 +605,29 @@ impl<S: CredentialStorage, P: PinStorage> soft_fido2::PinStorageCallbacks
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+struct BuiltInUvPolicy {
+    enforcement: PinEnforcement,
+    always_uv: bool,
+}
+
+impl BuiltInUvPolicy {
+    fn runtime_state(self, pin_is_set: bool) -> BuiltInUvState {
+        let requires_client_pin = pin_is_set
+            && match self.enforcement {
+                PinEnforcement::Never => false,
+                PinEnforcement::Optional => self.always_uv,
+                PinEnforcement::Required => true,
+            };
+
+        if requires_client_pin {
+            BuiltInUvState::SupportedNotConfigured
+        } else {
+            BuiltInUvState::Configured
+        }
+    }
+}
+
 /// Main authenticator service
 ///
 /// This service orchestrates the FIDO2 authenticator:
@@ -619,6 +642,10 @@ pub struct AuthenticatorService<
     pub authenticator: Authenticator<PasslessCallbacks<S, P>, K>,
     /// Storage backend (injected dependency)
     pub storage: Arc<Mutex<S>>,
+    /// PIN storage used to evaluate runtime verification availability.
+    pin_storage: Option<Arc<Mutex<P>>>,
+    /// Dynamic built-in UV policy; absent for agent authenticators.
+    built_in_uv_policy: Option<BuiltInUvPolicy>,
     /// Maximum UV retries (configured value)
     max_uv_retries: u8,
     /// Runtime feature gate for credential export/import.
@@ -861,14 +888,21 @@ impl<S: CredentialStorage + 'static, P: PinStorage + 'static>
             pin_config.clone(),
         )?;
 
-        Ok(Self {
+        let mut service = Self {
             authenticator,
             storage,
+            pin_storage,
+            built_in_uv_policy: Some(BuiltInUvPolicy {
+                enforcement: pin_config.enforcement,
+                always_uv: security_config.always_uv,
+            }),
             max_uv_retries: pin_config.max_uv_retries,
             credential_backup_enabled: security_config.enable_credential_backup,
             credential_backup_supported: true,
             pending_backups: HashMap::new(),
-        })
+        };
+        service.refresh_built_in_uv_state()?;
+        Ok(service)
     }
 
     /// Create a new authenticator service with shared storage and an agent interaction manager
@@ -897,6 +931,8 @@ impl<S: CredentialStorage + 'static, P: PinStorage + 'static>
         Ok(Self {
             authenticator,
             storage,
+            pin_storage,
+            built_in_uv_policy: None,
             max_uv_retries: pin_config.max_uv_retries,
             credential_backup_enabled: security_config.enable_credential_backup,
             credential_backup_supported: true,
@@ -1138,14 +1174,21 @@ impl<
             key_provider,
         )?;
 
-        Ok(Self {
+        let mut service = Self {
             authenticator,
             storage,
+            pin_storage,
+            built_in_uv_policy: Some(BuiltInUvPolicy {
+                enforcement: pin_config.enforcement,
+                always_uv: security_config.always_uv,
+            }),
             max_uv_retries: pin_config.max_uv_retries,
             credential_backup_enabled: false,
             credential_backup_supported: false,
             pending_backups: HashMap::new(),
-        })
+        };
+        service.refresh_built_in_uv_state()?;
+        Ok(service)
     }
 
     #[cfg(all(feature = "tpm", feature = "agent"))]
@@ -1169,11 +1212,33 @@ impl<
         Ok(Self {
             authenticator,
             storage,
+            pin_storage,
+            built_in_uv_policy: None,
             max_uv_retries: pin_config.max_uv_retries,
             credential_backup_enabled: false,
             credential_backup_supported: false,
             pending_backups: HashMap::new(),
         })
+    }
+
+    fn refresh_built_in_uv_state(&mut self) -> Result<()> {
+        let Some(policy) = self.built_in_uv_policy else {
+            return Ok(());
+        };
+
+        let pin_is_set = match &self.pin_storage {
+            Some(pin_storage) => {
+                let storage = pin_storage.lock().map_err(|_| SoftFido2Error::Other)?;
+                storage
+                    .load_pin_state()
+                    .map_err(SoftFido2Error::from)?
+                    .is_pin_set()
+            }
+            None => false,
+        };
+
+        self.authenticator
+            .set_built_in_uv_state(policy.runtime_state(pin_is_set))
     }
 
     fn reset_uv_retries(&mut self) -> core::result::Result<(), StatusCode> {
@@ -1489,6 +1554,8 @@ impl<
 
     /// Process a CTAP request and generate a response
     pub fn handle(&mut self, request: &[u8], response_buffer: &mut Vec<u8>) -> Result<()> {
+        self.refresh_built_in_uv_state()?;
+
         if request.first() == Some(&CMD_PASSLESS_BACKUP) {
             self.handle_backup_command(&request[1..], response_buffer);
             return Ok(());
@@ -1598,6 +1665,188 @@ mod tests {
     use super::*;
 
     use crate::storage::LocalStorageAdapter;
+
+    use soft_fido2_ctap::SecPinHash;
+
+    struct TestPinStorage {
+        state: Mutex<PinState>,
+    }
+
+    impl TestPinStorage {
+        fn new(state: PinState) -> Self {
+            Self {
+                state: Mutex::new(state),
+            }
+        }
+
+        fn set_state(&self, state: PinState) {
+            *self.state.lock().expect("test PIN storage lock") = state;
+        }
+    }
+
+    impl PinStorage for TestPinStorage {
+        fn load_pin_state(&self) -> core::result::Result<PinState, StatusCode> {
+            self.state
+                .lock()
+                .map(|state| state.clone())
+                .map_err(|_| StatusCode::Other)
+        }
+
+        fn save_pin_state(&self, state: &PinState) -> core::result::Result<(), StatusCode> {
+            *self.state.lock().map_err(|_| StatusCode::Other)? = state.clone();
+            Ok(())
+        }
+    }
+
+    fn pin_state_with_pin() -> PinState {
+        let mut state = PinState::new();
+        state.pin_hash = Some(SecPinHash::new([0x42; 32]));
+        state
+    }
+
+    fn get_info_uv(response: &[u8]) -> Option<bool> {
+        assert_eq!(response.first(), Some(&0x00));
+        let value: serde_cbor::Value =
+            serde_cbor::from_slice(&response[1..]).expect("decode authenticatorGetInfo");
+        let info = match value {
+            serde_cbor::Value::Map(info) => info,
+            other => panic!("expected GetInfo map, got {other:?}"),
+        };
+        let options = match info.get(&serde_cbor::Value::Integer(4)) {
+            Some(serde_cbor::Value::Map(options)) => options,
+            other => panic!("expected GetInfo options map, got {other:?}"),
+        };
+        match options.get(&serde_cbor::Value::Text("uv".to_string())) {
+            Some(serde_cbor::Value::Bool(value)) => Some(*value),
+            None => None,
+            other => panic!("expected boolean uv option, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_built_in_uv_policy_matrix() {
+        let state = |enforcement, always_uv, pin_is_set| {
+            BuiltInUvPolicy {
+                enforcement,
+                always_uv,
+            }
+            .runtime_state(pin_is_set)
+        };
+
+        for enforcement in [
+            PinEnforcement::Never,
+            PinEnforcement::Optional,
+            PinEnforcement::Required,
+        ] {
+            assert_eq!(state(enforcement, true, false), BuiltInUvState::Configured);
+            assert_eq!(state(enforcement, false, false), BuiltInUvState::Configured);
+        }
+
+        assert_eq!(
+            state(PinEnforcement::Never, true, true),
+            BuiltInUvState::Configured
+        );
+        assert_eq!(
+            state(PinEnforcement::Optional, false, true),
+            BuiltInUvState::Configured
+        );
+        assert_eq!(
+            state(PinEnforcement::Optional, true, true),
+            BuiltInUvState::SupportedNotConfigured
+        );
+        assert_eq!(
+            state(PinEnforcement::Required, false, true),
+            BuiltInUvState::SupportedNotConfigured
+        );
+        assert_eq!(
+            state(PinEnforcement::Required, true, true),
+            BuiltInUvState::SupportedNotConfigured
+        );
+    }
+
+    #[test]
+    fn test_get_info_tracks_runtime_pin_policy_without_consuming_uv_retries() {
+        let temp_dir = tempfile::tempdir().expect("create temp directory");
+        let credential_dir = temp_dir.path().join("credentials");
+        std::fs::create_dir_all(&credential_dir).expect("create credential directory");
+        let storage = LocalStorageAdapter::new(credential_dir).expect("create credential storage");
+
+        let mut pin_state = pin_state_with_pin();
+        pin_state.uv_retries = 5;
+        let pin_storage = Arc::new(Mutex::new(TestPinStorage::new(pin_state)));
+
+        let mut security_config = SecurityConfig::default();
+        security_config.always_uv = true;
+        let mut pin_config = PinConfig::default();
+        pin_config.enforcement = PinEnforcement::Optional;
+
+        let mut service = AuthenticatorService::with_pin_storage(
+            storage,
+            Some(pin_storage.clone()),
+            security_config,
+            pin_config,
+        )
+        .expect("create authenticator service");
+
+        assert_eq!(
+            service
+                .authenticator
+                .built_in_uv_state()
+                .expect("read built-in UV state"),
+            BuiltInUvState::SupportedNotConfigured
+        );
+
+        let mut response = Vec::new();
+        service
+            .handle(&[0x04], &mut response)
+            .expect("handle GetInfo with PIN");
+        assert_eq!(get_info_uv(&response), Some(false));
+        assert_eq!(
+            pin_storage
+                .lock()
+                .expect("test PIN storage")
+                .load_pin_state()
+                .expect("load PIN state")
+                .uv_retries,
+            5
+        );
+
+        pin_storage
+            .lock()
+            .expect("test PIN storage")
+            .set_state(PinState::new());
+        service
+            .handle(&[0x04], &mut response)
+            .expect("handle GetInfo without PIN");
+        assert_eq!(get_info_uv(&response), Some(true));
+        assert_eq!(
+            service
+                .authenticator
+                .built_in_uv_state()
+                .expect("read built-in UV state"),
+            BuiltInUvState::Configured
+        );
+
+        let mut pin_state = pin_state_with_pin();
+        pin_state.uv_retries = 5;
+        pin_storage
+            .lock()
+            .expect("test PIN storage")
+            .set_state(pin_state);
+        service
+            .handle(&[0x04], &mut response)
+            .expect("handle GetInfo after restoring PIN");
+        assert_eq!(get_info_uv(&response), Some(false));
+        assert_eq!(
+            pin_storage
+                .lock()
+                .expect("test PIN storage")
+                .load_pin_state()
+                .expect("load PIN state")
+                .uv_retries,
+            5
+        );
+    }
 
     #[test]
     fn test_service_creation() {


### PR DESCRIPTION
## Summary

- bump the `soft-fido2` crate family to `0.16.2`
- derive runtime built-in UV availability from the effective Passless PIN policy
- advertise `uv: false` when a configured PIN must be used, allowing Chromium-based clients to select Client PIN directly
- restore `uv: true` after a runtime PIN reset without requiring a daemon restart
- preserve the fixed agent-authenticator UV model
- add regression tests for the policy matrix, runtime `authenticatorGetInfo` transitions, and UV retry preservation

## Policy mapping

With no PIN configured, notification-based built-in UV remains `Configured`.

With a PIN configured:

- `never` remains `Configured`
- `optional` with `always_uv = false` remains `Configured`
- `optional` with `always_uv = true` becomes `SupportedNotConfigured`
- `required` becomes `SupportedNotConfigured`

The `soft-fido2` state transition also invalidates stale PIN/UV tokens and pending assertion state.

## Validation

- `cargo fmt --all`
- focused policy matrix test
- focused runtime GetInfo/PIN-state regression test
- `cargo check --workspace --all-features`
- `cargo clippy -p passless-rs --all-features -- -D warnings`

Fixes #393