### PR TITLE
release: Version 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.15.1](https://github.com/pando85/passless/tree/v0.15.1) - 2026-08-05
+
+### Fixed
+
+- Advertise dynamic built-in UV state (#395) ([19f4a14](https://github.com/pando85/passless/commit/19f4a14e71ecef8186f27e6d4eab9be07faa7654))
+
+### Documentation
+
+- Add credential backup and backup-eligibility guide (#391) ([6db1c32](https://github.com/pando85/passless/commit/6db1c32e681cb5148f2be0693e89b09ff882c3a3))
+
+### Build
+
+- deps: Update Rust crate base64 to v0.23.1 (#392) ([e8dca3a](https://github.com/pando85/passless/commit/e8dca3a691bfb53502896e5434f98d063b8f17f5))
+- deps: Upgrade soft-fido2 to 0.17.0 (#397) ([9b0e218](https://github.com/pando85/passless/commit/9b0e218b2f86e782168b1375884dd695486d2b38))
+
 ## [v0.15.0](https://github.com/pando85/passless/tree/v0.15.0) - 2026-08-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,7 +1718,7 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "passless-config-doc"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "passless-core"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "clap",
  "clap-serde-derive",
@@ -1752,7 +1752,7 @@ dependencies = [
 
 [[package]]
 name = "passless-rs"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1799,7 +1799,7 @@ dependencies = [
 
 [[package]]
 name = "passless-uhid"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "libc",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,15 @@ resolver = "2"
 [workspace.package]
 authors = ["Pando85 <pando855@gmail.com>"]
 edition = "2024"
-version = "0.15.0"
+version = "0.15.1"
 license-file = "./LICENSE"
 homepage = "https://github.com/pando85/passless"
 repository = "https://github.com/pando85/passless"
 [workspace.dependencies]
 # Workspace crates
-passless-core = { path = "./passless-core", version = "0.15.0" }
-passless-config-doc = { path = "./passless-config-doc", version = "0.15.0" }
-passless-uhid = { path = "./passless-uhid", version = "0.15.0" }
+passless-core = { path = "./passless-core", version = "0.15.1" }
+passless-config-doc = { path = "./passless-config-doc", version = "0.15.1" }
+passless-uhid = { path = "./passless-uhid", version = "0.15.1" }
 
 soft-fido2 = "0.17.0"
 soft-fido2-ctap = "0.17.0"


### PR DESCRIPTION
## Release v0.15.1

### Changes since v0.15.0

**Fixed:**
- Advertise dynamic built-in UV state (#395)

**Documentation:**
- Add credential backup and backup-eligibility guide (#391)

**Build:**
- deps: Update Rust crate base64 to v0.23.1 (#392)
- deps: Upgrade soft-fido2 to 0.17.0 (#397)

---
After merge, CI will automatically create the tag and publish the release.