### PR TITLE
feat: implement unified same-user and isolated agent modes

### DIFF
--- a/.github/workflows/diagnose-final-agent-validation.yml
+++ b/.github/workflows/diagnose-final-agent-validation.yml
@@ -1,0 +1,45 @@
+name: Diagnose final agent validation
+
+on:
+  push:
+    branches:
+      - agent/unified-agent-modes-adr
+    paths:
+      - .github/workflows/diagnose-final-agent-validation.yml
+
+permissions:
+  contents: read
+
+jobs:
+  diagnose:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install system dependencies
+        run: |
+          sudo apt update
+          sudo apt-get install -y dbus-daemon gnupg2 libtss2-dev libudev-dev pass shellcheck swtpm
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+      - uses: Swatinem/rust-cache@v2
+      - name: Run deterministic validation with captured output
+        id: validation
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -o pipefail
+          make test-agent-validation 2>&1 | tee /tmp/agent-validation.log
+          echo "status=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+      - name: Upload diagnostic log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: final-agent-validation-log
+          path: /tmp/agent-validation.log
+          retention-days: 1
+      - name: Preserve failure status
+        if: steps.validation.outputs.status != '0'
+        run: exit 1

--- a/cmd/passless/assets/agent-extension/broker.js
+++ b/cmd/passless/assets/agent-extension/broker.js
@@ -10,6 +10,7 @@
   var MAX_CHALLENGE_B64U_LEN = 2048;
   var MAX_USER_NAME_LEN = 256;
   var MAX_USER_ID_B64U_LEN = 128;
+  var MAX_ALGORITHMS = 16;
 
   function isValidGetRequest(req) {
     if (!req || typeof req !== "object") return false;
@@ -36,6 +37,10 @@
     for (var i = 0; i < req.exclude_credentials.length; i++) {
       var c = req.exclude_credentials[i];
       if (typeof c !== "string" || c.length === 0 || c.length > MAX_CREDENTIAL_ID_B64U_LEN) return false;
+    }
+    if (!Array.isArray(req.pub_key_cred_params) || req.pub_key_cred_params.length === 0 || req.pub_key_cred_params.length > MAX_ALGORITHMS) return false;
+    for (var j = 0; j < req.pub_key_cred_params.length; j++) {
+      if (!Number.isInteger(req.pub_key_cred_params[j])) return false;
     }
     if (typeof req.user_verification !== "boolean") return false;
     return true;
@@ -79,6 +84,8 @@
         id: message.id,
         ok: !failed && response.ok === true,
         response: failed ? null : response.response,
+        fallback: !failed && response.fallback === true,
+        error: failed ? "broker_unavailable" : response.error,
         type: messageType
       }, location.origin);
     });

--- a/cmd/passless/assets/agent-extension/main.js
+++ b/cmd/passless/assets/agent-extension/main.js
@@ -5,6 +5,9 @@
   var MAX_CHALLENGE_BYTES = 1024;
   var MAX_RP_ID_LEN = 253;
   var MAX_CREDENTIAL_ID_BYTES = 256;
+  var MAX_ALGORITHMS = 16;
+  var DEFAULT_TIMEOUT_MS = 30000;
+  var MAX_TIMEOUT_MS = 120000;
 
   var credentials = navigator.credentials;
   if (!credentials || typeof credentials.get !== "function") return;
@@ -36,17 +39,34 @@
     throw new TypeError("expected BufferSource");
   }
 
+  function domError(name, message) {
+    return new DOMException(message, name);
+  }
+
   function notAllowed() {
-    return new DOMException(
-      "The operation either timed out or was not allowed.",
-      "NotAllowedError"
-    );
+    return domError("NotAllowedError", "The operation either timed out or was not allowed.");
+  }
+
+  function abortError() {
+    return domError("AbortError", "The operation was aborted.");
   }
 
   function requestId() {
     var bytes = new Uint8Array(16);
     crypto.getRandomValues(bytes);
     return b64urlEncode(bytes);
+  }
+
+  function timeoutFor(publicKey) {
+    if (!Number.isFinite(publicKey.timeout) || publicKey.timeout <= 0) return DEFAULT_TIMEOUT_MS;
+    return Math.min(Math.floor(publicKey.timeout), MAX_TIMEOUT_MS);
+  }
+
+  function policyAllowsWebAuthn(feature) {
+    if (window.top === window.self) return true;
+    var policy = document.permissionsPolicy || document.featurePolicy;
+    if (!policy || typeof policy.allowsFeature !== "function") return true;
+    return policy.allowsFeature(feature);
   }
 
   function serialize(publicKey) {
@@ -60,11 +80,9 @@
       throw new TypeError("invalid rpId");
     }
 
-    var UV_ALLOWED = ["required", "preferred", "discouraged"];
+    var allowedUv = ["required", "preferred", "discouraged"];
     var uv = publicKey.userVerification || "preferred";
-    if (UV_ALLOWED.indexOf(uv) === -1) {
-      throw new TypeError("invalid userVerification");
-    }
+    if (allowedUv.indexOf(uv) === -1) throw new TypeError("invalid userVerification");
 
     var allowCredentials = [];
     if (Array.isArray(publicKey.allowCredentials)) {
@@ -73,21 +91,10 @@
       }
       for (var i = 0; i < publicKey.allowCredentials.length; i++) {
         var credential = publicKey.allowCredentials[i];
-        if (!credential || typeof credential !== "object") {
+        if (!credential || credential.type !== "public-key" || !credential.id) {
           throw new TypeError("malformed allowCredentials entry");
         }
-        if (credential.type !== "public-key") {
-          throw new TypeError("unsupported credential type");
-        }
-        if (!credential.id) {
-          throw new TypeError("missing credential id");
-        }
-        var idBytes;
-        try {
-          idBytes = toBytes(credential.id);
-        } catch (e) {
-          throw new TypeError("invalid credential id");
-        }
+        var idBytes = toBytes(credential.id);
         if (idBytes.length === 0 || idBytes.length > MAX_CREDENTIAL_ID_BYTES) {
           throw new TypeError("invalid credential id length");
         }
@@ -104,6 +111,7 @@
   }
 
   function serializeCreate(publicKey) {
+    if (!publicKey.rp || !publicKey.user) throw new TypeError("missing RP or user");
     var challenge = toBytes(publicKey.challenge);
     if (challenge.length === 0 || challenge.length > MAX_CHALLENGE_BYTES) {
       throw new TypeError("invalid challenge length");
@@ -115,14 +123,23 @@
     }
 
     var userId = toBytes(publicKey.user.id);
-    if (userId.length === 0 || userId.length > 64) {
-      throw new TypeError("invalid userId length");
-    }
+    if (userId.length === 0 || userId.length > 64) throw new TypeError("invalid userId length");
 
-    var UV_ALLOWED = ["required", "preferred", "discouraged"];
-    var uv = publicKey.authenticatorSelection?.userVerification || "preferred";
-    if (UV_ALLOWED.indexOf(uv) === -1) {
-      throw new TypeError("invalid userVerification");
+    var allowedUv = ["required", "preferred", "discouraged"];
+    var selection = publicKey.authenticatorSelection || {};
+    var uv = selection.userVerification || "preferred";
+    if (allowedUv.indexOf(uv) === -1) throw new TypeError("invalid userVerification");
+
+    if (!Array.isArray(publicKey.pubKeyCredParams) || publicKey.pubKeyCredParams.length === 0 || publicKey.pubKeyCredParams.length > MAX_ALGORITHMS) {
+      throw new TypeError("invalid pubKeyCredParams");
+    }
+    var algorithms = [];
+    for (var p = 0; p < publicKey.pubKeyCredParams.length; p++) {
+      var param = publicKey.pubKeyCredParams[p];
+      if (!param || param.type !== "public-key" || !Number.isInteger(param.alg)) {
+        throw new TypeError("malformed pubKeyCredParams entry");
+      }
+      algorithms.push(param.alg);
     }
 
     var excludeCredentials = [];
@@ -132,21 +149,10 @@
       }
       for (var i = 0; i < publicKey.excludeCredentials.length; i++) {
         var credential = publicKey.excludeCredentials[i];
-        if (!credential || typeof credential !== "object") {
+        if (!credential || credential.type !== "public-key" || !credential.id) {
           throw new TypeError("malformed excludeCredentials entry");
         }
-        if (credential.type !== "public-key") {
-          throw new TypeError("unsupported credential type");
-        }
-        if (!credential.id) {
-          throw new TypeError("missing credential id");
-        }
-        var idBytes;
-        try {
-          idBytes = toBytes(credential.id);
-        } catch (e) {
-          throw new TypeError("invalid credential id");
-        }
+        var idBytes = toBytes(credential.id);
         if (idBytes.length === 0 || idBytes.length > MAX_CREDENTIAL_ID_BYTES) {
           throw new TypeError("invalid credential id length");
         }
@@ -162,29 +168,25 @@
       user_name: publicKey.user.name,
       user_display_name: publicKey.user.displayName || null,
       exclude_credentials: excludeCredentials,
-      user_verification: uv === "required",
-      cross_origin: false
+      pub_key_cred_params: algorithms,
+      user_verification: uv === "required"
     };
   }
 
   function credentialFrom(data) {
-    if (
-      !data ||
-      typeof data.credential_id_b64u !== "string" ||
-      typeof data.authenticator_data_b64u !== "string" ||
-      typeof data.signature_b64u !== "string" ||
-      typeof data.client_data_json_b64u !== "string"
-    ) {
+    if (!data || typeof data.credential_id_b64u !== "string" ||
+        typeof data.authenticator_data_b64u !== "string" ||
+        typeof data.signature_b64u !== "string" ||
+        typeof data.client_data_json_b64u !== "string") {
       throw new TypeError("malformed daemon response");
     }
 
-    return {
+    var credential = {
       id: data.credential_id_b64u,
       rawId: b64urlDecode(data.credential_id_b64u),
       type: "public-key",
-      getClientExtensionResults: function() {
-        return {};
-      },
+      authenticatorAttachment: "platform",
+      getClientExtensionResults: function() { return {}; },
       response: {
         authenticatorData: b64urlDecode(data.authenticator_data_b64u),
         clientDataJSON: b64urlDecode(data.client_data_json_b64u),
@@ -192,129 +194,164 @@
         userHandle: data.user_handle_b64u ? b64urlDecode(data.user_handle_b64u) : null
       }
     };
+    credential.toJSON = function() {
+      return {
+        id: credential.id,
+        rawId: credential.id,
+        type: credential.type,
+        authenticatorAttachment: credential.authenticatorAttachment,
+        clientExtensionResults: {},
+        response: {
+          authenticatorData: data.authenticator_data_b64u,
+          clientDataJSON: data.client_data_json_b64u,
+          signature: data.signature_b64u,
+          userHandle: data.user_handle_b64u || null
+        }
+      };
+    };
+    return credential;
   }
 
   function credentialFromCreate(data) {
-    if (
-      !data ||
-      typeof data.credential_id_b64u !== "string" ||
-      typeof data.authenticator_data_b64u !== "string" ||
-      typeof data.attestation_object_b64u !== "string" ||
-      typeof data.client_data_json_b64u !== "string"
-    ) {
+    if (!data || typeof data.credential_id_b64u !== "string" ||
+        typeof data.public_key_algorithm !== "number" ||
+        typeof data.authenticator_data_b64u !== "string" ||
+        typeof data.attestation_object_b64u !== "string" ||
+        typeof data.client_data_json_b64u !== "string") {
       throw new TypeError("malformed daemon response");
     }
 
-    return {
+    var credential = {
       id: data.credential_id_b64u,
       rawId: b64urlDecode(data.credential_id_b64u),
       type: "public-key",
-      getClientExtensionResults: function() {
-        return {};
-      },
+      authenticatorAttachment: "platform",
+      getClientExtensionResults: function() { return {}; },
       response: {
         attestationObject: b64urlDecode(data.attestation_object_b64u),
         clientDataJSON: b64urlDecode(data.client_data_json_b64u),
-        getTransports: function() {
-          return ["internal"];
-        },
-        getAuthenticatorData: function() {
-          return b64urlDecode(data.authenticator_data_b64u);
-        },
-        getPublicKey: function() {
-          return null;
-        },
-        getPublicKeyAlgorithm: function() {
-          return -7;
-        }
+        getTransports: function() { return ["internal"]; },
+        getAuthenticatorData: function() { return b64urlDecode(data.authenticator_data_b64u); },
+        getPublicKey: function() { return null; },
+        getPublicKeyAlgorithm: function() { return data.public_key_algorithm; }
       }
     };
+    credential.toJSON = function() {
+      return {
+        id: credential.id,
+        rawId: credential.id,
+        type: credential.type,
+        authenticatorAttachment: credential.authenticatorAttachment,
+        clientExtensionResults: {},
+        response: {
+          attestationObject: data.attestation_object_b64u,
+          clientDataJSON: data.client_data_json_b64u,
+          transports: ["internal"],
+          authenticatorData: data.authenticator_data_b64u,
+          publicKey: null,
+          publicKeyAlgorithm: data.public_key_algorithm
+        }
+      };
+    };
+    return credential;
+  }
+
+  function finishOperation(id) {
+    var operation = pending.get(id);
+    if (!operation) return null;
+    pending.delete(id);
+    clearTimeout(operation.timer);
+    if (operation.signal && operation.abortListener) {
+      operation.signal.removeEventListener("abort", operation.abortListener);
+    }
+    return operation;
   }
 
   window.addEventListener("message", function(event) {
     var message = event.data;
-    if (
-      event.source !== window ||
-      !message ||
-      message.source !== "passless-agent-broker" ||
-      message.channel !== channel ||
-      typeof message.id !== "string"
-    ) return;
+    if (event.source !== window || !message || message.source !== "passless-agent-broker" ||
+        message.channel !== channel || typeof message.id !== "string") return;
 
-    var operation = pending.get(message.id);
+    var operation = finishOperation(message.id);
     if (!operation) return;
-    pending.delete(message.id);
-    clearTimeout(operation.timer);
 
     if (!message.ok) {
-      operation.reject(notAllowed());
+      if (message.fallback && operation.native) {
+        Promise.resolve(operation.native(operation.options)).then(operation.resolve, operation.reject);
+      } else {
+        operation.reject(notAllowed());
+      }
       return;
     }
 
     try {
-      if (message.type === "create") {
-        operation.resolve(credentialFromCreate(message.response));
-      } else {
-        operation.resolve(credentialFrom(message.response));
-      }
+      operation.resolve(message.type === "create"
+        ? credentialFromCreate(message.response)
+        : credentialFrom(message.response));
     } catch (error) {
       operation.reject(notAllowed());
     }
   });
 
-  credentials.get = function(options) {
-    if (!options || !options.publicKey) return originalGet(options);
-
-    var request;
-    try {
-      request = serialize(options.publicKey);
-    } catch (error) {
-      return Promise.reject(notAllowed());
-    }
-
+  function runOperation(type, options, request, nativeOperation) {
     return new Promise(function(resolve, reject) {
+      if (options.signal && options.signal.aborted) {
+        reject(abortError());
+        return;
+      }
+
       var id = requestId();
-      var timer = setTimeout(function() {
-        pending.delete(id);
-        reject(notAllowed());
-      }, 30000);
-      pending.set(id, { resolve: resolve, reject: reject, timer: timer });
+      var timeout = timeoutFor(options.publicKey);
+      var operation = {
+        resolve: resolve,
+        reject: reject,
+        native: nativeOperation,
+        options: options,
+        signal: options.signal || null,
+        abortListener: null,
+        timer: null
+      };
+      operation.timer = setTimeout(function() {
+        if (finishOperation(id)) reject(notAllowed());
+      }, timeout);
+      if (operation.signal) {
+        operation.abortListener = function() {
+          if (finishOperation(id)) reject(abortError());
+        };
+        operation.signal.addEventListener("abort", operation.abortListener, { once: true });
+      }
+      pending.set(id, operation);
       window.postMessage({
         source: "passless-agent-main",
         channel: channel,
         id: id,
         request: request,
-        type: "get"
+        type: type
       }, location.origin);
     });
+  }
+
+  credentials.get = function(options) {
+    if (!options || !options.publicKey || !policyAllowsWebAuthn("publickey-credentials-get")) return originalGet(options);
+    var request;
+    try {
+      request = serialize(options.publicKey);
+    } catch (error) {
+      return Promise.reject(error instanceof DOMException ? error : notAllowed());
+    }
+    return runOperation("get", options, request, originalGet);
   };
 
   if (originalCreate) {
     credentials.create = function(options) {
-      if (!options || !options.publicKey) return originalCreate(options);
-
+      if (!options || !options.publicKey || !policyAllowsWebAuthn("publickey-credentials-create")) return originalCreate(options);
       var request;
       try {
         request = serializeCreate(options.publicKey);
       } catch (error) {
-        return Promise.reject(notAllowed());
+        return Promise.reject(error instanceof DOMException ? error : notAllowed());
       }
-
-      return new Promise(function(resolve, reject) {
-        var id = requestId();
-        var timer = setTimeout(function() {
-          pending.delete(id);
-          reject(notAllowed());
-        }, 30000);
-        pending.set(id, { resolve: resolve, reject: reject, timer: timer });
-        window.postMessage({
-          source: "passless-agent-main",
-          channel: channel,
-          id: id,
-          request: request,
-          type: "create"
-        }, location.origin);
-      });
+      return runOperation("create", options, request, originalCreate);
     };
   }
 })("__PASSLESS_CHANNEL__");

--- a/cmd/passless/assets/agent-extension/worker.js
+++ b/cmd/passless/assets/agent-extension/worker.js
@@ -10,22 +10,37 @@
   var MAX_ORIGIN_LEN = 512;
   var MAX_USER_NAME_LEN = 256;
   var MAX_USER_ID_B64U_LEN = 128;
+  var MAX_ALGORITHMS = 16;
 
-  function validateOrigin(sender) {
-    if (typeof sender.url !== "string") return null;
-
-    var frameUrl;
+  function parseHttpsOrigin(url) {
+    if (typeof url !== "string") return null;
+    var parsed;
     try {
-      frameUrl = new URL(sender.url);
+      parsed = new URL(url);
     } catch (error) {
       return null;
     }
-    if (frameUrl.protocol !== "https:") return null;
+    if (parsed.protocol !== "https:") return null;
+    if (parsed.origin.length > MAX_ORIGIN_LEN) return null;
+    return parsed.origin;
+  }
 
-    var origin = frameUrl.origin;
-    if (origin.length > MAX_ORIGIN_LEN) return null;
+  function validateOrigins(sender) {
+    var origin = parseHttpsOrigin(sender.url);
+    if (!origin) return null;
 
-    return { origin: origin, hostname: frameUrl.hostname };
+    var topOrigin = origin;
+    if (sender.tab && typeof sender.tab.url === "string") {
+      topOrigin = parseHttpsOrigin(sender.tab.url);
+      if (!topOrigin) return null;
+    }
+
+    var crossOrigin = sender.frameId !== 0 && origin !== topOrigin;
+    return {
+      origin: origin,
+      top_origin: topOrigin,
+      cross_origin: crossOrigin
+    };
   }
 
   function validateGetRequest(req) {
@@ -36,8 +51,7 @@
       var c = req.allow_credentials[i];
       if (typeof c !== "string" || c.length === 0 || c.length > MAX_CREDENTIAL_ID_B64U_LEN) return false;
     }
-    if (typeof req.user_verification !== "boolean") return false;
-    return true;
+    return typeof req.user_verification === "boolean";
   }
 
   function validateCreateRequest(req) {
@@ -50,37 +64,27 @@
       var c = req.exclude_credentials[i];
       if (typeof c !== "string" || c.length === 0 || c.length > MAX_CREDENTIAL_ID_B64U_LEN) return false;
     }
-    if (typeof req.user_verification !== "boolean") return false;
-    return true;
+    if (!Array.isArray(req.pub_key_cred_params) || req.pub_key_cred_params.length === 0 || req.pub_key_cred_params.length > MAX_ALGORITHMS) return false;
+    for (var j = 0; j < req.pub_key_cred_params.length; j++) {
+      if (!Number.isInteger(req.pub_key_cred_params[j])) return false;
+    }
+    return typeof req.user_verification === "boolean";
   }
 
-  function handleGetRequest(req, originInfo, sendResponse) {
-    var cross_origin =
-      originInfo.hostname !== req.rp_id &&
-      !originInfo.hostname.endsWith("." + req.rp_id);
-
-    var safeRequest = {
-      origin: originInfo.origin,
-      rp_id: req.rp_id,
-      challenge_b64u: req.challenge_b64u,
-      allow_credentials: req.allow_credentials,
-      user_verification: req.user_verification,
-      cross_origin: cross_origin
-    };
-
+  function daemonRequest(path, request, sendResponse, responseField, type) {
     var body;
     try {
-      body = JSON.stringify(safeRequest);
-    } catch (e) {
-      sendResponse({ ok: false });
+      body = JSON.stringify(request);
+    } catch (error) {
+      sendResponse({ ok: false, type: type, error: "invalid_request" });
       return false;
     }
     if (body.length > MAX_REQUEST_BYTES) {
-      sendResponse({ ok: false });
+      sendResponse({ ok: false, type: type, error: "request_too_large" });
       return false;
     }
 
-    fetch("http://127.0.0.1:" + port + "/sign", {
+    fetch("http://127.0.0.1:" + port + path, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -88,26 +92,50 @@
       },
       body: body
     }).then(function(response) {
-      if (!response.ok) throw new Error("request denied");
-      return response.json();
-    }).then(function(response) {
-      if (!response || typeof response !== "object" || !response.sign_assertion_result) {
+      return response.json().catch(function() {
+        return { error: "invalid_daemon_response" };
+      }).then(function(payload) {
+        return { ok: response.ok, payload: payload };
+      });
+    }).then(function(result) {
+      if (!result.ok) {
+        var code = result.payload && typeof result.payload.error === "string"
+          ? result.payload.error
+          : "request_denied";
+        sendResponse({
+          ok: false,
+          type: type,
+          error: code,
+          fallback: code === "human_interaction_required"
+        });
+        return;
+      }
+      if (!result.payload || typeof result.payload !== "object" || !result.payload[responseField]) {
         throw new Error("malformed daemon response");
       }
-      sendResponse({ ok: true, response: response.sign_assertion_result });
+      sendResponse({ ok: true, response: result.payload[responseField], type: type });
     }).catch(function() {
-      sendResponse({ ok: false });
+      sendResponse({ ok: false, type: type, error: "transport_error" });
     });
     return true;
   }
 
-  function handleCreateRequest(req, originInfo, sendResponse) {
-    var cross_origin =
-      originInfo.hostname !== req.rp_id &&
-      !originInfo.hostname.endsWith("." + req.rp_id);
+  function handleGetRequest(req, origins, sendResponse) {
+    return daemonRequest("/sign", {
+      origin: origins.origin,
+      top_origin: origins.top_origin,
+      rp_id: req.rp_id,
+      challenge_b64u: req.challenge_b64u,
+      allow_credentials: req.allow_credentials,
+      user_verification: req.user_verification,
+      cross_origin: origins.cross_origin
+    }, sendResponse, "sign_assertion_result", "get");
+  }
 
-    var safeRequest = {
-      origin: originInfo.origin,
+  function handleCreateRequest(req, origins, sendResponse) {
+    return daemonRequest("/register", {
+      origin: origins.origin,
+      top_origin: origins.top_origin,
       rp_id: req.rp_id,
       rp_name: req.rp_name || null,
       challenge_b64u: req.challenge_b64u,
@@ -115,76 +143,40 @@
       user_name: req.user_name,
       user_display_name: req.user_display_name || null,
       exclude_credentials: req.exclude_credentials,
+      pub_key_cred_params: req.pub_key_cred_params,
       user_verification: req.user_verification,
-      cross_origin: cross_origin
-    };
-
-    var body;
-    try {
-      body = JSON.stringify(safeRequest);
-    } catch (e) {
-      sendResponse({ ok: false, type: "create" });
-      return false;
-    }
-    if (body.length > MAX_REQUEST_BYTES) {
-      sendResponse({ ok: false, type: "create" });
-      return false;
-    }
-
-    fetch("http://127.0.0.1:" + port + "/register", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": "Bearer " + bearer
-      },
-      body: body
-    }).then(function(response) {
-      if (!response.ok) throw new Error("request denied");
-      return response.json();
-    }).then(function(response) {
-      if (!response || typeof response !== "object" || !response.create_attestation_result) {
-        throw new Error("malformed daemon response");
-      }
-      sendResponse({ ok: true, response: response.create_attestation_result, type: "create" });
-    }).catch(function() {
-      sendResponse({ ok: false, type: "create" });
-    });
-    return true;
+      cross_origin: origins.cross_origin
+    }, sendResponse, "create_attestation_result", "create");
   }
 
   chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
-    if (
-      !message ||
-      message.source !== "passless-agent-broker" ||
-      !message.request
-    ) return false;
+    if (!message || message.source !== "passless-agent-broker" || !message.request) return false;
 
     if (typeof sender.id === "string" && sender.id !== chrome.runtime.id) {
-      sendResponse({ ok: false });
+      sendResponse({ ok: false, error: "invalid_sender" });
       return false;
     }
 
-    var originInfo = validateOrigin(sender);
-    if (!originInfo) {
-      sendResponse({ ok: false });
+    var origins = validateOrigins(sender);
+    if (!origins) {
+      sendResponse({ ok: false, error: "invalid_origin" });
       return false;
     }
 
     var req = message.request;
     var messageType = message.type === "create" ? "create" : "get";
-
     if (messageType === "create") {
       if (!validateCreateRequest(req)) {
-        sendResponse({ ok: false, type: "create" });
+        sendResponse({ ok: false, type: "create", error: "invalid_request" });
         return false;
       }
-      return handleCreateRequest(req, originInfo, sendResponse);
+      return handleCreateRequest(req, origins, sendResponse);
     }
 
     if (!validateGetRequest(req)) {
-      sendResponse({ ok: false });
+      sendResponse({ ok: false, type: "get", error: "invalid_request" });
       return false;
     }
-    return handleGetRequest(req, originInfo, sendResponse);
+    return handleGetRequest(req, origins, sendResponse);
   });
 })(__PASSLESS_PORT__, __PASSLESS_BEARER__);

--- a/cmd/passless/assets/skills/passless-agent/SKILL.md
+++ b/cmd/passless/assets/skills/passless-agent/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: passless-agent
-description: Use Passless agent authentication safely through native WebAuthn and explicit exact-RP ceremony policy.
+description: Use Passless agent authentication safely through native WebAuthn and explicit exact-RP ceremony policy. Includes Playwright MCP integration for high-level browser automation with passkey support.
 license: GPL-3.0
-compatibility: Requires Linux, Passless agent support, and a configured isolated or delegated-session profile.
+compatibility: Requires Linux, Passless agent support, and a configured same-user or isolated profile.
 metadata:
   project: passless
   repository: https://github.com/pando85/passless
@@ -30,10 +30,7 @@ Use Passless only through its agent commands and the stock browser session it la
    passless agent --profile <profile> intent create register --rp <rp-id> --reason "<reason>"
    passless agent --profile <profile> intent create authenticate --rp <rp-id> --credential <credential-ref-hex> --reason "<reason>"
    ```
-6. For a delegated-session profile, request one delegation for the exact RP ID and credential reference:
-   ```
-   passless agent --profile <profile> delegation request --rp <rp-id> --credential <credential-ref-hex> --session-ttl <seconds> --reason "<reason>"
-   ```
+6. For a same-user profile, the agent uses the human credential backend directly. No intent creation is needed for authentication — the daemon enforces policy on each WebAuthn call.
 7. Follow the matched action policy. A `confirm` rule requires the human to approve or deny the trusted Passless prompt. An `allow` rule resolves the operation without a notification using policy UP/UV. Never ask the human to disclose a PIN or approval capability in chat. Never read PINs or confirmation from stdin.
 7b. For fully autonomous browser automation (no native credential selection dialog), the production path is the daemon-backed MAIN-world override described below. The CDP virtual authenticator workflow is legacy/test-only and must not be used for production.
 8. Treat denial, expiry, cancellation, policy changes, and endpoint teardown as terminal. Create a new request rather than replaying one.
@@ -42,9 +39,9 @@ Use Passless only through its agent commands and the stock browser session it la
 ## Local documentation
 
 When a Passless source checkout is available, start with `docs/agents/README.md`. Use
-`docs/agents/isolated.md` for agent-owned credentials, `docs/agents/delegated-session.md` for human
-credential delegation, `docs/agents/security.md` for authority boundaries, and
-`docs/agents/operations.md` for audit and revocation. Search locally with:
+`docs/agents/same-user.md` for same-user mode, `docs/agents/isolated.md` for agent-owned credentials,
+`docs/agents/security.md` for authority boundaries, and `docs/agents/operations.md` for audit and revocation.
+Search locally with:
 
 ```
 rg --files docs/agents docs/decisions docs/plans
@@ -67,6 +64,116 @@ passless agent --profile <profile> browser-control --request-file /path/to/cdp-r
 - Do not mix CDP output with credential or admin output.
 - Do not log, cache, or forward CDP responses.
 - The principal holds full RP browser-session authority during the lease.
+
+## Playwright MCP Integration
+
+Passless can be combined with Playwright MCP for high-level browser automation while maintaining passkey authentication. The passless-managed browser exposes CDP on a configurable port, which Playwright can connect to.
+
+### Architecture
+
+```
+Playwright MCP (high-level API)
+    ↓ connectOverCDP
+Chromium with passless extension (CDP port 9222)
+    ↓
+WebAuthn intercepted → passless daemon signs → authenticated
+```
+
+### Configuration
+
+The passless profile must expose CDP on a TCP port:
+
+```toml
+[agents.profiles.coding]
+browser_cdp_expose = "port"
+browser_cdp_port = 9222
+```
+
+### Connecting Playwright to Passless Browser
+
+Instead of launching a new browser, connect to the passless-managed one:
+
+```javascript
+import { chromium } from 'playwright';
+
+// Connect to passless-managed browser
+const browser = await chromium.connectOverCDP('http://127.0.0.1:9222');
+const contexts = browser.contexts();
+const context = contexts[0];
+const pages = context.pages();
+const page = pages[0] || await context.newPage();
+
+// Use Playwright's high-level API
+await page.goto('https://tea.millaguie.net/user/login');
+await page.click('.signin-passkey');
+// WebAuthn is handled by passless extension automatically
+```
+
+### Helper Script for Agent Sessions
+
+When using passless with Playwright MCP, follow this pattern:
+
+1. **Check if browser is running:**
+   ```bash
+   passless agent run --profile <profile> -- /usr/bin/bash -c '
+     passless agent --profile <profile> browser-status
+   '
+   ```
+
+2. **Launch browser if not running:**
+   ```bash
+   passless agent-admin browser launch --profile <profile>
+   ```
+
+3. **Get CDP endpoint:**
+   The CDP endpoint is `http://127.0.0.1:<browser_cdp_port>` (default: 9222)
+
+4. **Connect Playwright and automate:**
+   Use the Playwright MCP tools or direct Playwright API to control the browser.
+
+### Benefits of Playwright Integration
+
+| Feature | Raw CDP (websocat) | Playwright MCP |
+|---------|-------------------|----------------|
+| Navigation | Manual JSON-RPC | `page.goto()` |
+| Clicking | Manual DOM queries | `page.click()` |
+| Auto-wait | Manual polling | Built-in |
+| Selectors | CSS/XPath only | Text, role, testid |
+| Screenshots | Manual CDP calls | `page.screenshot()` |
+| WebAuthn | Passless extension | Passless extension |
+
+### Security Model Preserved
+
+When using Playwright MCP with passless:
+- The passless extension still intercepts all WebAuthn calls
+- The daemon still enforces RP policy, credential refs, TTL, and audit
+- Private keys never leave the daemon
+- Playwright only controls navigation and DOM interaction, not authentication
+
+### Example: Login to Gitea with Passkey
+
+```bash
+# 1. Launch passless browser
+passless agent-admin browser launch --profile coding
+
+# 2. Use Playwright MCP to connect and automate
+# (In opencode with Playwright MCP configured)
+```
+
+```javascript
+// Connect to passless browser
+const browser = await chromium.connectOverCDP('http://127.0.0.1:9222');
+const page = browser.contexts()[0].pages()[0];
+
+// Navigate and login
+await page.goto('https://tea.millaguie.net/user/login');
+await page.click('.signin-passkey');
+// Passless extension handles WebAuthn, page is now authenticated
+
+// Verify login
+await page.waitForURL('**/');
+console.log(await page.title()); // "Dashboard - ..."
+```
 
 ## Daemon-backed WebAuthn override (production path)
 

--- a/cmd/passless/src/agent/backend.rs
+++ b/cmd/passless/src/agent/backend.rs
@@ -1,0 +1,75 @@
+//! Complete credential backend handles for agent WebAuthn operations.
+//!
+//! Storage, key-provider selection, PIN state, and operation serialization are
+//! deliberately carried as one unit. A handler must never reopen a backend or
+//! substitute a software provider after the mode has selected this handle.
+//! Same-user handles intentionally point at the human backend; isolated handles
+//! intentionally point at a profile-owned backend.
+
+use std::sync::{Arc, Mutex};
+
+use passless_core::agent::ProfileId;
+use soft_fido2::CredentialKeyProvider;
+
+use crate::pin_storage::PinStorage;
+use crate::storage::CredentialStorage;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CredentialNamespace {
+    Human,
+    Isolated(ProfileId),
+}
+
+#[derive(Clone)]
+pub struct CredentialBackendHandle {
+    pub namespace: CredentialNamespace,
+    pub credential_storage: Arc<Mutex<Box<dyn CredentialStorage>>>,
+    pub pin_storage: Arc<Mutex<Box<dyn PinStorage>>>,
+    pub key_provider: Arc<dyn CredentialKeyProvider + Send + Sync>,
+    pub operation_lock: Arc<Mutex<()>>,
+}
+
+impl core::fmt::Debug for CredentialBackendHandle {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CredentialBackendHandle")
+            .field("namespace", &self.namespace)
+            .finish_non_exhaustive()
+    }
+}
+
+impl CredentialBackendHandle {
+    pub fn human(
+        credential_storage: Arc<Mutex<Box<dyn CredentialStorage>>>,
+        pin_storage: Arc<Mutex<Box<dyn PinStorage>>>,
+        key_provider: Arc<dyn CredentialKeyProvider + Send + Sync>,
+        operation_lock: Arc<Mutex<()>>,
+    ) -> Self {
+        Self {
+            namespace: CredentialNamespace::Human,
+            credential_storage,
+            pin_storage,
+            key_provider,
+            operation_lock,
+        }
+    }
+
+    pub fn isolated(
+        profile_id: ProfileId,
+        credential_storage: Arc<Mutex<Box<dyn CredentialStorage>>>,
+        pin_storage: Arc<Mutex<Box<dyn PinStorage>>>,
+        key_provider: Arc<dyn CredentialKeyProvider + Send + Sync>,
+        operation_lock: Arc<Mutex<()>>,
+    ) -> Self {
+        Self {
+            namespace: CredentialNamespace::Isolated(profile_id),
+            credential_storage,
+            pin_storage,
+            key_provider,
+            operation_lock,
+        }
+    }
+
+    pub fn is_human(&self) -> bool {
+        matches!(self.namespace, CredentialNamespace::Human)
+    }
+}

--- a/cmd/passless/src/agent/ceremony.rs
+++ b/cmd/passless/src/agent/ceremony.rs
@@ -1578,7 +1578,7 @@ impl<H: CommandHandler> AgentCeremonyHandler<H> {
                 intent_action.clone(),
                 interaction_gen,
                 ceremony_policy.user_presence != UserPresenceSource::None,
-                ceremony_policy.user_verification == UserVerificationSource::Policy,
+                ceremony_policy.user_verification == UserVerificationSource::Agent,
                 Duration::from_secs(60),
             );
             Some(InteractionTokenGuard::new(manager.clone()))
@@ -4052,6 +4052,10 @@ mod tests {
             profiles.insert(
                 "test".to_string(),
                 AgentProfileConfig {
+                    max_operations: 64,
+                    credential_selection: passless_core::agent::config::CredentialSelection::Single,
+                    human_verification_prompt:
+                        passless_core::agent::config::HumanVerificationPrompt::Always,
                     mode: AgentMode::Isolated,
                     principal_user: "test-user".to_string(),
                     rp_ids: vec!["example.com".to_string()],
@@ -4998,6 +5002,11 @@ mod tests {
                 profiles.insert(
                     "test".to_string(),
                     AgentProfileConfig {
+                        max_operations: 64,
+                        credential_selection:
+                            passless_core::agent::config::CredentialSelection::Single,
+                        human_verification_prompt:
+                            passless_core::agent::config::HumanVerificationPrompt::Always,
                         mode: AgentMode::Isolated,
                         principal_user: "test-user".to_string(),
                         rp_ids: vec!["example.com".to_string()],
@@ -5036,8 +5045,8 @@ mod tests {
                     rp_id: "example.com".to_string(),
                     register: AgentCeremonyPolicy {
                         authorization: AgentAuthorization::Allow,
-                        user_presence: UserPresenceSource::Policy,
-                        user_verification: UserVerificationSource::Policy,
+                        user_presence: UserPresenceSource::Agent,
+                        user_verification: UserVerificationSource::Agent,
                     },
                     authenticate: AgentCeremonyPolicy::deny(),
                 }];
@@ -5650,6 +5659,11 @@ mod tests {
                 profiles.insert(
                     "test".to_string(),
                     AgentProfileConfig {
+                        max_operations: 64,
+                        credential_selection:
+                            passless_core::agent::config::CredentialSelection::Single,
+                        human_verification_prompt:
+                            passless_core::agent::config::HumanVerificationPrompt::Always,
                         mode: AgentMode::Isolated,
                         principal_user: "test-user".to_string(),
                         rp_ids: vec!["example.com".to_string()],

--- a/cmd/passless/src/agent/doctor.rs
+++ b/cmd/passless/src/agent/doctor.rs
@@ -451,6 +451,13 @@ pub fn build_profile_diagnostic_report(
         require_uv,
     } = params;
     let endpoint_state = match mode {
+        AgentMode::SameUser => {
+            if endpoint_has_id {
+                EndpointDiagnosticState::Ready
+            } else {
+                EndpointDiagnosticState::Unavailable
+            }
+        }
         AgentMode::Isolated => {
             if endpoint_has_id {
                 EndpointDiagnosticState::Ready

--- a/cmd/passless/src/agent/grant.rs
+++ b/cmd/passless/src/agent/grant.rs
@@ -157,6 +157,10 @@ pub struct CredentialSet {
 }
 
 impl CredentialSet {
+    fn empty() -> Self {
+        Self { sorted: Vec::new() }
+    }
+
     pub fn new(mut creds: Vec<CredentialRef>) -> Result<Self, GrantError> {
         if creds.is_empty() {
             return Err(GrantError::EmptyCredentialSet);
@@ -315,6 +319,7 @@ pub struct GrantRequest {
     pub rp_ids: Vec<String>,
     pub credentials: Vec<CredentialRef>,
     pub requested_ttl_secs: u64,
+    pub allow_empty_credentials: bool,
     pub resolved: bool,
     pub resolved_grant_id: Option<GrantId>,
 }
@@ -490,11 +495,30 @@ impl GrantRegistry {
         &mut self,
         params: GrantRequestParams,
     ) -> Result<GrantRequestId, GrantError> {
+        self.request_grant_inner(params, false)
+    }
+
+    pub fn request_dynamic_grant(
+        &mut self,
+        params: GrantRequestParams,
+    ) -> Result<GrantRequestId, GrantError> {
+        self.request_grant_inner(params, true)
+    }
+
+    fn request_grant_inner(
+        &mut self,
+        params: GrantRequestParams,
+        allow_empty_credentials: bool,
+    ) -> Result<GrantRequestId, GrantError> {
         self.check_clock()?;
 
         validate_rp_ids(&params.rp_ids)?;
 
-        let cred_set = CredentialSet::new(params.credentials)?;
+        let cred_set = if allow_empty_credentials && params.credentials.is_empty() {
+            CredentialSet::empty()
+        } else {
+            CredentialSet::new(params.credentials)?
+        };
 
         if params.requested_ttl_secs == 0 {
             return Err(GrantError::TtlZero);
@@ -515,6 +539,7 @@ impl GrantRegistry {
             rp_ids: params.rp_ids,
             credentials: cred_set.sorted,
             requested_ttl_secs: params.requested_ttl_secs,
+            allow_empty_credentials,
             resolved: false,
             resolved_grant_id: None,
         };
@@ -551,7 +576,11 @@ impl GrantRegistry {
         }
 
         let validated_rps = validate_rp_ids(&request.rp_ids)?;
-        let cred_set = CredentialSet::new(request.credentials.clone())?;
+        let cred_set = if request.allow_empty_credentials && request.credentials.is_empty() {
+            CredentialSet::empty()
+        } else {
+            CredentialSet::new(request.credentials.clone())?
+        };
         let ttl = clamp_ttl(request.requested_ttl_secs, self.max_ttl_secs);
         let now = self.clock.monotonic_secs();
 

--- a/cmd/passless/src/agent/mod.rs
+++ b/cmd/passless/src/agent/mod.rs
@@ -1,5 +1,6 @@
 pub mod audit;
 pub mod audit_events;
+pub mod backend;
 pub mod browser;
 pub mod ceremony;
 #[cfg(test)]

--- a/cmd/passless/src/agent/policy_engine.rs
+++ b/cmd/passless/src/agent/policy_engine.rs
@@ -1124,7 +1124,7 @@ impl PolicyRuntime {
         }
 
         match snapshot.mode {
-            AgentMode::Isolated => {
+            AgentMode::SameUser | AgentMode::Isolated => {
                 if !snapshot.action_allowed(&request.action) {
                     return (
                         Decision::deny(ReasonCode::ActionNotAllowed, OperatorAction::None),
@@ -1380,6 +1380,18 @@ impl PolicyRuntime {
             .get_mut(&profile_key)
             .ok_or(GrantError::ProfileMismatch)?;
         grants.request_grant(params)
+    }
+
+    pub fn admin_request_dynamic_grant(
+        &self,
+        params: GrantRequestParams,
+    ) -> Result<super::grant::GrantRequestId, GrantError> {
+        let profile_key = params.profile_id.as_str().to_string();
+        let mut grants_map = self.grants.lock().unwrap();
+        let grants = grants_map
+            .get_mut(&profile_key)
+            .ok_or(GrantError::ProfileMismatch)?;
+        grants.request_dynamic_grant(params)
     }
 
     pub fn admin_approve_grant(
@@ -2292,6 +2304,10 @@ mod tests {
         profiles.insert(
             profile_name.to_string(),
             AgentProfileConfig {
+                max_operations: 64,
+                credential_selection: passless_core::agent::config::CredentialSelection::Single,
+                human_verification_prompt:
+                    passless_core::agent::config::HumanVerificationPrompt::Always,
                 mode: AgentMode::Isolated,
                 principal_user: "test-user".to_string(),
                 rp_ids: rp_ids.into_iter().map(|s| s.to_string()).collect(),
@@ -2388,8 +2404,8 @@ mod tests {
             register: AgentCeremonyPolicy::deny(),
             authenticate: AgentCeremonyPolicy {
                 authorization: AgentAuthorization::Allow,
-                user_presence: UserPresenceSource::Policy,
-                user_verification: UserVerificationSource::Policy,
+                user_presence: UserPresenceSource::Agent,
+                user_verification: UserVerificationSource::Agent,
             },
         }];
 

--- a/cmd/passless/src/agent/register.rs
+++ b/cmd/passless/src/agent/register.rs
@@ -15,13 +15,11 @@ use passless_core::config::SecurityConfig;
 use super::audit::AuditGate;
 use super::audit_events::{AuditAction, PolicyAllowBuilder, PolicyDenyBuilder, PolicyDenyReason};
 use super::policy_engine::PolicyRuntime;
-use super::sign::{b64u_decode, b64u_encode, verify_origin_structural};
+use super::sign::{b64u_decode, b64u_encode, verify_origin_context};
 
 use crate::storage::CredentialStorage;
 
 use soft_fido2::CredentialKeyProvider;
-
-const COSE_ALG_ES256: i32 = -7;
 
 const PASSLESS_AAGUID: [u8; 16] = [
     0x66, 0x69, 0x64, 0x6F, 0x2E, 0x70, 0x61, 0x73, 0x73, 0x6C, 0x65, 0x73, 0x73, 0x2E, 0x72, 0x73,
@@ -51,7 +49,12 @@ impl RegisterHandler {
     ) -> Result<RegisterCredentialResponse, ProtocolError> {
         let normalized_rp = normalize_rp_id(&req.rp_id);
 
-        if !verify_origin_structural(&req.origin, &normalized_rp) {
+        if !verify_origin_context(
+            &req.origin,
+            req.top_origin.as_deref(),
+            req.cross_origin,
+            &normalized_rp,
+        ) {
             let deny_event = PolicyDenyBuilder::new(
                 ctx.profile_id.clone(),
                 AuditAction::Register,
@@ -131,13 +134,7 @@ impl RegisterHandler {
         let ceremony_policy = ctx
             .profile_config
             .rule_for_rp(&normalized_rp)
-            .and_then(|rule| {
-                if rule.register.authorization == passless_core::agent::AgentAuthorization::Allow {
-                    Some(rule.register)
-                } else {
-                    None
-                }
-            })
+            .map(|rule| rule.register)
             .ok_or_else(|| {
                 let deny_event = PolicyDenyBuilder::new(
                     ctx.profile_id.clone(),
@@ -153,6 +150,51 @@ impl RegisterHandler {
                     RecommendedAction::FixRequest,
                 )
             })?;
+
+        match ceremony_policy.authorization {
+            passless_core::agent::AgentAuthorization::Deny => {
+                return Err(ProtocolError::new(
+                    ErrorCode::Forbidden,
+                    "RP policy denies registration",
+                    RecommendedAction::FixRequest,
+                ));
+            }
+            passless_core::agent::AgentAuthorization::Confirm => {
+                return Err(ProtocolError::new(
+                    ErrorCode::InteractionRequired,
+                    "human confirmation is required by policy",
+                    RecommendedAction::Retry,
+                ));
+            }
+            passless_core::agent::AgentAuthorization::Allow => {}
+        }
+
+        let human_uv_required = ceremony_policy.user_verification
+            == passless_core::agent::UserVerificationSource::Human
+            && (req.user_verification
+                || self.security_config.always_uv
+                || ctx.profile_config.human_verification_prompt
+                    == passless_core::agent::HumanVerificationPrompt::Always);
+        if ceremony_policy.user_presence == passless_core::agent::UserPresenceSource::Human
+            || human_uv_required
+        {
+            return Err(ProtocolError::new(
+                ErrorCode::InteractionRequired,
+                "human WebAuthn verification is required by policy",
+                RecommendedAction::Retry,
+            ));
+        }
+
+        let up = ceremony_policy.user_presence == passless_core::agent::UserPresenceSource::Agent;
+        let uv = ceremony_policy.user_verification
+            == passless_core::agent::UserVerificationSource::Agent;
+        if (req.user_verification || self.security_config.always_uv) && !uv {
+            return Err(ProtocolError::new(
+                ErrorCode::Forbidden,
+                "user verification is required but the configured evidence source is none",
+                RecommendedAction::FixRequest,
+            ));
+        }
 
         let user_id = b64u_decode(&req.user_id_b64u).map_err(|_| {
             ProtocolError::new(
@@ -209,7 +251,19 @@ impl RegisterHandler {
             )
         })?;
 
-        let generated = self.key_provider.generate(COSE_ALG_ES256).map_err(|_| {
+        let algorithm = req
+            .pub_key_cred_params
+            .iter()
+            .copied()
+            .find(|algorithm| self.key_provider.supports_algorithm(*algorithm))
+            .ok_or_else(|| {
+                ProtocolError::new(
+                    ErrorCode::BadRequest,
+                    "no requested public-key algorithm is supported by this backend",
+                    RecommendedAction::FixRequest,
+                )
+            })?;
+        let generated = self.key_provider.generate(algorithm).map_err(|_| {
             ProtocolError::new(
                 ErrorCode::Internal,
                 "key generation failed",
@@ -223,12 +277,15 @@ impl RegisterHandler {
             &normalized_rp,
             &credential_id,
             &generated.cose_public_key,
+            up,
+            uv,
         );
 
         let client_data_json = build_client_data_json_for_registration(
             &req.origin,
             &req.challenge_b64u,
             req.cross_origin,
+            req.top_origin.as_deref(),
         );
 
         let attestation_object = build_attestation_object(&authenticator_data);
@@ -250,7 +307,7 @@ impl RegisterHandler {
                 display_name: req.user_display_name.clone(),
             },
             sign_count: 0,
-            alg: COSE_ALG_ES256,
+            alg: algorithm,
             key: generated.key,
             created: now_ms,
             discoverable: true,
@@ -294,6 +351,7 @@ impl RegisterHandler {
 
         Ok(RegisterCredentialResponse {
             credential_id_b64u: b64u_encode(&credential_id),
+            public_key_algorithm: algorithm,
             authenticator_data_b64u: b64u_encode(&authenticator_data),
             attestation_object_b64u: b64u_encode(&attestation_object),
             client_data_json_b64u: b64u_encode(&client_data_json),
@@ -316,13 +374,22 @@ fn build_authenticator_data_for_registration(
     rp_id: &str,
     credential_id: &[u8],
     cose_public_key: &[u8],
+    up: bool,
+    uv: bool,
 ) -> Vec<u8> {
     let mut auth_data = Vec::with_capacity(37 + credential_id.len() + cose_public_key.len());
 
     let rp_id_hash = Sha256::digest(rp_id.as_bytes());
     auth_data.extend_from_slice(&rp_id_hash);
 
-    auth_data.push(0x41);
+    let mut flags = 0x40;
+    if up {
+        flags |= 0x01;
+    }
+    if uv {
+        flags |= 0x04;
+    }
+    auth_data.push(flags);
 
     auth_data.extend_from_slice(&0u32.to_be_bytes());
 
@@ -340,6 +407,7 @@ fn build_client_data_json_for_registration(
     origin: &str,
     challenge_b64u: &str,
     cross_origin: bool,
+    top_origin: Option<&str>,
 ) -> Vec<u8> {
     let mut cdj = String::with_capacity(128);
     cdj.push_str("{\"type\":\"webauthn.create\",\"challenge\":\"");
@@ -349,6 +417,11 @@ fn build_client_data_json_for_registration(
     cdj.push('"');
     if cross_origin {
         cdj.push_str(",\"crossOrigin\":true");
+        if let Some(top_origin) = top_origin {
+            cdj.push_str(",\"topOrigin\":\"");
+            cdj.push_str(&json_escape_string(top_origin));
+            cdj.push('"');
+        }
     }
     cdj.push('}');
     cdj.into_bytes()
@@ -555,6 +628,10 @@ mod tests {
 
     fn make_registration_profile_config() -> AgentProfileConfig {
         AgentProfileConfig {
+            max_operations: 64,
+            credential_selection: passless_core::agent::config::CredentialSelection::Single,
+            human_verification_prompt:
+                passless_core::agent::config::HumanVerificationPrompt::Always,
             mode: AgentMode::Isolated,
             principal_user: String::new(),
             rp_ids: vec!["example.com".to_string()],
@@ -568,8 +645,8 @@ mod tests {
                 rp_id: "example.com".to_string(),
                 register: AgentCeremonyPolicy {
                     authorization: AgentAuthorization::Allow,
-                    user_presence: UserPresenceSource::Policy,
-                    user_verification: UserVerificationSource::Policy,
+                    user_presence: UserPresenceSource::Agent,
+                    user_verification: UserVerificationSource::Agent,
                 },
                 authenticate: AgentCeremonyPolicy::deny(),
             }],
@@ -686,6 +763,7 @@ mod tests {
         fn make_req(&self) -> RegisterCredentialRequest {
             RegisterCredentialRequest {
                 origin: "https://example.com".to_string(),
+                top_origin: None,
                 rp_id: "example.com".to_string(),
                 challenge_b64u: "dGVzdA".to_string(),
                 user_id_b64u: "dXNlcg".to_string(),
@@ -693,6 +771,7 @@ mod tests {
                 user_display_name: Some("Test User".to_string()),
                 rp_name: Some("Example".to_string()),
                 exclude_credentials: vec![],
+                pub_key_cred_params: vec![-7],
                 user_verification: false,
                 cross_origin: false,
             }
@@ -701,6 +780,10 @@ mod tests {
 
     fn make_deny_profile_config() -> AgentProfileConfig {
         AgentProfileConfig {
+            max_operations: 64,
+            credential_selection: passless_core::agent::config::CredentialSelection::Single,
+            human_verification_prompt:
+                passless_core::agent::config::HumanVerificationPrompt::Always,
             mode: AgentMode::Isolated,
             principal_user: String::new(),
             rp_ids: vec!["example.com".to_string()],
@@ -715,8 +798,8 @@ mod tests {
                 register: AgentCeremonyPolicy::deny(),
                 authenticate: AgentCeremonyPolicy {
                     authorization: AgentAuthorization::Allow,
-                    user_presence: UserPresenceSource::Policy,
-                    user_verification: UserVerificationSource::Policy,
+                    user_presence: UserPresenceSource::Agent,
+                    user_verification: UserVerificationSource::Agent,
                 },
             }],
             device: DeviceIdentity {
@@ -799,7 +882,8 @@ mod tests {
         let cred_id = vec![0xAA; 32];
         let cose_key = vec![0xBB; 20];
 
-        let auth_data = build_authenticator_data_for_registration(rp_id, &cred_id, &cose_key);
+        let auth_data =
+            build_authenticator_data_for_registration(rp_id, &cred_id, &cose_key, true, false);
 
         assert_eq!(auth_data[32], 0x41);
         assert_eq!(&auth_data[33..37], &0u32.to_be_bytes());
@@ -813,7 +897,8 @@ mod tests {
     #[test]
     fn test_build_authenticator_data_rp_id_hash() {
         let rp_id = "example.com";
-        let auth_data = build_authenticator_data_for_registration(rp_id, &[0; 10], &[0; 10]);
+        let auth_data =
+            build_authenticator_data_for_registration(rp_id, &[0; 10], &[0; 10], true, false);
 
         let mut hasher = Sha256::new();
         hasher.update(rp_id.as_bytes());
@@ -823,7 +908,8 @@ mod tests {
 
     #[test]
     fn test_build_client_data_json_for_registration_no_cross_origin() {
-        let cdj = build_client_data_json_for_registration("https://example.com", "dGVzdA", false);
+        let cdj =
+            build_client_data_json_for_registration("https://example.com", "dGVzdA", false, None);
         let expected =
             br#"{"type":"webauthn.create","challenge":"dGVzdA","origin":"https://example.com"}"#;
         assert_eq!(cdj, expected);
@@ -831,8 +917,13 @@ mod tests {
 
     #[test]
     fn test_build_client_data_json_for_registration_with_cross_origin() {
-        let cdj = build_client_data_json_for_registration("https://example.com", "dGVzdA", true);
-        let expected = br#"{"type":"webauthn.create","challenge":"dGVzdA","origin":"https://example.com","crossOrigin":true}"#;
+        let cdj = build_client_data_json_for_registration(
+            "https://example.com",
+            "dGVzdA",
+            true,
+            Some("https://top.example"),
+        );
+        let expected = br#"{"type":"webauthn.create","challenge":"dGVzdA","origin":"https://example.com","crossOrigin":true,"topOrigin":"https://top.example"}"#;
         assert_eq!(cdj, expected);
     }
 
@@ -1089,7 +1180,7 @@ mod tests {
         assert!(cdj_str.contains("\"origin\":\"https://example.com\""));
 
         let auth_data = b64u_decode(&resp.authenticator_data_b64u).unwrap();
-        assert_eq!(auth_data[32], 0x41);
+        assert_eq!(auth_data[32], 0x45);
         assert_eq!(&auth_data[37..53], &PASSLESS_AAGUID);
 
         let att_obj_bytes = b64u_decode(&resp.attestation_object_b64u).unwrap();
@@ -1114,7 +1205,6 @@ mod tests {
 
         let spoofed_origins = [
             "http://example.com",
-            "https://example.com:8443",
             "https://example.com/path",
             "https://example.com?foo=bar",
             "https://example.com#frag",
@@ -1130,6 +1220,18 @@ mod tests {
             assert!(result.is_err(), "should reject spoofed origin: {}", origin);
             assert_eq!(result.unwrap_err().code, ErrorCode::Forbidden);
         }
+    }
+
+    #[test]
+    fn test_register_explicit_https_port_allowed() {
+        let f = RegisterTestFixture::new();
+        let handler = f.make_handler();
+        let ctx = f.make_ctx();
+        let mut req = f.make_req();
+        req.origin = "https://example.com:8443".to_string();
+
+        let result = handler.register(&ctx, &req);
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/cmd/passless/src/agent/runtime.rs
+++ b/cmd/passless/src/agent/runtime.rs
@@ -27,6 +27,7 @@ use super::audit_events::{
     BackendKind, DaemonStartBuilder, DaemonStopBuilder, EndpointCreateBuilder, FailReason,
     ProfileCreateBuilder, ProfileFailBuilder, StopReason,
 };
+use super::backend::CredentialBackendHandle;
 use super::browser::{BrowserConfig, BrowserProcessManager, Clock, SystemClock};
 use super::ceremony::{
     AgentCeremonyHandler, CeremonyPreparationSlot, StaticCeremonyContext,
@@ -45,7 +46,7 @@ use super::policy_engine::PolicyRuntime;
 use super::prompt::{DesktopPromptHandle, PromptHandle, PromptMode};
 use super::sign::{SignContextRegistry, SignHttpServer};
 use super::storage::{CeremonyScope, ForwardingStorageHandle, IsolatedScopedStorage};
-use super::storage_factory::create_storage_bundle_with_options;
+use super::storage_factory::{create_storage_bundle_with_options, key_provider_for_config};
 use passless_core::agent::config::CdpExposeMode;
 
 use crate::authenticator::AuthenticatorService;
@@ -74,6 +75,7 @@ pub struct RuntimeStartParams<'a> {
     pub human_storage: Arc<Mutex<Box<dyn CredentialStorage>>>,
     pub human_pin_storage: Arc<Mutex<Box<dyn crate::pin_storage::PinStorage>>>,
     pub human_operation_lock: Arc<Mutex<()>>,
+    pub human_key_provider: Arc<dyn soft_fido2::CredentialKeyProvider + Send + Sync>,
     pub agent_config: &'a AgentConfig,
     pub security_config: SecurityConfig,
     pub pin_config: PinConfig,
@@ -193,6 +195,7 @@ pub struct ProfileRuntime {
     pub browser_uid: Option<u32>,
     pub browser_gid: Option<u32>,
     pub enabled: AtomicBool,
+    pub backend: CredentialBackendHandle,
     pub credential_storage: Arc<Mutex<Box<dyn CredentialStorage>>>,
 }
 
@@ -535,6 +538,7 @@ impl AgentRuntime {
         human_storage: Arc<Mutex<Box<dyn CredentialStorage>>>,
         human_pin_storage: Arc<Mutex<Box<dyn crate::pin_storage::PinStorage>>>,
         human_operation_lock: Arc<Mutex<()>>,
+        human_key_provider: Arc<dyn soft_fido2::CredentialKeyProvider + Send + Sync>,
         agent_config: &AgentConfig,
         security_config: SecurityConfig,
         pin_config: PinConfig,
@@ -544,6 +548,7 @@ impl AgentRuntime {
             human_storage,
             human_pin_storage,
             human_operation_lock,
+            human_key_provider,
             agent_config,
             security_config,
             pin_config,
@@ -554,15 +559,22 @@ impl AgentRuntime {
 
     pub fn start_with_factories(params: RuntimeStartParams<'_>) -> Result<Arc<Self>, RuntimeError> {
         let RuntimeStartParams {
-            human_storage: _human_storage,
-            human_pin_storage: _human_pin_storage,
-            human_operation_lock: _human_operation_lock,
+            human_storage,
+            human_pin_storage,
+            human_operation_lock,
+            human_key_provider,
             agent_config,
             security_config,
             pin_config,
             shutdown,
             endpoint_factory,
         } = params;
+        let human_backend = CredentialBackendHandle::human(
+            human_storage,
+            human_pin_storage,
+            human_key_provider,
+            human_operation_lock,
+        );
         let daemon_uid = unsafe { libc::getuid() };
         let daemon_gid = unsafe { libc::getgid() };
         let _startup_mono = Instant::now();
@@ -992,9 +1004,34 @@ impl AgentRuntime {
 
             let preparation_slot = Arc::new(CeremonyPreparationSlot::new());
             let interaction_manager = Arc::new(AgentInteractionManager::new());
-            let profile_op_lock = Arc::new(Mutex::new(()));
 
-            let spec_result = match profile.mode {
+            let spec_result: Result<
+                (EndpointSpec, CeremonyScope, CredentialBackendHandle),
+                RuntimeError,
+            > = match profile.mode {
+                AgentMode::SameUser => {
+                    let ceremony_scope = CeremonyScope::new();
+                    let backend = human_backend.clone();
+                    let spec = EndpointSpec {
+                        profile_name: name.clone(),
+                        profile_id: profile_id.clone(),
+                        mode: AgentMode::SameUser,
+                        profile_config: profile.clone(),
+                        security_config: security_config.clone(),
+                        pin_config: pin_config.clone(),
+                        interaction_manager: interaction_manager.clone(),
+                        preparation_slot: preparation_slot.clone(),
+                        operation_lock: backend.operation_lock.clone(),
+                        policy_runtime: policy_runtime.clone(),
+                        audit_gate: audit_gate.clone(),
+                        event_tx: event_tx.clone(),
+                        endpoint_factory: endpoint_factory.clone(),
+                        #[cfg(test)]
+                        test_transport_factory: None,
+                        isolated_deps: None,
+                    };
+                    Ok((spec, ceremony_scope, backend))
+                }
                 AgentMode::Isolated => {
                     let storage_config = profile.storage.as_ref().ok_or_else(|| {
                         RuntimeError::Config(format!(
@@ -1010,7 +1047,20 @@ impl AgentRuntime {
                             name, e
                         ))
                     })?;
-
+                    let operation_lock = Arc::new(Mutex::new(()));
+                    let key_provider = key_provider_for_config(storage_config).map_err(|e| {
+                        RuntimeError::Storage(format!(
+                            "profile '{}': failed to resolve credential key provider: {}",
+                            name, e
+                        ))
+                    })?;
+                    let backend = CredentialBackendHandle::isolated(
+                        profile_id.clone(),
+                        bundle.credential_storage.clone(),
+                        bundle.pin_storage.clone(),
+                        key_provider,
+                        operation_lock.clone(),
+                    );
                     let ceremony_scope = CeremonyScope::new();
 
                     let effective_pin_config = if profile.requires_human_uv() {
@@ -1030,7 +1080,7 @@ impl AgentRuntime {
                         pin_config: effective_pin_config,
                         interaction_manager: interaction_manager.clone(),
                         preparation_slot: preparation_slot.clone(),
-                        operation_lock: profile_op_lock.clone(),
+                        operation_lock,
                         policy_runtime: policy_runtime.clone(),
                         audit_gate: audit_gate.clone(),
                         event_tx: event_tx.clone(),
@@ -1046,13 +1096,13 @@ impl AgentRuntime {
                         }),
                     };
 
-                    Ok((spec, ceremony_scope, bundle.credential_storage))
+                    Ok((spec, ceremony_scope, backend))
                 }
             };
-
             match spec_result {
-                Ok((spec, _ceremony_scope, cred_storage)) => {
+                Ok((spec, _ceremony_scope, backend)) => {
                     let initial_endpoint_id = match profile.mode {
+                        AgentMode::SameUser => Some(EndpointId::new()),
                         AgentMode::Isolated => {
                             match Self::create_endpoint_from_spec(
                                 &spec,
@@ -1093,7 +1143,7 @@ impl AgentRuntime {
                             lifecycle_lock: Mutex::new(()),
                             endpoint_spec: spec,
                             preparation_slot,
-                            operation_lock: profile_op_lock,
+                            operation_lock: backend.operation_lock.clone(),
                             mode: profile.mode,
                             profile_config: profile.clone(),
                             current_pending: Mutex::new(None),
@@ -1103,7 +1153,8 @@ impl AgentRuntime {
                             browser_uid,
                             browser_gid,
                             enabled: AtomicBool::new(true),
-                            credential_storage: cred_storage,
+                            credential_storage: backend.credential_storage.clone(),
+                            backend,
                         },
                     );
                 }
@@ -1230,6 +1281,10 @@ impl AgentRuntime {
         let interaction_manager_inner = spec.interaction_manager.clone();
 
         match spec.mode {
+            AgentMode::SameUser => Err(RuntimeError::Config(format!(
+                "profile '{}': same-user mode does not create an agent UHID endpoint",
+                name
+            ))),
             AgentMode::Isolated => {
                 let deps = spec.isolated_deps.as_ref().ok_or_else(|| {
                     RuntimeError::Config(format!(
@@ -1510,6 +1565,10 @@ impl AgentRuntime {
         let interaction_manager_inner = spec.interaction_manager.clone();
 
         match spec.mode {
+            AgentMode::SameUser => Err(RuntimeError::Config(format!(
+                "profile '{}': same-user mode does not create an agent UHID endpoint",
+                name
+            ))),
             AgentMode::Isolated => {
                 let deps = spec.isolated_deps.as_ref().ok_or_else(|| {
                     RuntimeError::Config(format!(
@@ -3526,6 +3585,10 @@ impl AgentRuntime {
 
         if !has_endpoint {
             match profile.mode {
+                AgentMode::SameUser => {
+                    let mut eid_guard = profile.endpoint_id.lock().unwrap();
+                    *eid_guard = Some(EndpointId::new());
+                }
                 AgentMode::Isolated => {
                     let _lifecycle = profile.lifecycle_lock.lock().unwrap();
                     match self.create_profile_endpoint(&profile.endpoint_spec) {
@@ -4723,16 +4786,13 @@ impl AgentRuntime {
             profile_config: profile_config.clone(),
         };
 
-        let key_provider: Arc<dyn soft_fido2::CredentialKeyProvider + Send + Sync> =
-            Arc::new(soft_fido2::SoftwareCredentialKeyProvider);
-
         let register_handler = Arc::new(super::register::RegisterHandler {
-            human_storage: profile.credential_storage.clone(),
+            human_storage: profile.backend.credential_storage.clone(),
             policy_runtime: self.policy_runtime.clone(),
             audit_gate: self.audit_gate.clone(),
-            key_provider,
+            key_provider: profile.backend.key_provider.clone(),
             security_config: profile.endpoint_spec.security_config.clone(),
-            operation_lock: profile.operation_lock.clone(),
+            operation_lock: profile.backend.operation_lock.clone(),
         });
 
         // Register the bearer token with the sign registry for registration
@@ -4776,11 +4836,37 @@ impl AgentRuntime {
 
         let pid = snapshot.pid;
 
-        // Try to register sign context for authentication (if credentials exist)
-        if let Ok(mut storage) = profile.credential_storage.lock()
-            && let Ok(cred) = storage.read_first(crate::storage::CredentialFilter::None)
+        // Register one authentication context for every credential in the selected
+        // backend that is both in RP scope and in the optional configured
+        // credential scope. Selection for a concrete ceremony happens in the
+        // sign handler using allowCredentials/discoverable semantics.
+        let mut credential_refs = Vec::new();
+        if let Ok(mut storage) = profile.backend.credential_storage.lock()
+            && let Ok(mut cred) = storage.read_first(crate::storage::CredentialFilter::None)
         {
-            let cred_ref = passless_core::agent::CredentialRef::with_default_domain(&cred.id);
+            loop {
+                let rp_allowed = config
+                    .rp_ids
+                    .iter()
+                    .any(|rp| rp.eq_ignore_ascii_case(&cred.rp.id));
+                let credential_ref =
+                    passless_core::agent::CredentialRef::with_default_domain(&cred.id);
+                let credential_allowed = profile_config
+                    .credential_refs
+                    .as_ref()
+                    .is_none_or(|refs| refs.iter().any(|candidate| candidate == &credential_ref));
+                if rp_allowed && credential_allowed {
+                    credential_refs.push(credential_ref);
+                }
+                match storage.read_next() {
+                    Ok(next) => cred = next,
+                    Err(_) => break,
+                }
+            }
+        }
+
+        let dynamic_credential_scope = profile_config.credential_refs.is_none();
+        if dynamic_credential_scope || !credential_refs.is_empty() {
             let session_id = passless_core::agent::PrincipalSessionId::new();
             let grant_params = super::grant::GrantRequestParams {
                 profile_id: profile_id.clone(),
@@ -4788,10 +4874,24 @@ impl AgentRuntime {
                 endpoint_id: endpoint_id.clone(),
                 principal_digest: [0u8; 32],
                 rp_ids: config.rp_ids.clone(),
-                credentials: vec![cred_ref],
-                requested_ttl_secs: 300,
+                credentials: if dynamic_credential_scope {
+                    Vec::new()
+                } else {
+                    credential_refs
+                },
+                requested_ttl_secs: profile_config
+                    .max_session_ttl
+                    .as_ref()
+                    .map(|ttl| ttl.as_secs())
+                    .unwrap_or(300),
             };
-            match self.policy_runtime.admin_request_grant(grant_params) {
+            let grant_request = if dynamic_credential_scope {
+                self.policy_runtime
+                    .admin_request_dynamic_grant(grant_params)
+            } else {
+                self.policy_runtime.admin_request_grant(grant_params)
+            };
+            match grant_request {
                 Ok(request_id) => {
                     match self
                         .policy_runtime
@@ -4803,16 +4903,13 @@ impl AgentRuntime {
                                 active_grant_id: grant_id,
                                 profile_config: profile_config.clone(),
                             };
-                            let sign_key_provider: Arc<
-                                dyn soft_fido2::CredentialKeyProvider + Send + Sync,
-                            > = Arc::new(soft_fido2::SoftwareCredentialKeyProvider);
                             let sign_handler = Arc::new(super::sign::SignHandler {
-                                human_storage: profile.credential_storage.clone(),
+                                human_storage: profile.backend.credential_storage.clone(),
                                 policy_runtime: self.policy_runtime.clone(),
                                 audit_gate: self.audit_gate.clone(),
                                 security_config: profile.endpoint_spec.security_config.clone(),
-                                key_provider: sign_key_provider,
-                                operation_lock: profile.operation_lock.clone(),
+                                key_provider: profile.backend.key_provider.clone(),
+                                operation_lock: profile.backend.operation_lock.clone(),
                             });
                             if let Err(e) = self.sign_registry.register_pending(
                                 bearer_token.clone(),
@@ -4841,6 +4938,11 @@ impl AgentRuntime {
                     log::error!("failed to request grant: {}", e);
                 }
             }
+        } else {
+            debug!(
+                "no configured credentials in backend scope for profile={}; authentication remains unavailable",
+                profile_id
+            );
         }
 
         Ok(AdminResponse::BrowserLaunched(
@@ -5599,6 +5701,10 @@ mod tests {
             profile_id: ProfileId::new("test").unwrap(),
             mode: AgentMode::Isolated,
             profile_config: passless_core::agent::AgentProfileConfig {
+                max_operations: 64,
+                credential_selection: passless_core::agent::config::CredentialSelection::Single,
+                human_verification_prompt:
+                    passless_core::agent::config::HumanVerificationPrompt::Always,
                 mode: AgentMode::Isolated,
                 principal_user: "testuser".to_string(),
                 rp_ids: vec!["example.com".to_string()],
@@ -5838,6 +5944,10 @@ mod tests {
             config.profiles.insert(
                 "test-isolated".to_string(),
                 passless_core::agent::AgentProfileConfig {
+                    max_operations: 64,
+                    credential_selection: passless_core::agent::config::CredentialSelection::Single,
+                    human_verification_prompt:
+                        passless_core::agent::config::HumanVerificationPrompt::Always,
                     mode: AgentMode::Isolated,
                     principal_user: "testuser".to_string(),
                     rp_ids: vec!["example.com".to_string()],
@@ -5923,6 +6033,14 @@ mod tests {
             crate::worker::WorkerConfig::default(),
         ));
 
+        let backend = CredentialBackendHandle::isolated(
+            profile_id.clone(),
+            cred_storage.clone(),
+            pin_storage.clone(),
+            Arc::new(soft_fido2::SoftwareCredentialKeyProvider),
+            operation_lock.clone(),
+        );
+
         let profile_runtime = ProfileRuntime {
             profile_name: "test-isolated".to_string(),
             profile_id: profile_id.clone(),
@@ -5942,6 +6060,7 @@ mod tests {
             browser_uid: None,
             browser_gid: None,
             enabled: AtomicBool::new(true),
+            backend,
             credential_storage: cred_storage.clone(),
         };
 

--- a/cmd/passless/src/agent/sign.rs
+++ b/cmd/passless/src/agent/sign.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -9,6 +9,7 @@ use std::time::Duration;
 use log::{debug, warn};
 use sha2::{Digest, Sha256};
 
+use passless_core::agent::config::CredentialSelection;
 use passless_core::agent::protocol::{
     ErrorCode, PrincipalResponse, ProtocolError, RecommendedAction, RegisterCredentialRequest,
     SignAssertionRequest, SignAssertionResponse,
@@ -95,8 +96,13 @@ fn json_escape_string(s: &str) -> String {
     out
 }
 
-pub fn build_client_data_json(origin: &str, challenge_b64u: &str, cross_origin: bool) -> Vec<u8> {
-    let mut cdj = String::with_capacity(128);
+pub fn build_client_data_json(
+    origin: &str,
+    challenge_b64u: &str,
+    cross_origin: bool,
+    top_origin: Option<&str>,
+) -> Vec<u8> {
+    let mut cdj = String::with_capacity(160);
     cdj.push_str("{\"type\":\"webauthn.get\",\"challenge\":\"");
     cdj.push_str(challenge_b64u);
     cdj.push_str("\",\"origin\":\"");
@@ -104,6 +110,11 @@ pub fn build_client_data_json(origin: &str, challenge_b64u: &str, cross_origin: 
     cdj.push('"');
     if cross_origin {
         cdj.push_str(",\"crossOrigin\":true");
+        if let Some(top_origin) = top_origin {
+            cdj.push_str(",\"topOrigin\":\"");
+            cdj.push_str(&json_escape_string(top_origin));
+            cdj.push('"');
+        }
     }
     cdj.push('}');
     cdj.into_bytes()
@@ -176,11 +187,32 @@ pub fn verify_origin_structural(origin: &str, rp_id: &str) -> bool {
         Some(p) => p,
         None => return false,
     };
-    let normalized_rp = rp_id.trim().to_ascii_lowercase();
-    if parsed.port.is_some() {
+    let normalized_rp = rp_id.trim().trim_end_matches('.').to_ascii_lowercase();
+    if normalized_rp.is_empty() {
         return false;
     }
-    parsed.host == normalized_rp
+    parsed.host == normalized_rp || parsed.host.ends_with(&format!(".{normalized_rp}"))
+}
+
+pub fn verify_origin_context(
+    origin: &str,
+    top_origin: Option<&str>,
+    cross_origin: bool,
+    rp_id: &str,
+) -> bool {
+    if !verify_origin_structural(origin, rp_id) {
+        return false;
+    }
+    if cross_origin {
+        return top_origin.and_then(parse_origin).is_some();
+    }
+    match top_origin {
+        Some(top) => parse_origin(top).is_some_and(|parsed| {
+            parse_origin(origin)
+                .is_some_and(|frame| parsed.host == frame.host && parsed.port == frame.port)
+        }),
+        None => true,
+    }
 }
 
 fn normalize_rp_id(raw: &str) -> String {
@@ -207,21 +239,77 @@ pub fn generate_bearer_token() -> Result<String, String> {
 }
 
 #[derive(Clone)]
+struct RequestBudget {
+    used_requests: Arc<Mutex<HashSet<[u8; 32]>>>,
+    max_requests: usize,
+}
+
+impl RequestBudget {
+    fn claim(&self, body: &[u8]) -> RequestClaim {
+        claim_request_digest(&self.used_requests, self.max_requests, body)
+    }
+}
+
+#[derive(Clone)]
 pub struct LeaseEntry {
     pub context: SignContext,
     pub handler: Arc<SignHandler>,
     pub lease_id: Option<String>,
+    request_budget: RequestBudget,
+}
+
+impl LeaseEntry {
+    fn claim_request(&self, body: &[u8]) -> RequestClaim {
+        self.request_budget.claim(body)
+    }
 }
 
 pub struct SignContextRegistry {
     entries: Mutex<HashMap<String, LeaseEntry>>,
     registration_entries: Mutex<HashMap<String, RegistrationLeaseEntry>>,
+    request_budgets: Mutex<HashMap<String, RequestBudget>>,
 }
 
 #[derive(Clone)]
 pub struct RegistrationLeaseEntry {
     pub context: RegisterContext,
     pub handler: Arc<RegisterHandler>,
+    request_budget: RequestBudget,
+}
+
+impl RegistrationLeaseEntry {
+    fn claim_request(&self, body: &[u8]) -> RequestClaim {
+        self.request_budget.claim(body)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RequestClaim {
+    Claimed,
+    Replayed,
+    Exhausted,
+    Unavailable,
+}
+
+fn claim_request_digest(
+    registry: &Mutex<HashSet<[u8; 32]>>,
+    max_requests: usize,
+    body: &[u8],
+) -> RequestClaim {
+    let hash = Sha256::digest(body);
+    let mut digest = [0u8; 32];
+    digest.copy_from_slice(&hash);
+    let Ok(mut used) = registry.lock() else {
+        return RequestClaim::Unavailable;
+    };
+    if used.contains(&digest) {
+        return RequestClaim::Replayed;
+    }
+    if used.len() >= max_requests {
+        return RequestClaim::Exhausted;
+    }
+    used.insert(digest);
+    RequestClaim::Claimed
 }
 
 impl SignContextRegistry {
@@ -229,7 +317,27 @@ impl SignContextRegistry {
         Self {
             entries: Mutex::new(HashMap::new()),
             registration_entries: Mutex::new(HashMap::new()),
+            request_budgets: Mutex::new(HashMap::new()),
         }
+    }
+
+    fn request_budget(&self, token: &str, max_requests: usize) -> Result<RequestBudget, String> {
+        let mut budgets = self
+            .request_budgets
+            .lock()
+            .map_err(|_| "registry lock poisoned")?;
+        if let Some(existing) = budgets.get(token) {
+            if existing.max_requests != max_requests {
+                return Err("operation budget mismatch".into());
+            }
+            return Ok(existing.clone());
+        }
+        let budget = RequestBudget {
+            used_requests: Arc::new(Mutex::new(HashSet::new())),
+            max_requests,
+        };
+        budgets.insert(token.to_string(), budget.clone());
+        Ok(budget)
     }
 
     pub fn register_pending_registration(
@@ -238,6 +346,8 @@ impl SignContextRegistry {
         context: RegisterContext,
         handler: Arc<RegisterHandler>,
     ) -> Result<(), String> {
+        let max_requests = usize::from(context.profile_config.max_operations);
+        let request_budget = self.request_budget(&token, max_requests)?;
         let mut map = self
             .registration_entries
             .lock()
@@ -245,7 +355,14 @@ impl SignContextRegistry {
         if map.contains_key(&token) {
             return Err("duplicate token".into());
         }
-        map.insert(token, RegistrationLeaseEntry { context, handler });
+        map.insert(
+            token,
+            RegistrationLeaseEntry {
+                context,
+                handler,
+                request_budget,
+            },
+        );
         Ok(())
     }
 
@@ -263,11 +380,13 @@ impl SignContextRegistry {
     }
 
     pub fn revoke_registration(&self, token: &str) -> bool {
-        let mut map = match self.registration_entries.lock() {
-            Ok(m) => m,
-            Err(_) => return false,
-        };
-        map.remove(token).is_some()
+        let removed = self
+            .registration_entries
+            .lock()
+            .map(|mut map| map.remove(token).is_some())
+            .unwrap_or(false);
+        self.cleanup_request_budget(token);
+        removed
     }
 
     pub fn register_pending(
@@ -276,6 +395,8 @@ impl SignContextRegistry {
         context: SignContext,
         handler: Arc<SignHandler>,
     ) -> Result<(), String> {
+        let max_requests = usize::from(context.profile_config.max_operations);
+        let request_budget = self.request_budget(&token, max_requests)?;
         let mut map = self.entries.lock().map_err(|_| "registry lock poisoned")?;
         if map.contains_key(&token) {
             return Err("duplicate token".into());
@@ -286,9 +407,29 @@ impl SignContextRegistry {
                 context,
                 handler,
                 lease_id: None,
+                request_budget,
             },
         );
         Ok(())
+    }
+
+    fn cleanup_request_budget(&self, token: &str) {
+        let sign_active = self
+            .entries
+            .lock()
+            .map(|map| map.contains_key(token))
+            .unwrap_or(true);
+        let registration_active = self
+            .registration_entries
+            .lock()
+            .map(|map| map.contains_key(token))
+            .unwrap_or(true);
+        if !sign_active
+            && !registration_active
+            && let Ok(mut budgets) = self.request_budgets.lock()
+        {
+            budgets.remove(token);
+        }
     }
 
     pub fn bind_lease(&self, token: &str, lease_id: String) -> Result<(), String> {
@@ -324,11 +465,13 @@ impl SignContextRegistry {
     }
 
     pub fn revoke(&self, token: &str) -> bool {
-        let mut map = match self.entries.lock() {
-            Ok(m) => m,
-            Err(_) => return false,
-        };
-        map.remove(token).is_some()
+        let removed = self
+            .entries
+            .lock()
+            .map(|mut map| map.remove(token).is_some())
+            .unwrap_or(false);
+        self.cleanup_request_budget(token);
+        removed
     }
 
     pub fn revoke_by_lease(&self, lease_id: &str) -> usize {
@@ -342,8 +485,12 @@ impl SignContextRegistry {
             .map(|(k, _)| k.clone())
             .collect();
         let count = keys.len();
-        for k in keys {
-            map.remove(&k);
+        for k in &keys {
+            map.remove(k);
+        }
+        drop(map);
+        for key in keys {
+            self.cleanup_request_budget(&key);
         }
         count
     }
@@ -351,6 +498,12 @@ impl SignContextRegistry {
     pub fn revoke_all(&self) {
         if let Ok(mut map) = self.entries.lock() {
             map.clear();
+        }
+        if let Ok(mut map) = self.registration_entries.lock() {
+            map.clear();
+        }
+        if let Ok(mut budgets) = self.request_budgets.lock() {
+            budgets.clear();
         }
     }
 
@@ -639,6 +792,29 @@ fn handle_http_connection(
                     send_sign_error(&mut stream, "413 Payload Too Large", "body_too_large");
                     return Ok(());
                 }
+                match reg_entry.claim_request(&body) {
+                    RequestClaim::Claimed => {}
+                    RequestClaim::Replayed => {
+                        send_sign_error(&mut stream, "409 Conflict", "replayed_operation");
+                        return Ok(());
+                    }
+                    RequestClaim::Exhausted => {
+                        send_sign_error(
+                            &mut stream,
+                            "429 Too Many Requests",
+                            "operation_budget_exhausted",
+                        );
+                        return Ok(());
+                    }
+                    RequestClaim::Unavailable => {
+                        send_sign_error(
+                            &mut stream,
+                            "500 Internal Server Error",
+                            "operation_registry_unavailable",
+                        );
+                        return Ok(());
+                    }
+                }
                 let req: RegisterCredentialRequest = match serde_json::from_slice(&body) {
                     Ok(r) => r,
                     Err(_) => {
@@ -659,6 +835,9 @@ fn handle_http_connection(
                             ErrorCode::Forbidden => ("403 Forbidden", "forbidden"),
                             ErrorCode::NotFound => ("404 Not Found", "not_found"),
                             ErrorCode::Conflict => ("409 Conflict", "conflict"),
+                            ErrorCode::InteractionRequired => {
+                                ("409 Conflict", "human_interaction_required")
+                            }
                             _ => ("500 Internal Server Error", "internal_error"),
                         };
                         send_sign_error(&mut stream, status, code);
@@ -720,6 +899,29 @@ fn handle_http_connection(
         send_sign_error(&mut stream, "413 Payload Too Large", "body_too_large");
         return Ok(());
     }
+    match entry.claim_request(&body) {
+        RequestClaim::Claimed => {}
+        RequestClaim::Replayed => {
+            send_sign_error(&mut stream, "409 Conflict", "replayed_operation");
+            return Ok(());
+        }
+        RequestClaim::Exhausted => {
+            send_sign_error(
+                &mut stream,
+                "429 Too Many Requests",
+                "operation_budget_exhausted",
+            );
+            return Ok(());
+        }
+        RequestClaim::Unavailable => {
+            send_sign_error(
+                &mut stream,
+                "500 Internal Server Error",
+                "operation_registry_unavailable",
+            );
+            return Ok(());
+        }
+    }
     let req: SignAssertionRequest = match serde_json::from_slice(&body) {
         Ok(r) => r,
         Err(_) => {
@@ -739,6 +941,8 @@ fn handle_http_connection(
                 ErrorCode::Unauthorized => ("401 Unauthorized", "unauthorized"),
                 ErrorCode::Forbidden => ("403 Forbidden", "forbidden"),
                 ErrorCode::NotFound => ("404 Not Found", "not_found"),
+                ErrorCode::Conflict => ("409 Conflict", "conflict"),
+                ErrorCode::InteractionRequired => ("409 Conflict", "human_interaction_required"),
                 _ => ("500 Internal Server Error", "internal_error"),
             };
             send_sign_error(&mut stream, status, code);
@@ -765,6 +969,17 @@ pub struct SignHandler {
 }
 
 impl SignHandler {
+    fn record_policy_deny(&self, ctx: &SignContext, rp_id: &str, reason: PolicyDenyReason) {
+        let deny_event = PolicyDenyBuilder::new(
+            ctx.profile_id.clone(),
+            AuditAction::Authenticate,
+            rp_id,
+            reason,
+        )
+        .build();
+        let _ = self.audit_gate.record(deny_event);
+    }
+
     pub fn sign(
         &self,
         ctx: &SignContext,
@@ -772,7 +987,12 @@ impl SignHandler {
     ) -> Result<PrincipalResponse, ProtocolError> {
         let normalized_rp = normalize_rp_id(&req.rp_id);
 
-        if !verify_origin_structural(&req.origin, &normalized_rp) {
+        if !verify_origin_context(
+            &req.origin,
+            req.top_origin.as_deref(),
+            req.cross_origin,
+            &normalized_rp,
+        ) {
             let deny_event = PolicyDenyBuilder::new(
                 ctx.profile_id.clone(),
                 AuditAction::Authenticate,
@@ -870,15 +1090,7 @@ impl SignHandler {
         let ceremony_policy = ctx
             .profile_config
             .rule_for_rp(&normalized_rp)
-            .and_then(|rule| {
-                if rule.authenticate.authorization
-                    == passless_core::agent::AgentAuthorization::Allow
-                {
-                    Some(rule.authenticate)
-                } else {
-                    None
-                }
-            })
+            .map(|rule| rule.authenticate)
             .ok_or_else(|| {
                 let deny_event = PolicyDenyBuilder::new(
                     ctx.profile_id.clone(),
@@ -895,21 +1107,62 @@ impl SignHandler {
                 )
             })?;
 
-        let resolved_cred_ref = grant_snapshot.credential_refs.first().ok_or_else(|| {
-            let deny_event = PolicyDenyBuilder::new(
-                ctx.profile_id.clone(),
-                AuditAction::Authenticate,
+        match ceremony_policy.authorization {
+            passless_core::agent::AgentAuthorization::Deny => {
+                self.record_policy_deny(ctx, &normalized_rp, PolicyDenyReason::ActionNotAllowed);
+                return Err(ProtocolError::new(
+                    ErrorCode::Forbidden,
+                    "RP policy denies signing",
+                    RecommendedAction::FixRequest,
+                ));
+            }
+            passless_core::agent::AgentAuthorization::Confirm => {
+                self.record_policy_deny(ctx, &normalized_rp, PolicyDenyReason::ActionNotAllowed);
+                return Err(ProtocolError::new(
+                    ErrorCode::InteractionRequired,
+                    "human confirmation is required by policy",
+                    RecommendedAction::Retry,
+                ));
+            }
+            passless_core::agent::AgentAuthorization::Allow => {}
+        }
+
+        let human_uv_required = ceremony_policy.user_verification
+            == passless_core::agent::UserVerificationSource::Human
+            && (req.user_verification
+                || self.security_config.always_uv
+                || ctx.profile_config.human_verification_prompt
+                    == passless_core::agent::HumanVerificationPrompt::Always);
+        if ceremony_policy.user_presence == passless_core::agent::UserPresenceSource::Human
+            || human_uv_required
+        {
+            self.record_policy_deny(
+                ctx,
                 &normalized_rp,
-                PolicyDenyReason::CredentialNotMatch,
-            )
-            .build();
-            let _ = self.audit_gate.record(deny_event);
-            ProtocolError::new(
+                if human_uv_required {
+                    PolicyDenyReason::UvRequired
+                } else {
+                    PolicyDenyReason::ActionNotAllowed
+                },
+            );
+            return Err(ProtocolError::new(
+                ErrorCode::InteractionRequired,
+                "human WebAuthn verification is required by policy",
+                RecommendedAction::Retry,
+            ));
+        }
+
+        let up = ceremony_policy.user_presence == passless_core::agent::UserPresenceSource::Agent;
+        let uv = ceremony_policy.user_verification
+            == passless_core::agent::UserVerificationSource::Agent;
+        if (req.user_verification || self.security_config.always_uv) && !uv {
+            self.record_policy_deny(ctx, &normalized_rp, PolicyDenyReason::UvRequired);
+            return Err(ProtocolError::new(
                 ErrorCode::Forbidden,
-                "no credential in active grant",
+                "user verification is required but the configured evidence source is none",
                 RecommendedAction::FixRequest,
-            )
-        })?;
+            ));
+        }
 
         let mut storage = self.human_storage.lock().map_err(|_| {
             ProtocolError::new(
@@ -919,26 +1172,67 @@ impl SignHandler {
             )
         })?;
 
-        let cred_id = Self::resolve_credential_id(&mut storage, resolved_cred_ref, &normalized_rp)?;
+        let credential_scope = if grant_snapshot.credential_refs.is_empty() {
+            let mut discovered = Vec::new();
+            if let Ok(mut credential) = storage.read_first(crate::storage::CredentialFilter::None) {
+                loop {
+                    if credential.rp.id.eq_ignore_ascii_case(&normalized_rp) {
+                        discovered.push(CredentialRef::with_default_domain(&credential.id));
+                    }
+                    match storage.read_next() {
+                        Ok(next) => credential = next,
+                        Err(_) => break,
+                    }
+                }
+            }
+            discovered
+        } else {
+            grant_snapshot.credential_refs.clone()
+        };
 
-        if !req.allow_credentials.is_empty() {
-            let cred_id_b64u = b64u_encode(&cred_id);
-            if !req.allow_credentials.contains(&cred_id_b64u) {
-                let deny_event = PolicyDenyBuilder::new(
-                    ctx.profile_id.clone(),
-                    AuditAction::Authenticate,
-                    &normalized_rp,
-                    PolicyDenyReason::AllowCredentialsMismatch,
-                )
-                .build();
-                let _ = self.audit_gate.record(deny_event);
-                return Err(ProtocolError::new(
-                    ErrorCode::Forbidden,
-                    "credential not in allow_credentials",
-                    RecommendedAction::FixRequest,
-                ));
+        let mut candidates = Vec::new();
+        for credential_ref in &credential_scope {
+            if let Ok(credential_id) =
+                Self::resolve_credential_id(&mut storage, credential_ref, &normalized_rp)
+            {
+                let encoded_id = b64u_encode(&credential_id);
+                if !req.allow_credentials.is_empty() && !req.allow_credentials.contains(&encoded_id)
+                {
+                    continue;
+                }
+                if let Ok(credential) = storage.read(&credential_id) {
+                    if credential.extensions.cred_protect == Some(2)
+                        && !uv
+                        && req.allow_credentials.is_empty()
+                    {
+                        continue;
+                    }
+                    candidates.push((credential_id, credential_ref.clone(), credential.created));
+                }
             }
         }
+
+        if candidates.is_empty() && !req.allow_credentials.is_empty() {
+            self.record_policy_deny(
+                ctx,
+                &normalized_rp,
+                PolicyDenyReason::AllowCredentialsMismatch,
+            );
+            return Err(ProtocolError::new(
+                ErrorCode::Forbidden,
+                "allowCredentials does not contain a permitted credential",
+                RecommendedAction::FixRequest,
+            ));
+        }
+
+        let cred_id = Self::select_credential(
+            candidates,
+            &req.allow_credentials,
+            &ctx.profile_config.credential_selection,
+        )
+        .inspect_err(|_| {
+            self.record_policy_deny(ctx, &normalized_rp, PolicyDenyReason::CredentialNotMatch);
+        })?;
 
         let allow_event = PolicyAllowBuilder::new(
             ctx.profile_id.clone(),
@@ -966,6 +1260,14 @@ impl SignHandler {
                 RecommendedAction::FixRequest,
             )
         })?;
+        if cred.extensions.cred_protect == Some(3) && !uv {
+            self.record_policy_deny(ctx, &normalized_rp, PolicyDenyReason::UvRequired);
+            return Err(ProtocolError::new(
+                ErrorCode::Forbidden,
+                "credential protection policy requires user verification",
+                RecommendedAction::FixRequest,
+            ));
+        }
 
         let new_sign_count =
             if self.security_config.constant_signature_counter || !cred.discoverable {
@@ -1012,16 +1314,16 @@ impl SignHandler {
         }
 
         let backup_flags = cred.backup_state.flags();
-        let up = ceremony_policy.user_presence != passless_core::agent::UserPresenceSource::None;
-        let uv = req.user_verification
-            || ceremony_policy.user_verification
-                != passless_core::agent::UserVerificationSource::None;
 
         let authenticator_data =
             build_authenticator_data(&normalized_rp, up, uv, backup_flags, new_sign_count);
 
-        let client_data_json =
-            build_client_data_json(&req.origin, &req.challenge_b64u, req.cross_origin);
+        let client_data_json = build_client_data_json(
+            &req.origin,
+            &req.challenge_b64u,
+            req.cross_origin,
+            req.top_origin.as_deref(),
+        );
         let client_data_hash = Sha256::digest(&client_data_json);
 
         let sig_input = [&authenticator_data[..], &client_data_hash[..]].concat();
@@ -1045,6 +1347,59 @@ impl SignHandler {
                 client_data_json_b64u: b64u_encode(&client_data_json),
             },
         ))
+    }
+
+    fn select_credential(
+        mut candidates: Vec<(Vec<u8>, CredentialRef, i64)>,
+        allow_credentials: &[String],
+        selection: &CredentialSelection,
+    ) -> Result<Vec<u8>, ProtocolError> {
+        if candidates.is_empty() {
+            return Err(ProtocolError::new(
+                ErrorCode::NotFound,
+                "no permitted credential matches this WebAuthn request",
+                RecommendedAction::FixRequest,
+            ));
+        }
+
+        if !allow_credentials.is_empty() {
+            for allowed in allow_credentials {
+                if let Some(index) = candidates
+                    .iter()
+                    .position(|(id, _, _)| b64u_encode(id) == *allowed)
+                {
+                    return Ok(candidates.swap_remove(index).0);
+                }
+            }
+        }
+
+        match selection {
+            CredentialSelection::Credential(reference) => candidates
+                .into_iter()
+                .find(|(_, candidate_ref, _)| candidate_ref == reference)
+                .map(|(id, _, _)| id)
+                .ok_or_else(|| {
+                    ProtocolError::new(
+                        ErrorCode::NotFound,
+                        "configured credential does not match this WebAuthn request",
+                        RecommendedAction::FixRequest,
+                    )
+                }),
+            CredentialSelection::Single if candidates.len() != 1 => Err(ProtocolError::new(
+                ErrorCode::Conflict,
+                "multiple discoverable credentials match; configure credential_selection",
+                RecommendedAction::FixRequest,
+            )),
+            CredentialSelection::Single => Ok(candidates.remove(0).0),
+            CredentialSelection::FirstMatching => {
+                candidates.sort_by(|a, b| a.0.cmp(&b.0));
+                Ok(candidates.remove(0).0)
+            }
+            CredentialSelection::Newest => {
+                candidates.sort_by(|a, b| b.2.cmp(&a.2).then_with(|| a.0.cmp(&b.0)));
+                Ok(candidates.remove(0).0)
+            }
+        }
     }
 
     fn resolve_credential_id(
@@ -1085,7 +1440,7 @@ mod tests {
 
     #[test]
     fn test_client_data_json_no_cross_origin() {
-        let cdj = build_client_data_json("https://example.com", "dGVzdA", false);
+        let cdj = build_client_data_json("https://example.com", "dGVzdA", false, None);
         let expected =
             br#"{"type":"webauthn.get","challenge":"dGVzdA","origin":"https://example.com"}"#;
         assert_eq!(cdj, expected);
@@ -1093,21 +1448,26 @@ mod tests {
 
     #[test]
     fn test_client_data_json_with_cross_origin() {
-        let cdj = build_client_data_json("https://example.com", "dGVzdA", true);
-        let expected = br#"{"type":"webauthn.get","challenge":"dGVzdA","origin":"https://example.com","crossOrigin":true}"#;
+        let cdj = build_client_data_json(
+            "https://example.com",
+            "dGVzdA",
+            true,
+            Some("https://top.example"),
+        );
+        let expected = br#"{"type":"webauthn.get","challenge":"dGVzdA","origin":"https://example.com","crossOrigin":true,"topOrigin":"https://top.example"}"#;
         assert_eq!(cdj, expected);
     }
 
     #[test]
     fn test_client_data_json_cross_origin_false_omitted() {
-        let cdj = build_client_data_json("https://example.com", "dGVzdA", false);
+        let cdj = build_client_data_json("https://example.com", "dGVzdA", false, None);
         let s = std::str::from_utf8(&cdj).unwrap();
         assert!(!s.contains("crossOrigin"));
     }
 
     #[test]
     fn test_client_data_json_escaping() {
-        let cdj = build_client_data_json("https://ex\"ample.com", "dGVzdA", false);
+        let cdj = build_client_data_json("https://ex\"ample.com", "dGVzdA", false, None);
         let s = std::str::from_utf8(&cdj).unwrap();
         assert!(s.contains("ex\\\"ample.com"));
     }
@@ -1159,9 +1519,33 @@ mod tests {
     }
 
     #[test]
-    fn test_origin_verification_rejects_port() {
-        assert!(!verify_origin_structural(
+    fn test_origin_verification_accepts_port() {
+        assert!(verify_origin_structural(
             "https://example.com:8443",
+            "example.com"
+        ));
+    }
+
+    #[test]
+    fn test_origin_verification_accepts_rp_subdomain_origin() {
+        assert!(verify_origin_structural(
+            "https://login.example.com",
+            "example.com"
+        ));
+    }
+
+    #[test]
+    fn test_cross_origin_requires_top_origin() {
+        assert!(!verify_origin_context(
+            "https://login.example.com",
+            None,
+            true,
+            "example.com"
+        ));
+        assert!(verify_origin_context(
+            "https://login.example.com",
+            Some("https://portal.example.net"),
+            true,
             "example.com"
         ));
     }
@@ -1393,6 +1777,20 @@ mod tests {
     }
 
     #[test]
+    fn test_registry_request_budget_is_shared_for_one_bearer() {
+        let registry = SignContextRegistry::new();
+        let token = generate_bearer_token().unwrap();
+        let first = registry.request_budget(&token, 2).unwrap();
+        let second = registry.request_budget(&token, 2).unwrap();
+
+        assert_eq!(first.claim(b"register-operation"), RequestClaim::Claimed);
+        assert_eq!(second.claim(b"register-operation"), RequestClaim::Replayed);
+        assert_eq!(second.claim(b"sign-operation"), RequestClaim::Claimed);
+        assert_eq!(first.claim(b"third-operation"), RequestClaim::Exhausted);
+        assert!(registry.request_budget(&token, 3).is_err());
+    }
+
+    #[test]
     fn test_registry_unknown_token() {
         let registry = SignContextRegistry::new();
         assert!(registry.lookup_bound("nonexistent").is_none());
@@ -1549,6 +1947,7 @@ mod tests {
         let handle = server.serve(registry);
         let body = serde_json::to_vec(&SignAssertionRequest {
             origin: "https://example.com".to_string(),
+            top_origin: None,
             rp_id: "example.com".to_string(),
             challenge_b64u: "dGVzdA".to_string(),
             allow_credentials: vec![],
@@ -1885,6 +2284,7 @@ mod tests {
         let handle = server.serve(registry);
         let body = serde_json::to_vec(&SignAssertionRequest {
             origin: "https://example.com".to_string(),
+            top_origin: None,
             rp_id: "example.com".to_string(),
             challenge_b64u: "dGVzdA".to_string(),
             allow_credentials: vec![],
@@ -2216,6 +2616,10 @@ mod tests {
                     as Box<dyn CredentialStorage>));
 
                 let profile_config = AgentProfileConfig {
+                    max_operations: 64,
+                    credential_selection: passless_core::agent::config::CredentialSelection::Single,
+                    human_verification_prompt:
+                        passless_core::agent::config::HumanVerificationPrompt::Always,
                     mode: AgentMode::Isolated,
                     principal_user: String::new(),
                     rp_ids: vec!["example.com".to_string()],
@@ -2230,8 +2634,8 @@ mod tests {
                         register: AgentCeremonyPolicy::deny(),
                         authenticate: AgentCeremonyPolicy {
                             authorization: AgentAuthorization::Allow,
-                            user_presence: UserPresenceSource::Policy,
-                            user_verification: UserVerificationSource::Policy,
+                            user_presence: UserPresenceSource::Agent,
+                            user_verification: UserVerificationSource::Agent,
                         },
                     }],
                     device: DeviceIdentity {
@@ -2333,6 +2737,7 @@ mod tests {
             fn make_req(&self) -> SignAssertionRequest {
                 SignAssertionRequest {
                     origin: "https://example.com".to_string(),
+                    top_origin: None,
                     rp_id: "example.com".to_string(),
                     challenge_b64u: "dGVzdA".to_string(),
                     allow_credentials: vec![],
@@ -2369,6 +2774,58 @@ mod tests {
             let ctx = f.make_ctx();
             let req = f.make_req();
             let result = handler.sign(&ctx, &req);
+            assert!(result.is_ok());
+            assert_eq!(f.key_provider.sign_calls(), 1);
+        }
+
+        #[test]
+        fn dynamic_grant_discovers_credential_created_after_approval() {
+            let f = TestFixture::new(true);
+            f.storage.lock().unwrap().delete(&[1u8; 32]).unwrap();
+
+            let grant_request = f
+                .policy_runtime
+                .admin_request_dynamic_grant(GrantRequestParams {
+                    profile_id: f.profile_id.clone(),
+                    session_id: passless_core::agent::PrincipalSessionId::new(),
+                    endpoint_id: passless_core::agent::EndpointId::new(),
+                    principal_digest: [0u8; 32],
+                    rp_ids: vec!["example.com".to_string()],
+                    credentials: vec![],
+                    requested_ttl_secs: 300,
+                })
+                .unwrap();
+            let dynamic_grant_id = f
+                .policy_runtime
+                .admin_approve_grant(&grant_request, &intent::admin_authority())
+                .unwrap();
+
+            let new_credential_id = vec![2u8; 32];
+            let generated = SoftwareCredentialKeyProvider.generate(-7).unwrap();
+            get_write_counting_storage(&f.storage).add_cred(soft_fido2::Credential {
+                id: new_credential_id.clone(),
+                rp: RelyingParty::new("example.com".into()),
+                user: User::new(vec![4, 5, 6]),
+                sign_count: 0,
+                alg: -7,
+                key: generated.key,
+                created: 1,
+                discoverable: true,
+                backup_state: CredentialBackupState::NotEligible,
+                extensions: soft_fido2::Extensions::default(),
+            });
+
+            let mut profile_config = f.profile_config.clone();
+            profile_config.credential_refs = None;
+            let ctx = SignContext {
+                profile_id: f.profile_id.clone(),
+                active_grant_id: dynamic_grant_id,
+                profile_config,
+            };
+            let mut req = f.make_req();
+            req.allow_credentials = vec![b64u_encode(&new_credential_id)];
+
+            let result = f.make_handler().sign(&ctx, &req);
             assert!(result.is_ok());
             assert_eq!(f.key_provider.sign_calls(), 1);
         }
@@ -2544,6 +3001,7 @@ mod tests {
                 handles.push(std::thread::spawn(move || {
                     let req = SignAssertionRequest {
                         origin: "https://example.com".to_string(),
+                        top_origin: None,
                         rp_id: "example.com".to_string(),
                         challenge_b64u: "dGVzdA".to_string(),
                         allow_credentials: vec![],
@@ -2755,6 +3213,10 @@ mod tests {
                     grant_rp_ids.iter().map(|s| s.to_string()).collect();
 
                 let profile_config = AgentProfileConfig {
+                    max_operations: 64,
+                    credential_selection: passless_core::agent::config::CredentialSelection::Single,
+                    human_verification_prompt:
+                        passless_core::agent::config::HumanVerificationPrompt::Always,
                     mode: AgentMode::Isolated,
                     principal_user: String::new(),
                     rp_ids: rp_id_strings.clone(),
@@ -2849,8 +3311,8 @@ mod tests {
                     register: AgentCeremonyPolicy::deny(),
                     authenticate: AgentCeremonyPolicy {
                         authorization: AgentAuthorization::Allow,
-                        user_presence: UserPresenceSource::Policy,
-                        user_verification: UserVerificationSource::Policy,
+                        user_presence: UserPresenceSource::Agent,
+                        user_verification: UserVerificationSource::Agent,
                     },
                 };
                 Self::new(vec![rule], vec!["example.com"])
@@ -2878,6 +3340,7 @@ mod tests {
             fn make_req(&self) -> SignAssertionRequest {
                 SignAssertionRequest {
                     origin: "https://example.com".to_string(),
+                    top_origin: None,
                     rp_id: "example.com".to_string(),
                     challenge_b64u: "dGVzdA".to_string(),
                     allow_credentials: vec![],
@@ -2893,8 +3356,8 @@ mod tests {
                 register: AgentCeremonyPolicy::deny(),
                 authenticate: AgentCeremonyPolicy {
                     authorization: AgentAuthorization::Allow,
-                    user_presence: UserPresenceSource::Policy,
-                    user_verification: UserVerificationSource::Policy,
+                    user_presence: UserPresenceSource::Agent,
+                    user_verification: UserVerificationSource::Agent,
                 },
             }
         }
@@ -3070,8 +3533,8 @@ mod tests {
                 register: AgentCeremonyPolicy::deny(),
                 authenticate: AgentCeremonyPolicy {
                     authorization: AgentAuthorization::Allow,
-                    user_presence: UserPresenceSource::Policy,
-                    user_verification: UserVerificationSource::Policy,
+                    user_presence: UserPresenceSource::Agent,
+                    user_verification: UserVerificationSource::Agent,
                 },
             };
             let mut f = AuditTestFixture::new(vec![rule], vec!["example.com"]);
@@ -3259,6 +3722,7 @@ mod tests {
         ) -> Vec<u8> {
             serde_json::to_vec(&SignAssertionRequest {
                 origin: origin.to_string(),
+                top_origin: None,
                 rp_id: rp_id.to_string(),
                 challenge_b64u: challenge.to_string(),
                 allow_credentials,
@@ -3504,7 +3968,7 @@ mod tests {
         }
 
         #[test]
-        fn http_replay_attack_same_challenge() {
+        fn http_replay_attack_same_challenge_is_rejected() {
             let (shutdown, addr, _registry, token, _f, handle) = setup_bound(false);
             let body = sign_request_body(
                 "https://example.com",
@@ -3516,10 +3980,7 @@ mod tests {
             let req = format_sign_request(&token, &body);
             let resp1 = http_request(addr, &req, &body);
             assert!(resp1.contains("200 OK"));
-            let resp2 = http_request(addr, &req, &body);
-            assert!(resp2.contains("200 OK"));
             let parsed1: serde_json::Value = serde_json::from_str(http_body(&resp1)).unwrap();
-            let parsed2: serde_json::Value = serde_json::from_str(http_body(&resp2)).unwrap();
             let auth1 = parsed1
                 .get("sign_assertion_result")
                 .unwrap()
@@ -3527,32 +3988,12 @@ mod tests {
                 .unwrap()
                 .as_str()
                 .unwrap();
-            let auth2 = parsed2
-                .get("sign_assertion_result")
-                .unwrap()
-                .get("authenticator_data_b64u")
-                .unwrap()
-                .as_str()
-                .unwrap();
-            let counter1 = extract_counter(auth1);
-            let counter2 = extract_counter(auth2);
-            assert_eq!(counter1, 1);
-            assert_eq!(counter2, 2);
-            let sig1 = parsed1
-                .get("sign_assertion_result")
-                .unwrap()
-                .get("signature_b64u")
-                .unwrap()
-                .as_str()
-                .unwrap();
-            let sig2 = parsed2
-                .get("sign_assertion_result")
-                .unwrap()
-                .get("signature_b64u")
-                .unwrap()
-                .as_str()
-                .unwrap();
-            assert_ne!(sig1, sig2);
+            assert_eq!(extract_counter(auth1), 1);
+
+            let resp2 = http_request(addr, &req, &body);
+            assert!(resp2.contains("409 Conflict"));
+            assert!(http_body(&resp2).contains("replayed_operation"));
+
             shutdown.store(true, Ordering::Release);
             handle.join().unwrap();
         }

--- a/cmd/passless/src/agent/storage_factory.rs
+++ b/cmd/passless/src/agent/storage_factory.rs
@@ -219,6 +219,42 @@ pub fn create_storage_bundle(config: AgentStorageConfig) -> Result<AgentStorageB
     create_storage_bundle_with_options(config, false)
 }
 
+/// Resolve the signing provider that belongs to an agent storage backend.
+///
+/// Portable TPM storage must never silently fall back to the software provider.
+/// A fresh provider instance uses the same provisioned TPM parent and keeps its
+/// own TPM context, while the backend operation lock serializes credential use.
+pub fn key_provider_for_config(
+    config: &AgentStorageConfig,
+) -> Result<Arc<dyn soft_fido2::CredentialKeyProvider + Send + Sync>> {
+    match config {
+        #[cfg(feature = "tpm")]
+        AgentStorageConfig::Tpm {
+            path,
+            tcti,
+            portable: true,
+            ..
+        } => {
+            let tcti = if tcti.is_empty() {
+                None
+            } else {
+                Some(tcti.clone())
+            };
+            let provider =
+                crate::storage::tpm::portable::TpmCredentialKeyProvider::new(path.clone(), tcti)
+                    .map_err(|e| {
+                        Error::Storage(format!(
+                            "failed to create portable TPM key provider at {}: {:?}",
+                            path.display(),
+                            e
+                        ))
+                    })?;
+            Ok(Arc::new(provider))
+        }
+        _ => Ok(Arc::new(soft_fido2::SoftwareCredentialKeyProvider)),
+    }
+}
+
 pub fn create_storage_bundle_with_options(
     config: AgentStorageConfig,
     allow_create_without_prompt: bool,
@@ -620,6 +656,10 @@ mod tests {
         use passless_core::agent::{AgentMode, DeviceIdentity};
 
         let profile = AgentProfileConfig {
+            max_operations: 64,
+            credential_selection: passless_core::agent::config::CredentialSelection::Single,
+            human_verification_prompt:
+                passless_core::agent::config::HumanVerificationPrompt::Always,
             mode: AgentMode::Isolated,
             principal_user: "test-user".to_string(),
             rp_ids: vec!["example.com".to_string()],
@@ -664,6 +704,10 @@ mod tests {
         use passless_core::agent::{AgentMode, DeviceIdentity};
 
         let profile = AgentProfileConfig {
+            max_operations: 64,
+            credential_selection: passless_core::agent::config::CredentialSelection::Single,
+            human_verification_prompt:
+                passless_core::agent::config::HumanVerificationPrompt::Always,
             mode: AgentMode::Isolated,
             principal_user: "test-user".to_string(),
             rp_ids: vec!["example.com".to_string()],

--- a/cmd/passless/src/main.rs
+++ b/cmd/passless/src/main.rs
@@ -499,6 +499,7 @@ fn run() -> Result<()> {
                         shared_storage.clone(),
                         pin_storage.clone(),
                         operation_lock.clone(),
+                        Arc::new(SoftwareCredentialKeyProvider),
                         &config.agents,
                         security_config,
                         pin_config,
@@ -552,6 +553,7 @@ fn run() -> Result<()> {
                         shared_storage.clone(),
                         pin_storage.clone(),
                         operation_lock.clone(),
+                        Arc::new(SoftwareCredentialKeyProvider),
                         &config.agents,
                         security_config,
                         pin_config,
@@ -584,12 +586,20 @@ fn run() -> Result<()> {
                     if portable {
                         use storage::tpm::portable::build_portable_bundle;
 
-                        let (provider, storage, pin_storage) =
-                            build_portable_bundle(path.into(), Some(tcti), allow_storage_creation)?;
+                        let (provider, storage, pin_storage) = build_portable_bundle(
+                            path.clone().into(),
+                            Some(tcti.clone()),
+                            allow_storage_creation,
+                        )?;
                         let boxed: Box<dyn CredentialStorage> = Box::new(storage);
                         let shared_storage = Arc::new(Mutex::new(boxed));
                         let pin_storage: Arc<Mutex<Box<dyn crate::pin_storage::PinStorage>>> =
                             Arc::new(Mutex::new(Box::new(pin_storage)));
+                        let agent_key_provider: Arc<dyn CredentialKeyProvider + Send + Sync> =
+                            Arc::new(storage::tpm::portable::TpmCredentialKeyProvider::new(
+                                path.clone().into(),
+                                Some(tcti.clone()),
+                            )?);
                         let service = AuthenticatorService::with_shared_storage_and_key_provider(
                             shared_storage.clone(),
                             Some(pin_storage.clone()),
@@ -602,6 +612,7 @@ fn run() -> Result<()> {
                             shared_storage.clone(),
                             pin_storage.clone(),
                             operation_lock.clone(),
+                            agent_key_provider,
                             &config.agents,
                             security_config,
                             pin_config,
@@ -647,6 +658,7 @@ fn run() -> Result<()> {
                             shared_storage.clone(),
                             pin_storage.clone(),
                             operation_lock.clone(),
+                            Arc::new(SoftwareCredentialKeyProvider),
                             &config.agents,
                             security_config,
                             pin_config,
@@ -782,8 +794,11 @@ fn run() -> Result<()> {
                 if portable {
                     use storage::tpm::portable::build_portable_bundle;
 
-                    let (provider, storage, pin_storage) =
-                        build_portable_bundle(path.into(), Some(tcti), allow_storage_creation)?;
+                    let (provider, storage, pin_storage) = build_portable_bundle(
+                        path.clone().into(),
+                        Some(tcti.clone()),
+                        allow_storage_creation,
+                    )?;
                     let pin_storage = Arc::new(Mutex::new(pin_storage));
                     let service = AuthenticatorService::with_pin_storage_and_key_provider(
                         storage,

--- a/cmd/passless/tests/agent_config_integration.rs
+++ b/cmd/passless/tests/agent_config_integration.rs
@@ -21,6 +21,9 @@ fn minimal_device() -> DeviceIdentity {
 
 fn isolated_profile() -> AgentProfileConfig {
     AgentProfileConfig {
+        max_operations: 64,
+        credential_selection: passless_core::agent::config::CredentialSelection::Single,
+        human_verification_prompt: passless_core::agent::config::HumanVerificationPrompt::Always,
         mode: AgentMode::Isolated,
         principal_user: "testuser".into(),
         rp_ids: vec!["example.com".into()],

--- a/cmd/passless/tests/agent_extension_behavioral.js
+++ b/cmd/passless/tests/agent_extension_behavioral.js
@@ -1245,7 +1245,11 @@ test("worker: derives origin and cross_origin from sender.url", async function()
     };
 
     const listener = sandbox._listeners[0];
-    const sender = { url: "https://sub.example.com/page" };
+    const sender = {
+      url: "https://sub.example.com/page",
+      tab: { url: "https://sub.example.com/top" },
+      frameId: 0,
+    };
     listener(
       {
         source: "passless-agent-broker",
@@ -1265,10 +1269,11 @@ test("worker: derives origin and cross_origin from sender.url", async function()
   assert.strictEqual(sandbox._fetchCalls.length, 1);
   const body = JSON.parse(sandbox._fetchCalls[0].opts.body);
   assert.strictEqual(body.origin, "https://sub.example.com");
+  assert.strictEqual(body.top_origin, "https://sub.example.com");
   assert.strictEqual(body.cross_origin, false);
 });
 
-test("worker: computes cross_origin=true for unrelated domain", async function() {
+test("worker: computes cross_origin=true for a cross-origin subframe", async function() {
   const sandbox = runWorkerTest(12345, "testtoken", function(sandbox) {
     sandbox._fetchResponse = {
       ok: true,
@@ -1276,7 +1281,11 @@ test("worker: computes cross_origin=true for unrelated domain", async function()
     };
 
     const listener = sandbox._listeners[0];
-    const sender = { url: "https://evil.com/page" };
+    const sender = {
+      url: "https://evil.com/page",
+      tab: { url: "https://example.com/top" },
+      frameId: 7,
+    };
     listener(
       {
         source: "passless-agent-broker",
@@ -1294,6 +1303,8 @@ test("worker: computes cross_origin=true for unrelated domain", async function()
 
   await flushPromises();
   const body = JSON.parse(sandbox._fetchCalls[0].opts.body);
+  assert.strictEqual(body.origin, "https://evil.com");
+  assert.strictEqual(body.top_origin, "https://example.com");
   assert.strictEqual(body.cross_origin, true);
 });
 

--- a/docs/agents/delegated-session.md
+++ b/docs/agents/delegated-session.md
@@ -1,239 +1,42 @@
-# Delegated-session mode
+# Delegated-session migration notice
 
-> **EXPERIMENTAL** — Agent mode is not yet validated for production use.
-> Autonomous (`allow`) assertions for delegated sessions are being redesigned to use a
-> daemon-loaded MV3 extension and localhost daemon signing channel instead of a UHID ceremony.
-> The `confirm` path remains an explicit human prompt. Implementation is **in progress**.
+`delegated-session` is no longer a supported agent mode. The former UHID-based design was removed because stock Chromium could still present a native credential-selection modal, preventing reliable autonomous browser operation.
 
-Delegated-session mode permits exact-policy authentication using configured human credentials and,
-when explicitly selected, registration into the human store. The RP sees the same account context
-as ordinary use by the human.
+Use [`same-user`](same-user.md) for bounded access to the existing human credential backend. Same-user retains the daemon-backed MV3 browser path selected by ADR 0005 while replacing the old one-shot delegated credential view with:
 
-## How delegated-session mode works
+- the real human storage, PIN service, key provider, signature counters, and operation lock;
+- exact RP and optional credential-reference scope;
+- a short-lived browser capability with a shared operation budget;
+- replay rejection and policy re-evaluation for every distinct request;
+- immediate authentication with a credential registered during the same session.
 
-```
-┌──────────────────────────────────────────────────────────────────┐
-│                       Passless Daemon (root)                      │
-│                                                                   │
-│  ┌─────────────────────────────────────────────────────────────┐ │
-│  │  Delegated Profile: "opencode"                              │ │
-│  │                                                              │ │
-│  │  ┌──────────────────┐   ┌────────────────────────────────┐  │ │
-│  │  │ Agent UHID        │   │ Human Credential Store         │  │ │
-│  │  │ Endpoint          │   │ (filtered view: 1 credential)  │  │ │
-│  │  │ /dev/hidraw*      │   │                                │  │ │
-│  │  └─────────┬─────────┘   └────────────────────────────────┘  │ │
-│  │            │                                                  │ │
-│  │  ┌─────────┴──────────────────────────────────────────────┐  │ │
-│  │  │  Policy Engine                                          │  │ │
-│  │  │  rp_id="github.com"                                     │  │ │
-│  │  │  authenticate: allow / policy UP / policy UV            │  │ │
-│  │  └─────────────────────────────────────────────────────────┘  │ │
-│  │                                                               │ │
-│  │  ┌────────────────────┐  ┌─────────────────────────────────┐ │ │
-│  │  │ One-shot Grant     │  │ Browser Lease                   │ │ │
-│  │  │ (consumed after    │  │ (ephemeral profile,             │ │ │
-│  │  │  one assertion)    │  │  auto-destroyed on expiry)      │ │ │
-│  │  └────────────────────┘  └─────────────────────────────────┘ │ │
-│  └─────────────────────────────────────────────────────────────┘ │
-│                                                                   │
-│  ┌─────────────────────────────────────────────────────────────┐ │
-│  │  Autonomous path (allow):                                   │ │
-│  │  MV3 extension → MAIN-world origin read → localhost sign    │ │
-│  │  channel → daemon validates origin/grant/policy → sign      │ │
-│  └─────────────────────────────────────────────────────────────┘ │
-└──────────────────────────────────────────────────────────────────┘
-         ▲                              ▲
-         │ CTAP                         │ CDP (pipe or port)
-         │                              │
-┌────────┴────────┐          ┌──────────┴──────────┐
-│  Agent Process  │          │  Ephemeral Browser   │
-│  (principal     │          │  (browser user)      │
-│   user)         │          │                      │
-└─────────────────┘          └──────────────────────┘
-```
+## Configuration migration
 
-## Semantics
-
-- The delegated credential is the same user credential. The RP cannot distinguish agent
-  use from human use.
-- One grant authorizes one passkey login, not all WebAuthn operations during the browser
-  lease.
-- A later WebAuthn operation requires another grant and fresh ceremony evidence.
-- Local browser-lease expiry is not RP-side session revocation.
-
-## Configuration
+Replace:
 
 ```toml
-[agents.profiles.opencode]
 mode = "delegated-session"
-principal_user = "passless-opencode"
-credential_refs = ["<credential-ref-hex>"]
 delegated_registration_storage = "human"
-max_grant_ttl = 120
-max_session_ttl = 900
-browser_command = ["firefox", "--profile", "<daemon-managed>"]
-start_url = "https://github.com/dashboard"
-browser_user = "passless-browser"
-browser_runtime_root = "/var/run/passless-browser"
-
-[[agents.profiles.opencode.rules]]
-rp_id = "github.com"
-register = { authorization = "confirm", user_presence = "human", user_verification = "human" }
-authenticate = { authorization = "allow", user_presence = "policy", user_verification = "policy" }
-
-[agents.profiles.opencode.device]
-name = "passless-agent-opencode"
-phys = "opencode-phys"
-uniq = "opencode-uniq"
-vendor_id = 4660
-product_id = 22136
 ```
 
-- `browser_user` must differ from `principal_user`.
-- `browser_runtime_root` must be owned by `browser_user` with mode 0700; the principal never sees the filesystem path.
-- `credential_refs` are non-secret SHA-256 digests over credential IDs.
-
-## Workflow
-
-1. Operator validates configuration:
-   ```bash
-   passless agent-admin profile check opencode
-   ```
-2. Operator launches the principal session:
-   ```bash
-   passless agent run --profile opencode -- /usr/local/bin/agent-command
-   ```
-
-   The `agent run` command requires an absolute executable path owned by root,
-   attaches stdio to the principal process, and waits for it to exit. See
-   [isolated mode](isolated.md#agent-run-behavior) for details.
-
-3. Inside the session, the principal requests delegation:
-   ```bash
-   passless agent --profile opencode delegation request \
-     --rp github.com --credential <credential-ref-hex> \
-     --session-ttl 900 --reason "CI deploy"
-   ```
-4. The daemon launches an ephemeral browser and evaluates the exact authentication rule.
-5. An `allow` rule is resolved autonomously by the daemon's policy check with no desktop
-   notification. A `confirm` rule is not auto-signed and remains an explicit human prompt path.
-   A `deny` rule fails closed. The configured UP/UV sources are recorded in audit.
-   The autonomous path uses a daemon-loaded MV3 extension that reads the frame origin via a
-   MAIN-world override and forwards the request to the daemon over a localhost bearer channel;
-   the daemon validates origin, grant, policy, credential ref, and audit before signing.
-   Implementation is **in progress**.
-6. The local browser lease starts at the clamped monotonic deadline.
-7. The grant and delegated credential view are consumed after the assertion.
-
-## Local lease vs RP revocation
-
-The local browser lease controls how long Passless keeps the ephemeral browser available.
-It does not alter the RP's cookie lifetime or prove that the RP invalidated its server-side
-session. If compromise or session copying is suspected, instruct users to revoke RP
-sessions through RP controls.
-
-## Browser lease lifecycle
-
-- Starts no earlier than successful CTAP assertion completion.
-- Uses a daemon-owned monotonic deadline.
-- Terminates on expiry, revocation, browser exit, principal exit, or daemon shutdown.
-- The ephemeral profile is removed after browser termination.
-- A profile whose cleanup fails is quarantined and never reused.
-
-## Revocation
-
-```bash
-passless agent-admin delegation list --profile opencode
-passless agent-admin delegation revoke <grant-id> --confirm
-passless agent-admin session revoke <session-id> --confirm
-```
-
-## Trusted (port) mode
-
-By default, delegated-session mode uses pipe-based CDP transport (`browser_cdp_expose = "pipe"`).
-The daemon mediates every CDP command through Unix pipes, and `browser_user` must differ from
-`principal_user`.
-
-Setting `browser_cdp_expose = "port"` switches to a trusted trust model where the agent connects
-directly to the browser's CDP WebSocket endpoint. This enables external tools like Playwright MCP,
-Puppeteer, and native DevTools clients.
-
-### Configuration
+with:
 
 ```toml
-[agents.profiles.opencode]
-mode = "delegated-session"
-principal_user = "alice"
-browser_cdp_expose = "port"
-browser_cdp_port = 9222
-credential_refs = ["<credential-ref-hex>"]
-max_grant_ttl = 120
-max_session_ttl = 900
-browser_command = ["chromium", "--user-data-dir", "<daemon-managed>"]
-start_url = "https://github.com/dashboard"
-browser_runtime_root = "/var/run/passless-browser"
-
-[[agents.profiles.opencode.rules]]
-rp_id = "github.com"
-register = { authorization = "deny", user_presence = "none", user_verification = "none" }
-authenticate = { authorization = "allow", user_presence = "policy", user_verification = "policy" }
-
-[agents.profiles.opencode.device]
-name = "passless-agent-opencode"
-phys = "opencode-phys"
-uniq = "opencode-uniq"
-vendor_id = 4660
-product_id = 22136
+mode = "same-user"
+max_session_ttl = 600
+max_operations = 16
+credential_selection = "single"
 ```
 
-- `browser_user` is optional; if omitted, defaults to `principal_user`.
-- `browser_cdp_port` is optional; 0 (default) lets the OS assign an ephemeral port.
-- `browser_command` extra args must not include `--remote-debugging-port` or
-  `--remote-debugging-address`; the daemon sets these automatically.
+Remove delegated-only storage/view fields. Keep exact RP rules, but replace the legacy evidence spelling `policy` with `agent` or use the aliases:
 
-### Workflow
+```toml
+[[agents.profiles.opencode.rules]]
+rp_id = "github.com"
+register = "deny"
+authenticate = "autonomous"
+```
 
-1. Operator configures the profile with `browser_cdp_expose = "port"`.
-2. Operator launches the principal session:
-   ```bash
-   passless agent run --profile opencode -- /usr/local/bin/agent-command
-   ```
-3. Inside the session, the principal requests delegation:
-   ```bash
-   passless agent --profile opencode delegation request \
-     --rp github.com --credential <credential-ref-hex> \
-     --session-ttl 900 --reason "Playwright automation"
-   ```
-4. The daemon performs the WebAuthn ceremony (confirm-policy human prompt) or, for allow-policy
-   assertions, loads an MV3 extension that routes the assertion through the daemon signing
-   channel. Chromium is launched with
-   `--remote-debugging-port=<N> --remote-debugging-address=127.0.0.1`.
-5. The daemon reads Chromium's `DevToolsActivePort` file to discover the WebSocket URL.
-6. The daemon writes the full WebSocket URL to `<runtime_dir>/cdp-endpoint`
-   (mode 0600, owned by principal user).
-7. The agent reads the CDP endpoint and connects with Playwright:
-   ```javascript
-   const browser = await chromium.connectOverCDP('ws://127.0.0.1:9222/devtools/browser/<uuid>');
-   ```
-8. The agent has full browser control: snapshots, clicks, typing, navigation.
-9. Lease expiry or revocation kills the browser process.
+The parser accepts `policy` as a temporary alias for `agent`, but new configuration and audit output use `agent`.
 
-### What changes in port mode
-
-- `browser-control` returns an error directing the caller to use the CDP endpoint directly.
-- `browser-status` includes a `cdp_endpoint` field with the WebSocket URL.
-- No daemon mediation of CDP commands after the ceremony.
-- Audit records the exposure mode at lease creation.
-- The credential private key never leaves the daemon; only the authenticated session (cookies)
-  is exposed to the agent.
-
-### When to use port mode
-
-- Single-user workstations where the operator fully trusts the agent.
-- Automation that requires rich browser interaction (Playwright MCP, accessibility snapshots,
-  element targeting, auto-waiting).
-- Environments where per-command daemon round-trips are unacceptable.
-
-Do not use port mode for multi-user systems, production environments, or untrusted agents.
-Use pipe mode instead. See [security](security.md#port-mode-threat-model) for the full threat model.
+See [same-user.md](same-user.md), [configuration.md](configuration.md), and [security.md](security.md).

--- a/docs/agents/same-user.md
+++ b/docs/agents/same-user.md
@@ -1,0 +1,96 @@
+# Same-user mode
+
+> **EXPERIMENTAL** — Same-user mode deliberately gives the configured agent bounded authority to act as the human user for exact relying parties. Review the policy and verification evidence before enabling it.
+
+`same-user` uses the daemon's existing human credential backend. It does not copy, reopen, or export passkey material. Registration and authentication are performed by the daemon through the same storage, key provider, operation lock, signature counters, and local-verification services used by the human authenticator.
+
+This is a trust mode, not an isolation mode. An autonomous same-user agent can authenticate as the human account to every RP and credential permitted by its profile while its session is active. Exact RP rules, credential selectors, TTLs, operation budgets, replay protection, and audit bound that authority; they do not turn the agent into a separate identity.
+
+## Minimal autonomous profile
+
+```toml
+[agents]
+enabled = true
+audit_path = "/var/lib/passless-agent/audit/events.jsonl"
+
+[agents.profiles.opencode]
+mode = "same-user"
+principal_user = "passless-opencode"
+browser_command = ["chromium"]
+browser_runtime_root = "/run/passless-agent/opencode"
+max_session_ttl = 600
+max_operations = 16
+credential_selection = "single"
+
+[[agents.profiles.opencode.rules]]
+rp_id = "github.com"
+authenticate = "autonomous"
+register = "deny"
+```
+
+The aliases normalize as follows:
+
+- `"deny"`: deny authorization, no UP, no UV.
+- `"autonomous"`: automatic authorization with agent-derived UP and UV.
+- `"supervised"`: human confirmation with human-derived UP and UV.
+
+The expanded table form remains available:
+
+```toml
+authenticate = {
+  authorization = "allow",
+  user_presence = "agent",
+  user_verification = "agent"
+}
+```
+
+## Credential scope
+
+Omitting `credential_refs` permits discovery of human credentials matching an allowed RP. Narrow the profile to explicit non-secret credential references when practical:
+
+```toml
+credential_refs = ["<credential-ref-hex>"]
+credential_selection = "credential:<credential-ref-hex>"
+```
+
+Other selection policies are `single`, `first-matching`, and `newest`. `single` fails closed when more than one eligible credential exists.
+
+## Registration
+
+Registration is denied unless the exact RP rule explicitly permits it. Autonomous same-user registration writes the new passkey into the human backend through its configured key provider. A newly registered credential is immediately eligible for later authentication in the same bounded browser session, subject to the rule and optional credential scope.
+
+```toml
+[[agents.profiles.bootstrap.rules]]
+rp_id = "git.example.com"
+register = "autonomous"
+authenticate = "autonomous"
+```
+
+Disable autonomous registration after enrollment when it is no longer needed.
+
+## Session and operation bounds
+
+A browser session receives a random bearer capability, a TTL, and a shared `max_operations` budget covering both registration and authentication. Every WebAuthn request is independently validated against the current policy, exact RP, caller origin, top origin, credential scope, and replay digest. Repeating the same operation body is rejected; distinct operations may continue until the shared budget or session expires.
+
+Human verification can be required by using `user_verification = "human"`. `human_verification_prompt = "always"` prompts whenever that provider is selected; `"when-required"` prompts only when the RP or credential requires UV. Human-derived evidence is never synthesized from an agent rule.
+
+## Browser path
+
+The daemon launches a stock browser with the Passless MV3 extension. A MAIN-world script intercepts `navigator.credentials.create()` and `navigator.credentials.get()`, while the service worker forwards a bounded request to the loopback daemon. The daemon validates and signs; the extension never receives private keys, PINs, storage handles, or arbitrary-signing authority.
+
+## Operational checks
+
+```bash
+passless agent-admin profile check opencode
+passless agent-admin policy check opencode
+passless agent run --profile opencode -- <agent-command>
+```
+
+Inside the principal session:
+
+```bash
+passless agent --profile opencode doctor
+passless agent --profile opencode capabilities
+```
+
+Review [security.md](security.md), [operations.md](operations.md), and [audit.md](audit.md) before deployment.

--- a/docs/decisions/0007-unified-agent-identity-modes.md
+++ b/docs/decisions/0007-unified-agent-identity-modes.md
@@ -1,0 +1,510 @@
+# ADR 0007: Unified Same-User and Isolated Agent Identity Modes
+
+- **Status:** Accepted
+- **Date:** 2026-08-06
+- **Decision owners:** Passless maintainers
+- **Implementation status:** Implemented in PR #402; automated software validation complete, environment-specific release gates pending
+- **Implementation plan:** [ADR 0007 implementation plan](../plans/adr-0007-agent-mode-redesign-implementation.md)
+- **Verification matrix:** [ADR 0007 verification matrix](../plans/adr-0007-verification-matrix.md)
+- **Related decisions:** [ADR 0001](0001-agent-authentication-security-model.md), [ADR 0002](0002-native-webauthn-agent-architecture.md), [ADR 0003](0003-portable-tpm-credential-keys.md), [ADR 0005](0005-delegated-autonomous-authentication-redesign.md), [ADR 0006](0006-agent-passkey-registration.md)
+- **Supersedes:** the credential-ownership, delegated-session, grant-consumption, and agent-evidence portions of ADRs 0001, 0005, and 0006 where they conflict with this decision
+- **Retains:** the daemon-backed browser extension transport selected by ADR 0005 and the autonomous registration capability selected by ADR 0006
+
+## Context
+
+Passless needs to support two materially different agent use cases without pretending that they provide the same security boundary.
+
+The first use case is the convenient one: an operator runs a trusted coding or browser agent as the same local user and wants it to authenticate as that user with the user's existing passkeys. The operator does not want a separate RP account, a second set of passkeys, or a human prompt for every WebAuthn ceremony. When explicitly configured for full autonomy, Passless should authorize every matching request, including requests that require user presence or user verification, while retaining short-lived authority, exact RP policy, daemon-side signing, and complete audit.
+
+The second use case is a stronger isolation boundary: an agent receives its own passkeys, storage namespace, key provider, browser state, and revocation lifecycle. Compromise of that agent should not directly expose or exercise the human credential namespace. This mode may also be autonomous, but the identity presented to the RP is an agent identity rather than the human's existing passkey identity.
+
+The current implementation does not provide a coherent version of both use cases:
+
+- `AgentMode` currently exposes only `isolated`.
+- The browser extension and `/sign` and `/register` endpoints exist, but production runtime wiring gives those handlers the profile credential store and a software key provider rather than a mode-selected credential backend.
+- The daemon receives the human storage, PIN storage, and operation lock, but the agent runtime does not use them.
+- The sign path can set the UV bit merely because the RP requested UV or the rule mentioned UV, without first resolving a concrete verification source.
+- Session grants are reusable until expiry, while the documentation describes one-shot ceremony authority.
+- Registration and authentication duplicate part of the authenticator behavior and do not consistently negotiate algorithms, enforce credential protection, or use the configured key provider.
+- Origin, top-origin, cross-origin, abort, timeout, and browser-object compatibility behavior is incomplete.
+
+Restoring the old UHID-based `delegated-session` implementation is not the answer. It reintroduces Chromium's native credential modal, duplicates the agent and human ceremony stacks, and cannot provide a reliable headless path. Sharing the human storage path with an isolated profile is also not the answer: it creates multiple storage objects and locks for the same namespace, makes counter and provider behavior unsafe, and obscures the intended trust boundary.
+
+The design must instead make credential ownership an explicit mode while keeping one operation pipeline.
+
+## Decision summary
+
+Passless will provide two agent identity modes:
+
+| Mode | RP identity | Credential backend | Trust statement |
+|---|---|---|---|
+| `same-user` | The user's existing passkeys and RP accounts | The daemon's existing human credential backend | The configured agent is fully trusted to act as the user within its RP policy |
+| `isolated` | Separate agent passkeys and RP accounts | A profile-specific credential backend | The agent cannot use or enumerate the human credential namespace |
+
+Both modes use the same daemon-backed browser extension, session capability, operation state machine, policy engine, evidence providers, signing and registration service, and audit pipeline.
+
+Autonomy is not a credential mode. It is an operation policy. Either identity mode may be autonomous, supervised, mixed by RP and action, or denied.
+
+## 1. Identity modes
+
+### 1.1 `same-user`
+
+A `same-user` profile uses the already-constructed human `CredentialBackendHandle`. It does not configure or reopen a storage path. The handle contains the exact storage, key provider, PIN or local-verification service, operation lock, counter behavior, and backend metadata used by the ordinary human authenticator.
+
+This mode intentionally means that the agent is trusted as the same authenticator user. A malicious or compromised agent with an active, sufficiently broad profile can authenticate as the human to every RP allowed by that profile. Exact RP rules, short session TTLs, credential selectors, operation binding, and audit limit accidents and authority duration; they do not turn a fully trusted same-user agent into an isolated principal.
+
+The private key remains in the configured backend and signatures remain daemon-mediated. For a portable TPM backend, the agent can exercise the key through the daemon but cannot export it. For an extractable software backend running under the same Unix identity, daemon exclusivity is an architectural and audit property rather than a hard boundary against that Unix user. The mode does not claim otherwise.
+
+A same-user profile:
+
+- has no profile storage path or profile PIN namespace;
+- may use existing human credentials matching an exact RP rule;
+- may optionally narrow access to explicit credential references;
+- may autonomously authenticate with existing credentials;
+- may autonomously register new credentials into the human backend when registration is explicitly allowed;
+- shares the human operation lock and signature counter state;
+- never receives raw keys, PINs, storage handles, or arbitrary-signing access.
+
+### 1.2 `isolated`
+
+An `isolated` profile uses a profile-specific `CredentialBackendHandle` containing separate credential storage, key provider, PIN or verification state, operation lock, and backend metadata.
+
+An isolated profile:
+
+- cannot enumerate, select, register into, or sign with the human backend;
+- cannot share a storage or PIN path with the human backend or another profile;
+- presents separate credentials to the RP;
+- can be revoked at the RP without revoking human credentials;
+- can independently choose software or portable-TPM key protection when supported;
+- may use the same autonomous or supervised evidence policies as same-user mode.
+
+The existing isolated UHID route may remain as a compatibility transport for non-extension clients, but it is not a second policy or signing implementation. It must delegate to the same backend, operation, evidence, and audit services as the extension path.
+
+## 2. One backend abstraction
+
+Runtime code will construct a `CredentialBackendHandle` for every credential namespace:
+
+```rust
+pub struct CredentialBackendHandle {
+    pub namespace: CredentialNamespace,
+    pub storage: Arc<dyn CredentialStorage>,
+    pub key_provider: Arc<dyn CredentialKeyProvider>,
+    pub verification: Arc<dyn LocalVerificationProvider>,
+    pub operation_lock: Arc<tokio::sync::Mutex<()>>,
+    pub capabilities: BackendCapabilities,
+}
+
+pub enum CredentialNamespace {
+    Human,
+    Isolated(ProfileId),
+}
+```
+
+The precise trait names may follow existing code, but the architectural invariant is normative: storage, key provider, verification state, and operation lock are selected together and cannot be independently substituted by an agent handler.
+
+`same-user` receives a clone of the human backend handle. `isolated` receives a handle created by the agent storage factory. The sign and register services accept only a backend handle selected by the runtime. They must not open paths, infer providers, or hardcode the software provider.
+
+This design makes software, pass-backed, legacy TPM, and portable TPM behavior follow the same provider selection as the human path. It also prevents two independently locked storage objects from updating one credential namespace.
+
+## 3. Session authority and one-shot operations
+
+An agent task runs inside a short-lived `AgentSession`. The session is the reusable authority envelope for one browser or agent task; it is not itself a WebAuthn operation authorization.
+
+A session is bound to at least:
+
+- profile ID and identity mode;
+- authenticated local principal and launcher instance;
+- browser runtime and extension instance;
+- policy generation;
+- creation and expiry times;
+- maximum operation count;
+- optional RP narrowing supplied at launch;
+- a random, high-entropy capability known to the extension worker and daemon.
+
+Recommended defaults are a ten-minute TTL and sixteen operations. Deployments may reduce those values. The daemon enforces a hard configured maximum TTL and operation count.
+
+Every intercepted `navigator.credentials.get()` or `create()` call creates a separate one-shot `OperationIntent`. The operation is bound to:
+
+- session ID;
+- action (`authenticate` or `register`);
+- exact RP ID;
+- caller origin, top origin, and cross-origin state;
+- a canonical hash of the public-key options and challenge;
+- selected credential reference or registration target;
+- matched rule and policy generation;
+- requested and resolved UP/UV evidence;
+- a unique operation nonce.
+
+The normative operation lifecycle is:
+
+```text
+Pending -> Authorized -> AuditReserved -> Executing -> Succeeded | Failed -> Consumed
+```
+
+Terminal success and failure both consume the operation. Replaying a nonce, request hash, or completed operation fails. A session may authorize a later operation only by creating a new intent and re-evaluating current policy.
+
+Policy reload, session revocation, browser shutdown, principal death, TTL expiry, or operation-count exhaustion invalidates further operations. In-flight operations fail closed when their policy generation or session validity changes before key use.
+
+This preserves the convenience of a short agent task while making every WebAuthn request independently bound, audited, and replay-resistant.
+
+## 4. Authorization and evidence are independent
+
+Each exact RP rule defines `authenticate` and `register` independently. The canonical policy model is:
+
+```text
+authorization: deny | confirm | allow
+user_presence: agent | human | none
+user_verification: agent | human | none
+```
+
+The meanings are:
+
+- `authorization = deny`: reject before credential enumeration or key access.
+- `authorization = confirm`: require a fresh trusted human approval bound to the operation intent.
+- `authorization = allow`: authorize automatically from the current administrator-owned rule.
+- `user_presence = agent`: prove that the active, bound agent session initiated this operation and set UP from that agent evidence.
+- `user_presence = human`: forward the operation to the human interaction path and set UP only after its bound presence result.
+- `user_presence = none`: do not set UP; fail if the operation cannot validly proceed without it.
+- `user_verification = agent`: verify the bound agent session as the authenticator user and set UV from that agent evidence.
+- `user_verification = human`: invoke the normal human PIN, biometric, or platform-verification path and set UV only after it succeeds.
+- `user_verification = none`: do not set UV; fail when the RP, credential policy, or authenticator configuration requires UV.
+
+`agent` is the canonical name for the existing policy-derived evidence concept. A temporary compatibility alias `policy` may be accepted during migration, but audit records and new documentation use `agent`.
+
+### 4.1 Autonomous operation
+
+A fully autonomous action uses:
+
+```text
+authorization = allow
+user_presence = agent
+user_verification = agent
+```
+
+This combination is valid in both identity modes and is capable of satisfying RP requests for required UP and UV without involving a human. It does not blindly set flags because the RP requested them. The daemon must first validate the active session capability, principal binding, policy generation, exact rule, operation nonce, audit reservation, and credential scope. That successful authenticator-local agent verification is the evidence source.
+
+This is an explicit trust choice. The RP receives ordinary WebAuthn UP and UV bits and cannot distinguish agent-session verification from human PIN or biometric verification. Audit must distinguish them. Operators enabling this policy accept that the agent is treated as the authenticator user and that RP-required UV no longer implies ceremony-time human participation.
+
+The WebAuthn requirement that UV be set only after authenticator-local user verification still applies. Merely matching an `allow` rule or seeing `userVerification = "required"` is insufficient. An expired, unbound, replayed, or otherwise invalid agent session must not produce UV.
+
+### 4.2 Human-forwarded operation
+
+Human interaction remains available by configuration. Examples include:
+
+- automatic authorization with human UV: `allow + agent presence + human verification`;
+- human approval but agent verification: `confirm + human presence + agent verification`;
+- fully human ceremony evidence: `confirm + human presence + human verification`.
+
+The human PIN or biometric result is handled inside the daemon's normal verification boundary. PIN values and verification secrets are never returned to the extension, browser page, agent process, audit log, or environment.
+
+A successful human interaction is bound to one operation intent and cannot be reused by a later operation unless a separate future ADR explicitly introduces a bounded human-verification cache.
+
+### 4.3 RP preference handling
+
+For `userVerification`:
+
+- `required`: the configured `agent` or `human` provider must succeed; `none` fails.
+- `preferred`: Passless applies the configured provider. `agent` verifies and sets UV. `human` follows the profile's human-prompt preference; by default it prompts and sets UV, while an optional `when-required` setting may omit UV without prompting.
+- `discouraged`: `agent` may still set UV when configured; `human` does not prompt unless explicitly configured `always`; `none` omits UV.
+
+Credential-level requirements such as `credProtect` are evaluated in addition to the RP request. A credential that requires UV cannot be used with `user_verification = none`. `agent` satisfies that requirement only after valid agent-session verification; `human` satisfies it only after human verification.
+
+For UP, the resolved evidence provider must produce a successful result whenever the selected authenticator behavior requires UP. The flags are derived exclusively from resolved evidence, never directly from request preferences.
+
+## 5. Policy syntax and ergonomic presets
+
+The normalized table form remains available:
+
+```toml
+[[agents.profiles.opencode.rules]]
+rp_id = "github.com"
+credential_selection = "single"
+authenticate = {
+  authorization = "allow",
+  user_presence = "agent",
+  user_verification = "agent"
+}
+register = {
+  authorization = "deny",
+  user_presence = "none",
+  user_verification = "none"
+}
+```
+
+For the common cases, the parser may expose exact aliases that normalize before validation:
+
+| Alias | Normalized policy |
+|---|---|
+| `"deny"` | `deny + none + none` |
+| `"autonomous"` | `allow + agent + agent` |
+| `"supervised"` | `confirm + human + human` |
+
+Example easy same-user configuration:
+
+```toml
+[agents]
+enabled = true
+audit_path = "/var/lib/passless/agent-audit.jsonl"
+
+[agents.profiles.opencode]
+mode = "same-user"
+principal_user = "alice"
+session_ttl = "10m"
+max_operations = 16
+
+[[agents.profiles.opencode.rules]]
+rp_id = "github.com"
+authenticate = "autonomous"
+register = "deny"
+credential_selection = "single"
+```
+
+Example isolated autonomous configuration:
+
+```toml
+[agents.profiles.release-bot]
+mode = "isolated"
+principal_user = "passless-release"
+session_ttl = "5m"
+max_operations = 8
+
+[agents.profiles.release-bot.storage.local]
+path = "/var/lib/passless-agent/release-bot/credentials"
+pin_path = "/var/lib/passless-agent/release-bot/pin"
+
+[[agents.profiles.release-bot.rules]]
+rp_id = "gitea.example.com"
+authenticate = "autonomous"
+register = "autonomous"
+credential_selection = "single"
+```
+
+Example same-user authentication with human UV:
+
+```toml
+[[agents.profiles.finance-assistant.rules]]
+rp_id = "bank.example"
+authenticate = {
+  authorization = "allow",
+  user_presence = "agent",
+  user_verification = "human"
+}
+register = "deny"
+```
+
+Configuration validation is fail-closed:
+
+- `same-user` rejects profile storage and profile PIN paths.
+- `isolated` requires a complete non-overlapping profile backend.
+- missing modes, rules, actions, evidence, audit, or selectors deny or fail startup as appropriate;
+- `deny` cannot assert evidence;
+- unsupported combinations fail configuration rather than silently degrading;
+- agent support remains disabled by default.
+
+## 6. Credential discovery and selection
+
+Same-user mode should not require duplicating every human credential reference in configuration. For an exact RP rule, the daemon may consider credentials in the selected backend whose RP ID matches the request and whose IDs satisfy `allowCredentials` when present.
+
+The page and agent never receive an unrestricted credential listing. Discovery and selection happen inside the daemon.
+
+Selection is deterministic:
+
+1. If `allowCredentials` is non-empty, choose the first RP-provided credential ID that exists in the allowed backend scope and satisfies configured credential restrictions.
+2. If the rule names an exact credential reference, use only that credential.
+3. If discoverable authentication yields exactly one permitted credential, use it.
+4. If multiple credentials remain, apply the explicit `credential_selection` rule.
+5. Without an explicit ambiguity policy, fail with a credential-selection error rather than selecting an arbitrary human account.
+
+Supported ambiguity policies are:
+
+- `single`: require exactly one candidate; this is the safe default;
+- `first-matching`: choose a stable order defined by credential ID, only when the operator explicitly accepts that behavior;
+- `newest`: choose the most recently created permitted credential;
+- `credential:<ref>`: select one exact configured credential.
+
+This allows a fully autonomous configuration to handle multi-account discoverable flows while ensuring that such selection is deliberate.
+
+## 7. Authentication and registration service
+
+The extension transport calls one daemon `WebAuthnOperationService` with separate authentication and registration methods. The service is responsible for the common pipeline:
+
+1. authenticate the session capability;
+2. create and bind the one-shot operation intent;
+3. derive and validate origin, top origin, cross-origin state, and exact RP ID;
+4. re-evaluate the current exact RP/action rule;
+5. resolve the mode-selected backend and credential scope;
+6. resolve authorization and UP/UV evidence providers;
+7. enforce RP options, credential protection, backend capabilities, and algorithm support;
+8. reserve durable audit before credential creation or use;
+9. acquire the backend operation lock;
+10. perform key generation or signing through the backend key provider;
+11. update storage and counters atomically where possible;
+12. finalize the audit result and consume the operation intent;
+13. return a structured WebAuthn response or a specific DOM-compatible error.
+
+Authentication must honor `allowCredentials`, discoverable credentials, user handles, signature counters, `credProtect`, supported extensions, and the backend's actual key provider.
+
+Registration must honor `pubKeyCredParams` in RP preference order, `excludeCredentials`, resident-key requirements, user-verification requirements, authenticator-selection constraints that Passless can represent, supported extensions, and attestation capability. It must not hardcode ES256 or claim unsupported attestation. Unsupported requirements return `NotSupportedError` before storage mutation.
+
+Registration targets the selected mode's backend. `same-user` writes to the human backend; `isolated` writes to the profile backend. Registration remains denied unless the exact RP rule explicitly allows it.
+
+## 8. Browser extension contract
+
+The daemon-backed MV3 extension remains the primary browser integration for both identity modes.
+
+The extension must:
+
+- intercept both `navigator.credentials.get()` and `create()` at `document_start`;
+- preserve non-public-key credential calls by delegating to the original API;
+- obtain caller origin from trusted extension sender metadata and cross-check it with the MAIN-world report;
+- capture or derive top origin and cross-origin state;
+- enforce the WebAuthn RP-ID relationship and supported iframe policy rather than equating origin host with RP ID;
+- keep the daemon bearer outside the MAIN world and page JavaScript;
+- serialize all relevant WebAuthn options without lossy conversions;
+- honor `AbortSignal`, RP timeout, extension timeout, and browser shutdown;
+- return appropriate DOMException names and messages;
+- expose the expected credential response methods and JSON serialization;
+- never fall back to native WebAuthn after an operation has been authorized by the agent path unless policy explicitly selects a supervised native path.
+
+Top-level frames are the minimum shipping requirement. Cross-origin iframe support ships only after origin, top-origin, Permissions Policy, and ancestor validation tests pass. Until then, cross-origin requests fail closed.
+
+A `chrome.webAuthenticationProxy` adapter may be added for RPs that require native `PublicKeyCredential` identity. It must use the same daemon operation service and must not weaken origin binding to solve request correlation.
+
+## 9. Audit model
+
+Audit is mandatory for agent credential operations. Failure to reserve or finalize the required audit record fails the operation.
+
+Each record includes at least:
+
+- session and operation identifiers or non-reversible hashes;
+- profile, identity mode, principal, and policy generation;
+- action, exact RP ID, origin, top origin, and cross-origin state;
+- credential namespace and credential reference when known;
+- authorization source;
+- requested UP/UV and resolved UP/UV source (`agent`, `human`, or absent);
+- credential-selection rule;
+- backend and key-provider type without secret material;
+- audit reservation, start, terminal result, and failure class;
+- signature counter before and after successful authentication when applicable.
+
+Audit must make same-user autonomous use unmistakable. A record that contains UV from agent-session verification must never be labeled or rendered as human PIN or biometric verification.
+
+## 10. Security invariants
+
+1. Agent support is disabled by default.
+2. Every profile has exactly one identity mode.
+3. Same-user mode uses the existing human backend handle; it never reopens the human storage path.
+4. Isolated mode cannot obtain the human backend handle.
+5. Storage, key provider, verification provider, and operation lock are selected as one backend unit.
+6. The extension, page, and agent never receive private keys, PINs, backend handles, or arbitrary signing APIs.
+7. Every operation matches one current exact RP/action rule before credential discovery and again before key use.
+8. Every operation is bound to one active session, request hash, challenge, origin context, action, and policy generation.
+9. Every operation is one-shot and consumed on all terminal results.
+10. Session reuse never implies operation reuse.
+11. UP and UV flags derive only from successful evidence-provider results.
+12. RP-requested UV alone never sets UV.
+13. Agent UV requires a valid bound agent-session verification result.
+14. Human UV requires the production human verification path.
+15. Credential protection and backend requirements may strengthen, but never weaken, the configured evidence requirement.
+16. Every credential creation or use has a durable pre-execution audit reservation.
+17. Signature counters and credential updates use the selected backend's shared operation lock.
+18. Policy reload, revocation, expiry, principal death, and browser shutdown invalidate outstanding authority.
+19. Same-user registration writes only to the human backend and only under an explicit exact-RP registration rule.
+20. Isolated registration writes only to its profile backend.
+21. Origin and RP validation follow WebAuthn rules; explicit ports are not rejected merely for being present in a valid origin.
+22. Unsupported algorithms, attestation, extensions, iframe contexts, or authenticator-selection requirements fail closed.
+23. Agent failure cannot disable or weaken the ordinary human authenticator path.
+
+## 11. Threat model and residual risk
+
+| Threat | Mitigation | Residual risk |
+|---|---|---|
+| Compromised same-user agent authenticates as the human | Explicit mode opt-in, exact RP rules, short sessions, operation limits, credential selectors, audit | This is fundamentally allowed by the mode; the agent is trusted as the user |
+| Isolated agent reaches human credentials | Separate backend handle, no path sharing, runtime type and validation boundaries | Host root or daemon compromise remains trusted |
+| Page replays an assertion request | One-shot nonce, request hash, atomic consumption, session and policy binding | A new valid request may still be authorized by an autonomous rule |
+| Local process calls loopback endpoints | High-entropy session capability, short TTL, profile binding, origin/RP/policy validation, operation replay protection | Same-user local compromise is inside the same-user trust boundary |
+| RP requests UV and daemon fabricates it | Evidence-provider result required before setting UV | RP cannot distinguish agent verification from human verification |
+| Wrong credential selected for a multi-account RP | Safe `single` default and explicit deterministic selection policies | `first-matching` is intentionally less account-specific |
+| Counter races corrupt human credentials | Shared backend handle and operation lock | Backend-specific crash consistency remains |
+| Extension reports a false origin | Cross-check trusted sender metadata, validate top origin and RP relationship, fail closed on unsupported frames | Browser or extension compromise is in the trusted computing base |
+| Autonomous registration creates unwanted passkeys | Separate registration rule, exact RP, session limits, exclude checks, audit | Broad same-user registration policy intentionally grants broad power |
+| Human PIN leaks to agent | Verification occurs inside daemon UI/provider and returns only evidence result | Compromised daemon or host remains trusted |
+
+## 12. Consequences
+
+### Positive
+
+- The convenient configuration actually uses the user's existing passkeys without duplicating storage.
+- The stronger configuration retains a genuine credential-ownership boundary.
+- Both modes share one implementation, reducing semantic drift and duplicated security bugs.
+- Full autonomy can satisfy required UP and UV through explicit agent-session verification.
+- Human approval and human UV remain available per RP and action.
+- Software and TPM providers are selected correctly through the same backend abstraction.
+- Short-lived sessions remain ergonomic while each WebAuthn operation becomes one-shot and replay-resistant.
+- Audit accurately distinguishes agent, human, and absent evidence.
+
+### Negative
+
+- Same-user autonomous mode deliberately removes ceremony-time human assurance for allowed RPs.
+- The RP cannot tell whether UV came from agent-session or human verification.
+- The backend abstraction, evidence providers, and operation state machine require substantial refactoring.
+- Correct browser-origin and WebAuthn compatibility behavior adds extension complexity.
+- Supporting autonomous registration into the human backend increases the impact of a broad rule.
+
+### Neutral
+
+- Isolated mode remains the recommended mode when the agent should not be equivalent to the human.
+- Workload identities, service accounts, scoped OAuth, and RP-native automation credentials remain preferable when available.
+- The daemon remains a signer and audit mediator, but same-user mode does not claim to defend the human account from the explicitly trusted agent.
+
+## 13. Alternatives considered
+
+### Restore the old `delegated-session` UHID path
+
+Rejected. Chromium's native modal prevents reliable headless use, the approach duplicates ceremony behavior, and it does not solve provider and storage wiring.
+
+### Point an isolated profile at the human storage path
+
+Rejected. It creates ambiguous ownership, duplicate locks and providers, unsafe counter behavior, and no honest isolation boundary.
+
+### Export human keys into a browser virtual authenticator
+
+Rejected for production. It bypasses daemon policy and audit, leaks keys into the browser process, and cannot support non-extractable TPM keys.
+
+### Require one human verification per agent session
+
+Rejected as the only autonomous model. It is a useful optional policy but does not satisfy the requirement for completely autonomous operation. Human verification remains selectable per action.
+
+### Always claim UV whenever an RP requests it
+
+Rejected. Flags must be based on a resolved evidence provider. Fully autonomous mode uses agent-session verification, not an unchecked request bit.
+
+### Make same-user and isolated separate implementations
+
+Rejected. Identity ownership changes backend selection, not the correctness requirements for origin validation, policy, evidence, audit, registration, signing, and replay protection.
+
+### Give the agent direct storage or key-provider access
+
+Rejected. Even for a fully trusted same-user profile, daemon mediation provides consistent provider support, counter serialization, policy enforcement, revocation, and audit while avoiding a general-purpose signing interface.
+
+## 14. Rollout decision
+
+Implementation ships behind an experimental feature gate until all mandatory verification rows pass. The rollout order is:
+
+1. backend abstraction and one-shot operation model;
+2. isolated mode through the unified service, preserving current behavior;
+3. same-user authentication with software backend;
+4. agent and human evidence providers, including required UV and `credProtect`;
+5. same-user registration;
+6. portable-TPM coverage for both modes;
+7. browser compatibility and approved iframe support;
+8. removal or deprecation of contradictory delegated-session documentation and code.
+
+No phase may enable same-user mode by default. The operator must explicitly configure the mode and exact RP rules.
+
+## References
+
+- W3C Web Authentication Level 3: <https://www.w3.org/TR/webauthn-3/>
+- Chrome `webAuthenticationProxy` API: <https://developer.chrome.com/docs/extensions/reference/api/webAuthenticationProxy>
+- [ADR 0007 implementation plan](../plans/adr-0007-agent-mode-redesign-implementation.md)
+- [ADR 0007 verification matrix](../plans/adr-0007-verification-matrix.md)

--- a/docs/plans/adr-0007-agent-mode-redesign-implementation.md
+++ b/docs/plans/adr-0007-agent-mode-redesign-implementation.md
@@ -1,0 +1,794 @@
+# ADR 0007 Implementation Plan: Unified Same-User and Isolated Agent Modes
+
+- **Status:** Proposed
+- **Date:** 2026-08-06
+- **Decision:** [ADR 0007](../decisions/0007-unified-agent-identity-modes.md)
+- **Verification matrix:** [ADR 0007 verification matrix](adr-0007-verification-matrix.md)
+- **Target branch:** `master`
+
+## Objective
+
+Implement one agent WebAuthn operation pipeline that supports:
+
+1. `same-user`: a fully trusted agent uses the existing human passkeys and backend;
+2. `isolated`: an agent uses a separate credential namespace and can be independently revoked;
+3. autonomous, supervised, denied, and mixed policies per exact RP and action;
+4. autonomous UP and UV through bound agent-session evidence;
+5. optional human approval or human PIN/platform verification by configuration;
+6. short-lived agent sessions with one-shot, replay-resistant WebAuthn operations;
+7. software and portable-TPM backends without exporting credential keys;
+8. autonomous authentication and registration through the daemon-backed browser extension.
+
+This plan deliberately refactors the current implementation before exposing `same-user`. Adding another mode directly to the current handlers would preserve incorrect provider wiring, request-derived UV, reusable operation authority, and duplicated authenticator behavior.
+
+## Delivery principles
+
+- Preserve ordinary human WebAuthn behavior throughout the migration.
+- Keep agent support and `same-user` disabled by default.
+- Make changes in reviewable increments with a working or explicitly gated tree after every PR.
+- Convert existing isolated behavior to the unified abstractions before enabling human-backend access.
+- Require a durable audit reservation before any credential creation or use.
+- Do not treat documentation or unit tests as proof of real browser interoperability; use real-RP E2E gates.
+- Do not delete the old path until the replacement has passed equivalent and stronger tests.
+- Prefer provider and authenticator primitives already used by the human path over new ad hoc crypto or data builders.
+
+## Current implementation gaps to close
+
+The implementation at commit `06722884` provides useful transport and policy pieces, but the following gaps are blockers for `same-user`:
+
+1. `AgentMode` exposes only `isolated`.
+2. `AgentRuntime::start_with_factories` receives human storage, PIN storage, and operation lock but does not use them.
+3. `/sign` and `/register` are wired to `profile.credential_storage` and a software provider regardless of the configured human or isolated backend.
+4. The sign handler may set UV from the RP request or policy presence rather than a resolved verification result.
+5. Session grants can authorize repeated calls until TTL expiry, including replay of the same request.
+6. Authentication selects from a grant's credential list before fully resolving request selection semantics.
+7. Registration hardcodes ES256 and does not completely honor `pubKeyCredParams`, authenticator selection, extensions, attestation, and UV requirements.
+8. Registration and authentication build part of the authenticator response independently of the ordinary authenticator path.
+9. Origin validation rejects valid origins with ports and does not implement the complete origin/RP relationship.
+10. Cross-origin state is derived from RP/domain comparison rather than same-origin-with-ancestors semantics.
+11. The extension does not fully preserve `AbortSignal`, timeout, DOMException, native response methods, or all option fields.
+12. Stale delegated-session documentation and implementation terminology conflict with the merged runtime.
+
+Each gap maps to a phase and verification row below.
+
+## Target architecture
+
+```text
+Agent launcher
+  |
+  | creates short-lived AgentSession
+  v
+Managed browser + Passless MV3 extension
+  |
+  | one request per navigator.credentials.get/create
+  | session capability + operation nonce
+  v
+Agent HTTP/IPC ingress
+  |
+  v
+WebAuthnOperationService
+  |-- validate session and request binding
+  |-- validate origin/RP/action policy
+  |-- select CredentialBackendHandle
+  |-- resolve authorization and UP/UV evidence
+  |-- reserve audit
+  |-- acquire backend operation lock
+  |-- authenticate or register via provider-aware service
+  |-- finalize audit and atomically consume operation
+  v
+CredentialBackendHandle
+  |-- Human backend for same-user
+  `-- Profile backend for isolated
+```
+
+The browser transport, policy, evidence, audit, and operation services are shared. Mode selection occurs only when resolving the backend and credential namespace.
+
+## Proposed module boundaries
+
+The exact file organization may change during implementation, but responsibilities must remain explicit.
+
+### `passless-core/src/agent/config.rs`
+
+- `AgentMode::{SameUser, Isolated}`.
+- Canonical evidence enum `Agent | Human | None`.
+- Policy aliases `deny`, `autonomous`, and `supervised`.
+- Session TTL, maximum operations, credential scope, and credential selection configuration.
+- Strict mode-specific validation.
+- Compatibility parsing for legacy `policy` evidence if retained.
+
+### `passless-core/src/agent/ids.rs`
+
+- `AgentSessionId`.
+- `OperationIntentId`.
+- Strong nonce or request token types.
+- Avoid interchanging session, operation, grant, and registration identifiers.
+
+### `passless-core/src/agent/protocol.rs`
+
+- Complete request/response types for authentication and registration.
+- Origin, top-origin, cross-origin, mediation, timeout, and extension inputs.
+- Structured errors that map to DOMException values.
+- Protocol versioning so extension and daemon incompatibility fails clearly.
+
+### `cmd/passless/src/agent/backend.rs` (new or equivalent)
+
+- `CredentialBackendHandle` and `CredentialNamespace`.
+- Backend capability description.
+- Human backend construction adapter.
+- Isolated backend construction adapter.
+- No handler may independently select storage or key providers.
+
+### `cmd/passless/src/agent/session.rs` (new or evolved from `grant.rs`)
+
+- Session creation, lookup, revocation, expiry, operation limits, and principal binding.
+- Capability registry.
+- Browser-runtime binding.
+- Policy-generation invalidation.
+
+### `cmd/passless/src/agent/operation.rs` (new)
+
+- One-shot `OperationIntent` state machine.
+- Canonical request hash.
+- Atomic state transitions and replay rejection.
+- Audit reservation identity.
+- Terminal consumption on success, expected errors, cancellation, panic boundaries, and timeout.
+
+### `cmd/passless/src/agent/evidence.rs` (new)
+
+- `AuthorizationProvider` or policy resolution.
+- `AgentSessionEvidenceProvider`.
+- `HumanInteractionEvidenceProvider`.
+- Resolved evidence object used to derive UP/UV flags.
+- No handler-level Boolean shortcuts.
+
+### `cmd/passless/src/agent/webauthn.rs` (new or common service)
+
+- Shared `WebAuthnOperationService`.
+- Authentication and registration orchestration.
+- Credential selection and discovery.
+- RP option and credential-policy validation.
+- Provider-aware key generation and signing.
+- Authenticator data and client data construction through shared, tested primitives.
+
+### Existing handlers
+
+- `sign.rs` becomes a thin HTTP adapter to the operation service.
+- `register.rs` becomes a thin HTTP adapter to the operation service.
+- `runtime.rs` constructs sessions, backends, and handlers; it does not own WebAuthn semantics.
+- `storage_factory.rs` returns complete backend handles rather than loosely related components.
+- `policy_engine.rs` returns normalized authorization/evidence decisions and policy-generation metadata.
+- `audit.rs` supports reservation/finalization tied to operation intent.
+
+### Browser extension assets
+
+- `main.js`: Web API interception and response facade only.
+- `broker.js`: isolated-world validation, request correlation, cancellation forwarding, and page/extension boundary.
+- `worker.js`: trusted sender metadata, session channel, daemon transport, lifecycle handling, and protocol-version checks.
+
+## Phase 0: Baseline, feature gate, and test freeze
+
+### Tasks
+
+1. Add an experimental feature/config gate for the unified pipeline, for example `agents.experimental_unified_webauthn = true`.
+2. Record the current isolated authentication and registration behavior in integration tests before refactoring.
+3. Add failing regression tests for known blockers:
+   - RP-requested UV must not set UV without evidence;
+   - replaying one operation request must fail;
+   - portable-TPM profile must not receive a software provider;
+   - human backend inputs must not be silently discarded in same-user construction;
+   - a valid HTTPS origin with an explicit port must pass structural parsing;
+   - cross-origin is not equivalent to frame host versus RP ID.
+4. Make existing extension and daemon protocol versions explicit.
+5. Document exact commands and fixtures for current real-RP software E2E.
+
+### Completion criteria
+
+- The current tree has a reproducible baseline test suite.
+- Known incorrect behavior is represented by ignored or expected-failure tests linked to this plan.
+- Unified behavior cannot be accidentally enabled in production.
+
+## Phase 1: Configuration and normalized policy model
+
+### Tasks
+
+1. Add `SameUser` to `AgentMode`.
+2. Replace or extend evidence naming so `agent`, `human`, and `none` are canonical.
+3. Parse aliases:
+   - `deny` -> `deny + none + none`;
+   - `autonomous` -> `allow + agent + agent`;
+   - `supervised` -> `confirm + human + human`.
+4. Add:
+   - `session_ttl`;
+   - `max_operations`;
+   - optional launch-time RP narrowing;
+   - optional credential refs;
+   - `credential_selection = single | first-matching | newest | credential:<ref>`;
+   - human verification prompt preference for `preferred` and `discouraged` requests.
+5. Enforce mode-specific validation:
+   - same-user rejects profile storage, PIN path, and agent-specific backend provider settings;
+   - isolated requires complete storage and rejects overlap with human and other profiles;
+   - missing RP action policy denies;
+   - deny cannot carry evidence;
+   - unknown values fail startup.
+6. Preserve `isolated` configuration compatibility.
+7. Optionally accept `policy` as an alias for `agent` for one release, with a startup warning.
+8. Add redacted config rendering and `passless agent doctor` diagnostics for the new fields.
+
+### Tests
+
+- TOML parsing for all canonical and alias forms.
+- Validation matrix for both modes.
+- Path-overlap regression tests.
+- Round-trip/redacted rendering tests.
+- Defaults prove support is disabled and same-user is never implied.
+
+### Completion criteria
+
+- Configuration can represent every ADR 0007 policy without runtime behavior changes.
+- Invalid or ambiguous configurations fail before starting agent endpoints.
+
+## Phase 2: Complete credential backend abstraction
+
+### Tasks
+
+1. Define `CredentialBackendHandle` with:
+   - namespace;
+   - credential storage;
+   - key provider;
+   - local verification provider or PIN service;
+   - shared operation lock;
+   - capability metadata.
+2. Refactor human daemon startup to expose one cloneable human backend handle.
+3. Refactor the agent storage factory to return complete isolated backend handles.
+4. Update `AgentRuntime::start` and `start_with_factories` to consume the human backend rather than separate ignored arguments.
+5. Mode resolution:
+   - same-user clones the human backend handle;
+   - isolated constructs a profile backend handle.
+6. Remove handler construction that hardcodes `SoftwareCredentialKeyProvider`.
+7. Ensure portable-TPM provider, sealed metadata, and operation lock travel together.
+8. Ensure a backend handle cannot be converted into a storage path or exposed through the agent protocol.
+9. Add namespace-aware metrics and diagnostics without exposing credential identifiers.
+
+### Tests
+
+- Pointer/identity test proving human UI and same-user agent use the same operation lock.
+- Software backend provider selection.
+- Portable-TPM backend provider selection.
+- Isolated profile receives a different namespace and lock.
+- Same-user cannot start without a human backend.
+- Isolated cannot receive a human backend through factory substitution.
+- Concurrent signature counter test across human and same-user operations.
+
+### Completion criteria
+
+- Every credential operation receives one complete backend handle.
+- No sign/register handler opens storage or chooses a provider.
+- Current isolated tests pass through the new abstraction.
+
+## Phase 3: Short-lived sessions and one-shot operation intents
+
+### Tasks
+
+1. Separate reusable task authority from one-shot WebAuthn authority:
+   - `AgentSession` for the short browser/agent task;
+   - `OperationIntent` for one `get()` or `create()` call.
+2. Session fields:
+   - profile and mode;
+   - principal identity;
+   - launcher/browser runtime identity;
+   - policy generation;
+   - issued/expiry timestamps;
+   - operation budget;
+   - optional RP narrowing;
+   - random capability hash.
+3. Bind the extension bearer to one session and extension/runtime instance.
+4. Implement operation states and atomic transitions.
+5. Generate a cryptographic operation nonce in the extension worker or daemon and bind it to a canonical request hash.
+6. Reject duplicate nonces, duplicate completed operation IDs, and mismatched request hashes.
+7. Re-evaluate policy before authorization and immediately before key use.
+8. Consume on:
+   - success;
+   - policy denial;
+   - RP/credential mismatch;
+   - user cancellation;
+   - timeout;
+   - handler error;
+   - audit failure;
+   - signing or storage failure.
+9. Revoke sessions on browser shutdown, launcher failure, explicit revoke, expiry, policy change, and operation-budget exhaustion.
+10. Bound registries and replay caches to prevent memory exhaustion.
+11. Replace tests that expect replayed requests to sign again.
+
+### Persistence decision
+
+Sessions and pending operations remain in memory. Audit reservations are durable. Daemon restart invalidates sessions and operations, which is the desired fail-closed behavior.
+
+### Tests
+
+- Session TTL boundaries with a controllable clock.
+- Operation-count exhaustion.
+- Atomic double-submit: exactly one caller reaches key use.
+- Replay after success, failure, cancellation, and timeout.
+- Policy-generation invalidation between authorization and key use.
+- Browser shutdown and principal death invalidation.
+- Registry cleanup and bounded memory tests.
+
+### Completion criteria
+
+- A session can perform multiple newly authorized operations within its limit.
+- The same operation can never create or use a credential twice.
+- Every terminal path leaves the operation consumed and auditable.
+
+## Phase 4: Evidence-provider architecture
+
+### Tasks
+
+1. Introduce a resolved evidence type, for example:
+
+```rust
+pub struct ResolvedEvidence {
+    pub user_present: bool,
+    pub user_verified: bool,
+    pub presence_source: EvidenceSource,
+    pub verification_source: EvidenceSource,
+    pub verified_at: Option<SystemTime>,
+}
+```
+
+2. Implement `AgentSessionEvidenceProvider`:
+   - verifies active session capability;
+   - verifies principal, browser/runtime, profile, policy generation, nonce, and request binding;
+   - returns agent UP and/or UV only for fields configured as `agent`;
+   - never returns evidence for an expired or replayed operation.
+3. Implement `HumanInteractionEvidenceProvider`:
+   - invokes existing production approval and PIN/platform-verification paths;
+   - binds the result to one operation intent;
+   - does not expose PIN or biometric data;
+   - supports cancellation and timeout.
+4. Resolve authorization separately from evidence.
+5. Derive authenticator flags only from `ResolvedEvidence`.
+6. Enforce RP `userVerification` and credential-level requirements:
+   - required needs successful agent or human UV;
+   - preferred follows configured provider and prompt preference;
+   - discouraged avoids human prompts unless explicitly `always`;
+   - `credProtect` can strengthen required verification.
+7. Remove every shortcut equivalent to:
+   - `uv = request_requires_uv`;
+   - `uv = policy_mentions_uv`;
+   - `up = authorization_allowed`.
+8. Emit explicit audit fields for authorization, presence source, and verification source.
+
+### Tests
+
+- Complete cross-product of authorization and evidence values.
+- Required/preferred/discouraged behavior.
+- `credProtect` with agent, human, and none.
+- Agent evidence fails after session invalidation.
+- Human verification is one-shot and cancellation-safe.
+- Audit never labels agent verification as human verification.
+
+### Completion criteria
+
+- UP and UV flags are impossible to construct without a successful provider result.
+- Fully autonomous policy succeeds for RP-required UV.
+- Human-forwarded UV succeeds without revealing verification secrets.
+
+## Phase 5: Unified authentication service
+
+### Tasks
+
+1. Move authentication semantics from `sign.rs` into `WebAuthnOperationService::authenticate`.
+2. Validate request protocol version and complete option structure.
+3. Parse and validate:
+   - challenge;
+   - RP ID;
+   - origin/top origin/cross-origin context;
+   - allow credentials;
+   - userVerification;
+   - extensions;
+   - timeout and mediation where applicable.
+4. Apply exact RP policy before backend credential discovery.
+5. Select the mode backend and candidate credentials.
+6. Implement deterministic selection from ADR 0007.
+7. Enforce credential refs as optional narrowing, not as an alternative storage namespace.
+8. Enforce credential policy, including discoverability and `credProtect`.
+9. Resolve authorization and evidence.
+10. Reserve audit before key use.
+11. Acquire backend lock.
+12. Re-read credential under lock and revalidate policy/session.
+13. Construct canonical client data and authenticator data through shared primitives.
+14. Sign through the backend key provider.
+15. Update signature counter safely and persist it with defined failure semantics.
+16. Finalize audit and consume operation.
+17. Return complete response data plus extension outputs.
+18. Make `sign.rs` an adapter that maps HTTP and DOM errors.
+
+### Counter failure semantics
+
+Define and test one explicit order. Preferred behavior:
+
+1. reserve audit;
+2. lock backend;
+3. load credential and next counter;
+4. sign response containing next counter;
+5. persist counter before returning success;
+6. if persistence fails, do not return the assertion and record terminal failure.
+
+Backends that can provide stronger atomicity may do so, but externally visible behavior must remain fail-closed.
+
+### Tests
+
+- Same-user authentication with existing software credential.
+- Same-user authentication with portable-TPM credential.
+- Isolated software and TPM authentication.
+- Exact `allowCredentials` ordering.
+- Discoverable single and ambiguous selections.
+- Credential ref narrowing.
+- Required UV and `credProtect`.
+- Counter concurrency, persistence failure, and restart behavior.
+- Unsupported extensions fail or are omitted according to documented capability.
+- Cryptographic verification of every generated assertion.
+
+### Completion criteria
+
+- Isolated authentication no longer depends on handler-local provider selection.
+- Same-user authentication uses the exact human backend.
+- Assertions are cryptographically and semantically valid for all supported cases.
+
+## Phase 6: Unified registration service
+
+### Tasks
+
+1. Move registration semantics from `register.rs` into `WebAuthnOperationService::register`.
+2. Use the selected mode backend as the registration target.
+3. Validate:
+   - RP and user entities;
+   - challenge;
+   - origin context;
+   - `pubKeyCredParams`;
+   - `excludeCredentials`;
+   - authenticator selection;
+   - resident-key requirements;
+   - userVerification;
+   - attestation preference;
+   - supported extensions.
+4. Select the first RP-preferred algorithm supported by the backend. Do not hardcode ES256.
+5. Resolve authorization and evidence before key generation.
+6. Reserve audit before generating a key or credential ID.
+7. Acquire backend lock and revalidate session/policy.
+8. Re-check exclude credentials under lock.
+9. Generate the key through the backend provider.
+10. Construct credential source, COSE public key, authenticator data, and attestation through shared primitives.
+11. Persist the credential only in the mode-selected backend.
+12. Define cleanup behavior when provider generation succeeds but storage fails, especially for TPM objects.
+13. Return complete registration response and extension outputs.
+14. Make `register.rs` a protocol adapter only.
+
+### Supported-capability policy
+
+- `none` attestation is mandatory for initial release.
+- Unsupported enterprise or direct-attestation requirements return `NotSupportedError` rather than false claims.
+- The initial algorithm set is whatever the backend providers can truthfully implement and advertise.
+- Resident/discoverable requirements are honored, not silently ignored.
+- Unsupported extensions are explicitly rejected when required for correctness.
+
+### Tests
+
+- Same-user registration writes to human storage and is visible to normal human authentication.
+- Isolated registration writes only to profile storage.
+- Software and TPM key generation.
+- Algorithm preference and no-supported-algorithm failure.
+- Exclude credential race under concurrent requests.
+- Resident-key and UV requirements.
+- Storage failure cleanup.
+- Register then authenticate E2E in both modes.
+
+### Completion criteria
+
+- Registration behavior is provider-aware and RP-option-aware.
+- No path can create a same-user credential without an explicit exact-RP registration rule.
+
+## Phase 7: Origin, RP, and browser security correctness
+
+### Tasks
+
+1. Replace current structural origin checks with a shared parser and validator implementing supported WebAuthn rules:
+   - secure origin requirements;
+   - valid explicit ports;
+   - RP ID equal to or registrable-domain suffix of the effective domain;
+   - public-suffix rejection;
+   - IP and localhost behavior documented and tested;
+   - canonical host and trailing-dot handling.
+2. Trust extension sender metadata as the primary frame URL source and cross-check the MAIN-world report.
+3. Derive top origin from trusted browser metadata where possible.
+4. Initially allow top-level frames only.
+5. Add cross-origin iframe support only after implementing:
+   - same-origin-with-ancestors calculation;
+   - top-origin client data;
+   - Permissions Policy checks for create/get;
+   - request and response tests across same-origin and cross-origin frames.
+6. Keep session bearer and daemon endpoint details out of page JavaScript.
+7. Restrict daemon ingress:
+   - loopback only;
+   - high-entropy per-session bearer;
+   - body and header limits;
+   - no permissive CORS;
+   - constant-time bearer comparison where applicable;
+   - request rate and concurrency bounds;
+   - protocol version check.
+8. Evaluate native messaging as a future transport, but do not block the redesign on it.
+
+### Tests
+
+- Origin with port.
+- Parent/subdomain RP relationships.
+- Public suffix rejection.
+- Origin spoof mismatch between MAIN and sender metadata.
+- Same-origin iframe.
+- Cross-origin iframe denied before support.
+- Cross-origin allowed only with correct top origin and Permissions Policy after support.
+- Local untrusted process without bearer.
+- Stolen expired bearer and bearer from another browser session.
+
+### Completion criteria
+
+- The daemon never accepts origin solely because its host equals an RP ID.
+- Unsupported frame contexts fail closed.
+- Session transport compromise does not bypass exact RP, operation, and policy checks.
+
+## Phase 8: Browser API compatibility and lifecycle
+
+### Tasks
+
+1. Preserve the original Credentials API for non-public-key calls.
+2. Serialize all required request fields and binary values.
+3. Implement cancellation:
+   - listen to `AbortSignal`;
+   - send cancel to worker/daemon;
+   - consume the operation;
+   - reject with `AbortError`.
+4. Honor the minimum of RP timeout, configured operation timeout, and session expiry.
+5. Return DOM-compatible errors:
+   - `NotAllowedError` for denial, timeout, cancellation, or unavailable user interaction where appropriate;
+   - `SecurityError` for origin/RP violations;
+   - `InvalidStateError` for excluded/duplicate registration state;
+   - `NotSupportedError` for unsupported algorithms, attestation, or extensions;
+   - `UnknownError` only for genuinely unmapped internal failures.
+6. Complete response facades:
+   - `id`, `rawId`, `type`;
+   - `authenticatorAttachment` where known;
+   - `response.clientDataJSON`;
+   - authentication and registration response fields;
+   - `getClientExtensionResults()`;
+   - `toJSON()` compatible with WebAuthn JSON conventions;
+   - registration `getTransports()` where representable.
+7. Make request correlation frame- and session-specific.
+8. Add a compatibility probe and optional `webAuthenticationProxy` adapter only if a target RP requires native object identity. The adapter must preserve trustworthy origin correlation.
+
+### Tests
+
+- Abort before dispatch, during daemon processing, and after completion race.
+- RP timeout and daemon timeout.
+- Browser/tab shutdown.
+- Nested frames and multiple simultaneous requests.
+- `toJSON()` and response methods.
+- RPs that use field access, JSON serialization, and `instanceof` checks.
+- No accidental fallback to native security-key UI.
+
+### Completion criteria
+
+- Supported RPs observe normal promise, cancellation, timeout, error, and response behavior.
+- The extension cannot leave an operation reusable after page cancellation.
+
+## Phase 9: CLI, operator UX, and diagnostics
+
+### Tasks
+
+1. Add guided configuration commands, for example:
+   - `passless agent profile init --mode same-user`;
+   - `passless agent profile init --mode isolated`;
+   - `passless agent rule add --rp github.com --authenticate autonomous`.
+2. Require an explicit warning acknowledgement for same-user autonomous profiles.
+3. Show the effective normalized rule without exposing secrets.
+4. Add `doctor` checks for:
+   - human backend availability;
+   - profile storage isolation;
+   - selected key provider;
+   - extension/daemon protocol version;
+   - browser extension load;
+   - audit write and fsync behavior;
+   - session TTL and operation limits;
+   - stale or contradictory configuration.
+5. Add session list/revoke commands for administrators.
+6. Add audit rendering that clearly labels:
+   - same-user versus isolated;
+   - agent versus human UP/UV;
+   - successful, denied, cancelled, replayed, and expired operations.
+7. Keep the capability token out of normal logs and command output.
+
+### Completion criteria
+
+- An operator can create both common profiles without hand-authoring every nested field.
+- The effective trust statement is visible before enabling same-user autonomy.
+- Diagnostics identify backend/provider mistakes before the first RP operation.
+
+## Phase 10: Migration and cleanup
+
+### Tasks
+
+1. Route current isolated extension authentication and registration through the unified services.
+2. Retain the old path behind a temporary rollback flag until E2E gates pass.
+3. Remove handler-local provider construction and duplicated WebAuthn semantics.
+4. Replace grant replay semantics with session plus one-shot operation semantics.
+5. Update or remove tests that encode repeated-sign behavior.
+6. Remove dead human-storage arguments only after they are replaced by the backend handle.
+7. Remove stale delegated-session mode references from:
+   - agent documentation;
+   - examples;
+   - installed skills;
+   - plan status files;
+   - CLI help;
+   - comments and tests.
+8. Mark ADRs 0001, 0005, and 0006 as superseded or amended by ADR 0007 where appropriate, while preserving their historical findings.
+9. Deprecate the legacy `policy` evidence spelling if the alias was shipped.
+10. Remove the experimental gate only after release criteria are met.
+
+### Rollback strategy
+
+- Before same-user ships, rollback means disabling the unified gate and using the current isolated path.
+- After isolated migrates, keep one release with a hidden compatibility switch if operationally practical.
+- Same-user never falls back to path sharing or key export. If its backend resolution fails, startup or the operation fails closed.
+- Schema changes remain backward-readable for isolated profiles throughout the migration window.
+
+## Proposed PR sequence
+
+Each implementation PR should be independently reviewable and identify the verification rows it closes.
+
+1. **Config model and experimental gate**
+   - mode/evidence enums, aliases, validation, baseline regressions.
+2. **Credential backend handle**
+   - human and isolated construction, provider/lock wiring, no behavior exposure.
+3. **Session and one-shot operation state machine**
+   - replay protection and lifecycle tests.
+4. **Evidence providers**
+   - agent and human evidence, flag derivation, UV regressions.
+5. **Unified authentication service**
+   - isolated migration first, then same-user behind gate.
+6. **Authentication real-RP software gate**
+   - same-user and isolated E2E.
+7. **Unified registration service**
+   - algorithm negotiation, backend target, register/authenticate E2E.
+8. **Origin and extension lifecycle correctness**
+   - sender metadata, ports, cancellation, timeout, response facade.
+9. **Portable-TPM gates**
+   - same-user and isolated authentication/registration.
+10. **Cross-origin iframe support or explicit permanent limitation**
+    - separate review because of browser security complexity.
+11. **CLI, doctor, audit UX, and documentation migration**
+12. **Remove old path and experimental gate**
+
+Large PRs that mix backend ownership, browser transport, crypto construction, and cleanup should be avoided.
+
+## Verification environments
+
+### Unit and property testing
+
+- Pure config validation.
+- Session and operation state machines with deterministic clocks.
+- Origin/RP validation with public-suffix fixtures.
+- Canonical request hashing.
+- Credential selection.
+- Authenticator data and client data byte-level checks.
+- Cryptographic signature verification.
+- Property tests for one-shot state transitions and no terminal-to-active transition.
+
+### Integration testing
+
+- In-memory software backend.
+- Filesystem/pass-style backend where supported.
+- Portable-TPM provider with simulator or test TPM.
+- Concurrent human and same-user operations.
+- Extension-to-daemon protocol with a test browser page.
+- Audit failure injection and storage failure injection.
+
+### Real-RP E2E
+
+Minimum targets:
+
+- Gitea or Forgejo controlled instance for registration and authentication.
+- One external RP with username-first `allowCredentials` flow.
+- One discoverable-credential flow.
+- One RP requesting `userVerification = required`.
+- One page using JSON serialization of the credential response.
+- A compatibility fixture that performs `instanceof PublicKeyCredential` to define whether a proxy adapter is required.
+
+Run software E2E in CI where practical. Portable-TPM and selected external-RP gates may be release/manual gates with captured command output and audit evidence.
+
+## Observability
+
+Add metrics with bounded labels:
+
+- active sessions by mode;
+- session creation, expiry, revoke, and operation-budget exhaustion;
+- operations by action, mode, authorization source, evidence source, and result class;
+- replay and request-binding rejection counts;
+- backend/provider operation latency;
+- human-verification latency and cancellation;
+- audit reservation/finalization failures;
+- extension protocol-version mismatches.
+
+Do not use RP IDs, origins, credential IDs, user handles, session IDs, or operation IDs as unbounded metric labels. Those belong in protected audit and debug logs with appropriate redaction.
+
+## Performance targets
+
+The redesign is security-driven, but should not make local authentication impractical.
+
+Initial non-normative targets on a local software backend:
+
+- session lookup and operation creation: under 5 ms p95;
+- policy/backend/evidence resolution for autonomous operation: under 5 ms p95 excluding audit storage;
+- total daemon authentication overhead excluding provider signing and browser transport: under 20 ms p95;
+- no global lock across independent isolated backends;
+- serialization only on operations sharing the same backend handle.
+
+Human verification and TPM signing have provider-dependent latency and are measured separately.
+
+## Release criteria
+
+`same-user` may leave the experimental gate only when all of the following are true:
+
+1. All mandatory rows in the verification matrix pass.
+2. No handler hardcodes a key provider or opens credential storage.
+3. RP-requested UV without resolved evidence is covered by a passing regression test.
+4. Replaying a completed operation is covered by concurrency and E2E tests.
+5. Same-user software authentication passes a real RP with an existing human credential.
+6. Same-user required-UV autonomous authentication passes and audit labels UV as agent evidence.
+7. Same-user human-UV forwarding passes and audit labels UV as human evidence.
+8. Isolated authentication and registration remain green.
+9. Same-user registration is either fully gated and tested or explicitly disabled in the first release.
+10. Portable-TPM same-user authentication passes before documentation claims TPM support.
+11. Origin-with-port, RP suffix, public suffix, and top-level frame tests pass.
+12. Abort, timeout, browser shutdown, policy reload, and daemon restart consume or invalidate authority.
+13. Audit failure prevents key use.
+14. Operator documentation states the same-user trust boundary prominently.
+15. Security review finds no path from isolated mode to the human backend.
+
+## Decisions intentionally deferred
+
+These items are outside the first implementation unless a blocker is discovered:
+
+- durable sessions across daemon restart;
+- reusable human-verification caches;
+- enterprise attestation;
+- arbitrary authenticator extensions;
+- unrestricted cross-origin iframe support;
+- native messaging as the extension transport;
+- RP-visible distinction between human and agent UV, which standard WebAuthn flags do not provide;
+- business-action authorization after the RP login completes;
+- protection against host root, kernel, daemon administrator, or browser-extension compromise.
+
+Deferred items must not be simulated with misleading flags or permissive fallbacks.
+
+## Definition of done
+
+The redesign is complete when an operator can configure:
+
+```toml
+[agents.profiles.opencode]
+mode = "same-user"
+
+[[agents.profiles.opencode.rules]]
+rp_id = "github.com"
+authenticate = "autonomous"
+register = "deny"
+```
+
+and a daemon-launched agent browser can authenticate with an existing human passkey, including an RP-required UV request, without human interaction, while:
+
+- the extension never receives the private key;
+- the daemon uses the real human backend and provider;
+- the operation is exact-RP, origin-bound, one-shot, short-lived, replay-resistant, and audited;
+- audit identifies agent-derived UP/UV;
+- a separately configured isolated profile cannot access that human credential;
+- changing `user_verification` to `human` forwards verification to the human path rather than silently approving it;
+- disabling or revoking the session immediately prevents further credential operations.

--- a/docs/plans/adr-0007-implementation-status.md
+++ b/docs/plans/adr-0007-implementation-status.md
@@ -1,0 +1,41 @@
+# ADR 0007 implementation status
+
+This document records implementation evidence separately from the normative ADR and verification matrix.
+
+## Implemented in PR #402
+
+- `same-user` and `isolated` identity modes share one daemon WebAuthn operation path.
+- Mode selection resolves a complete credential backend handle: credential storage, PIN storage, key provider, namespace, and operation lock.
+- Same-user operations use the existing human backend; isolated operations retain profile-owned storage and revocation.
+- Autonomous agent evidence can satisfy UP and UV, including RP-required UV, without being recorded as human verification.
+- Human confirmation or PIN/platform verification remains an explicit stricter policy and falls back to the native human ceremony path.
+- `human_verification_prompt = "when-required"` omits a human prompt when the RP does not require UV; `always` preserves the stricter behavior.
+- Authentication performs scoped multi-credential discovery and deterministic selection.
+- Registration negotiates RP-requested algorithms and uses the selected backend provider.
+- Dynamic credential scope lets a credential registered during a session authenticate immediately without relaunching the browser.
+- Registration and authentication consume one shared replay set and operation budget for the bearer session.
+- Browser requests propagate frame origin, top origin, cross-origin state, cancellation, timeout semantics, and the correct get/create Permissions Policy feature.
+- Replayed identical operation requests are rejected and each short-lived session has a bounded operation budget.
+- Portable-TPM backends propagate their real key provider instead of silently substituting software signing.
+
+## Automated evidence
+
+The branch is required to pass:
+
+- Rustfmt and Clippy with all features and warnings denied.
+- Build and unit tests on x86_64 and aarch64.
+- Repository pre-commit checks.
+- `make test-agent-validation`, the deterministic twelve-phase agent validation harness.
+
+The final software-validation cycle is run from a normal maintainer-authored commit after all formatter, Clippy, deterministic-fixture, policy, and lifecycle corrections have landed. Bot-authored maintenance commits are not used as evidence when GitHub suppresses their pull-request workflows.
+
+## External release evidence
+
+The following remain environment-dependent release gates rather than claims made from ordinary GitHub-hosted CI:
+
+- A real relying-party registration and authentication round trip using same-user credentials.
+- A real relying-party isolated-mode regression round trip.
+- Portable-TPM registration and authentication against a physical or recorded TPM laboratory environment.
+- Independent review of the agent-as-user UV semantics and browser-extension trust boundary.
+
+A required external gate that has not run must be reported as incomplete; it must not be represented as passing.

--- a/docs/plans/adr-0007-verification-matrix.md
+++ b/docs/plans/adr-0007-verification-matrix.md
@@ -1,0 +1,298 @@
+# ADR 0007 Verification Matrix
+
+- **Status:** Proposed
+- **Date:** 2026-08-06
+- **Decision:** [ADR 0007](../decisions/0007-unified-agent-identity-modes.md)
+- **Implementation plan:** [ADR 0007 implementation plan](adr-0007-agent-mode-redesign-implementation.md)
+
+## Purpose
+
+This matrix is the acceptance contract for the unified `same-user` and `isolated` agent modes. A row is not complete because code exists or a unit test passes. Its required evidence column defines the minimum proof.
+
+Status values:
+
+- `not-started`
+- `in-progress`
+- `blocked`
+- `passed`
+- `deferred` — allowed only for rows marked optional
+
+All mandatory rows must be `passed` before `same-user` leaves its experimental gate.
+
+## Configuration and trust boundary
+
+| ID | Mandatory | Requirement | Required evidence | Status |
+|---|---:|---|---|---|
+| C01 | yes | Agent support and same-user mode are disabled by default | Config unit test and integration startup test | not-started |
+| C02 | yes | `mode = "same-user"` parses without profile storage | Config unit test | not-started |
+| C03 | yes | Same-user rejects profile credential and PIN paths | Negative config integration test | not-started |
+| C04 | yes | `mode = "isolated"` requires a complete profile backend | Negative and positive config tests | not-started |
+| C05 | yes | Isolated storage cannot overlap human or another profile | Canonical-path overlap tests, including symlink cases where supported | not-started |
+| C06 | yes | Missing RP/action policy denies | Unit and daemon integration tests | not-started |
+| C07 | yes | `deny`, `autonomous`, and `supervised` normalize exactly as ADR 0007 defines | Parser table test | not-started |
+| C08 | yes | Invalid authorization/evidence combinations fail startup | Exhaustive config matrix | not-started |
+| C09 | yes | The effective config clearly identifies same-user as fully trusted | CLI/doctor snapshot test and documentation review | not-started |
+| C10 | optional | Legacy `policy` evidence alias emits a deprecation warning and normalizes to `agent` | Parser and log test | not-started |
+
+## Backend ownership and provider wiring
+
+| ID | Mandatory | Requirement | Required evidence | Status |
+|---|---:|---|---|---|
+| B01 | yes | Same-user receives the exact human backend handle | Integration test comparing namespace, provider, and lock identity | not-started |
+| B02 | yes | Isolated receives a distinct backend handle | Integration test | not-started |
+| B03 | yes | Isolated code cannot resolve the human backend | Type/factory unit test and adversarial integration test | not-started |
+| B04 | yes | Sign and register handlers do not open paths or choose providers | Code review checklist and architecture test where practical | not-started |
+| B05 | yes | Software human backend remains software in same-user mode | Integration test | not-started |
+| B06 | yes | Portable-TPM human backend remains TPM in same-user mode | TPM integration test | not-started |
+| B07 | yes | Portable-TPM isolated backend remains TPM | TPM integration test | not-started |
+| B08 | yes | Human and same-user operations share counter serialization | Concurrent integration test | not-started |
+| B09 | yes | Independent isolated backends do not share a global operation lock | Concurrency test | not-started |
+| B10 | yes | No backend handle, private key, PIN, or arbitrary-signing API appears in agent protocol or logs | Protocol review, secret-scanning test, and log assertions | not-started |
+
+## Session lifecycle
+
+| ID | Mandatory | Requirement | Required evidence | Status |
+|---|---:|---|---|---|
+| S01 | yes | Session is bound to profile, mode, principal, browser runtime, extension instance, and policy generation | Unit and integration tests | not-started |
+| S02 | yes | Session expires at configured TTL and cannot exceed daemon maximum | Deterministic-clock tests | not-started |
+| S03 | yes | Session operation budget is enforced atomically | Concurrent test | not-started |
+| S04 | yes | Explicit revoke prevents new operations immediately | Integration test | not-started |
+| S05 | yes | Policy reload invalidates affected sessions | Integration test | not-started |
+| S06 | yes | Browser shutdown invalidates its session | Browser E2E | not-started |
+| S07 | yes | Principal/launcher death invalidates the session | Process integration test | not-started |
+| S08 | yes | Daemon restart invalidates all in-memory sessions | Restart integration test | not-started |
+| S09 | yes | Session capability is high entropy, redacted, and scoped to one session | Unit entropy/format test and log assertions | not-started |
+| S10 | yes | Session registry is bounded and expired entries are cleaned | Load/unit test | not-started |
+
+## One-shot operation authority and replay resistance
+
+| ID | Mandatory | Requirement | Required evidence | Status |
+|---|---:|---|---|---|
+| O01 | yes | Every `get()` and `create()` call creates a distinct operation intent | Protocol integration test | not-started |
+| O02 | yes | Operation binds session, action, RP, origin context, challenge, request hash, policy generation, and nonce | Unit serialization/hash test and integration assertion | not-started |
+| O03 | yes | Exactly one concurrent submission reaches key use | Race test with instrumented provider | not-started |
+| O04 | yes | Replay after success fails | Integration and browser E2E | not-started |
+| O05 | yes | Replay after policy denial fails | Integration test | not-started |
+| O06 | yes | Replay after cancellation fails | Browser E2E | not-started |
+| O07 | yes | Replay after timeout fails | Browser E2E | not-started |
+| O08 | yes | Request hash mismatch fails before credential access | Negative integration test with storage access spy | not-started |
+| O09 | yes | Policy change between authorization and key use fails | Synchronization/race integration test | not-started |
+| O10 | yes | Every terminal path consumes the operation | State-machine property test and failure injection | not-started |
+| O11 | yes | Operation/replay registries remain bounded | Load test | not-started |
+
+## Authorization and evidence
+
+| ID | Mandatory | Requirement | Required evidence | Status |
+|---|---:|---|---|---|
+| E01 | yes | `authorization = allow` skips human approval but still evaluates all operation gates | Integration test with gate spies | not-started |
+| E02 | yes | `authorization = confirm` requires one operation-bound human approval | Human-interaction integration test | not-started |
+| E03 | yes | `authorization = deny` performs no credential access and no human prompt | Negative test with storage/UI spies | not-started |
+| E04 | yes | RP-required UV alone never sets UV | Regression unit and E2E test | not-started |
+| E05 | yes | Agent UV requires successful bound agent-session verification | Unit and integration tests | not-started |
+| E06 | yes | Human UV requires production human PIN/platform verification | Integration test | not-started |
+| E07 | yes | Agent UP requires successful bound agent-session presence evidence | Unit and integration tests | not-started |
+| E08 | yes | Human UP requires the bound human interaction path | Integration test | not-started |
+| E09 | yes | Fully autonomous policy satisfies RP-required UV without human interaction | Real-RP E2E and audit evidence | not-started |
+| E10 | yes | `user_verification = human` forwards verification and never exposes the PIN | E2E, protocol assertion, and secret log scan | not-started |
+| E11 | yes | `user_verification = none` fails when RP or credential policy requires UV | Unit and E2E tests | not-started |
+| E12 | yes | `preferred` and `discouraged` follow configured prompt preference | Policy table tests | not-started |
+| E13 | yes | `credProtect` strengthens verification requirements | Credential-policy integration tests | not-started |
+| E14 | yes | Audit distinguishes agent UV, human UV, and absent UV | Audit snapshot tests | not-started |
+| E15 | yes | A human interaction result cannot authorize a later operation | Replay integration test | not-started |
+
+## Credential discovery and selection
+
+| ID | Mandatory | Requirement | Required evidence | Status |
+|---|---:|---|---|---|
+| D01 | yes | Same-user can use an existing human credential without duplicating its ref in normal allow-list flows | Real-RP or faithful integration test | not-started |
+| D02 | yes | `allowCredentials` order is respected among permitted credentials | Unit and integration tests | not-started |
+| D03 | yes | Explicit credential ref narrows selection | Integration test | not-started |
+| D04 | yes | Discoverable single candidate succeeds | Browser E2E | not-started |
+| D05 | yes | Multiple candidates with `single` fail without key use | Negative E2E and storage spy | not-started |
+| D06 | yes | `first-matching` is stable and only active when explicit | Deterministic selection test | not-started |
+| D07 | yes | `newest` selects by persisted creation metadata | Unit and integration tests | not-started |
+| D08 | yes | A selected credential must match exact RP and configured scope | Negative integration tests | not-started |
+| D09 | yes | Page and agent cannot request unrestricted credential enumeration | Protocol/API review and negative test | not-started |
+| D10 | yes | Isolated selection never returns a human candidate | Adversarial integration test | not-started |
+
+## Authentication correctness
+
+| ID | Mandatory | Requirement | Required evidence | Status |
+|---|---:|---|---|---|
+| A01 | yes | Same-user software assertion verifies with existing credential public key | Cryptographic integration test | not-started |
+| A02 | yes | Same-user portable-TPM assertion verifies | TPM integration/E2E | not-started |
+| A03 | yes | Isolated software assertion verifies | Cryptographic integration test | not-started |
+| A04 | yes | Isolated portable-TPM assertion verifies | TPM integration/E2E | not-started |
+| A05 | yes | UP/UV bits equal resolved evidence and no other source | Byte-level authenticator-data tests | not-started |
+| A06 | yes | RP ID hash is correct | Byte-level test | not-started |
+| A07 | yes | Client data type, challenge, origin, topOrigin, and crossOrigin are correct | Byte-level and browser E2E | not-started |
+| A08 | yes | Signature counter increments once per successful returned assertion | Sequential and concurrent tests | not-started |
+| A09 | yes | Counter persistence failure prevents returning success | Failure-injection test | not-started |
+| A10 | yes | Unsupported required extension fails explicitly | Integration test | not-started |
+| A11 | yes | Authentication audit is reserved before provider sign | Instrumented provider/audit ordering test | not-started |
+| A12 | yes | Failure after audit reservation finalizes a terminal result | Failure-injection audit test | not-started |
+| A13 | yes | Same-user existing credential succeeds against a real RP | Real-RP E2E | not-started |
+| A14 | yes | Isolated credential continues to succeed against a real RP | Regression real-RP E2E | not-started |
+
+## Registration correctness
+
+| ID | Mandatory | Requirement | Required evidence | Status |
+|---|---:|---|---|---|
+| R01 | yes | Same-user registration writes only to human backend | Integration test | not-started |
+| R02 | yes | Isolated registration writes only to profile backend | Integration test | not-started |
+| R03 | yes | Registration is denied unless exact RP rule explicitly allows it | Negative E2E | not-started |
+| R04 | yes | Algorithm is selected from RP order and backend capabilities, not hardcoded | Parameterized unit/integration test | not-started |
+| R05 | yes | No supported algorithm returns `NotSupportedError` before key generation | Provider spy test | not-started |
+| R06 | yes | `excludeCredentials` is checked under lock immediately before creation | Concurrent race test | not-started |
+| R07 | yes | Resident/discoverable requirements are honored | Registration integration tests | not-started |
+| R08 | yes | Required UV uses configured agent or human evidence | Registration E2E | not-started |
+| R09 | yes | Authenticator data includes correct AT, UP, UV, RP hash, AAGUID, credential ID, and COSE key | Byte-level test | not-started |
+| R10 | yes | Unsupported attestation requirement fails without false claims | Integration test | not-started |
+| R11 | yes | Software registration then authentication succeeds | Real-RP E2E in both modes | not-started |
+| R12 | yes | Portable-TPM registration then authentication succeeds before TPM registration is advertised | TPM real-RP/manual release gate | not-started |
+| R13 | yes | Provider generation followed by storage failure performs documented cleanup | Failure-injection test | not-started |
+| R14 | yes | Registration audit is reserved before key generation | Ordering test | not-started |
+
+## Origin, RP, frame, and transport security
+
+| ID | Mandatory | Requirement | Required evidence | Status |
+|---|---:|---|---|---|
+| X01 | yes | Valid HTTPS origin with explicit port is accepted | Unit and E2E test | not-started |
+| X02 | yes | RP equal to origin effective domain is accepted | Unit test | not-started |
+| X03 | yes | Valid registrable-domain suffix RP is accepted | Unit test | not-started |
+| X04 | yes | Public suffix RP is rejected | Public-suffix fixture test | not-started |
+| X05 | yes | Invalid IP/localhost cases follow documented policy | Unit tests | not-started |
+| X06 | yes | Extension sender URL is primary and MAIN-world origin is cross-checked | Spoofing E2E | not-started |
+| X07 | yes | Top-level frame requests succeed | Browser E2E | not-started |
+| X08 | yes | Cross-origin frames fail closed until fully supported | Browser E2E | not-started |
+| X09 | optional | Supported cross-origin iframe uses correct topOrigin and Permissions Policy | Multi-origin browser E2E | not-started |
+| X10 | yes | Bearer never enters page-visible MAIN-world data or logs | Extension test and source review | not-started |
+| X11 | yes | Missing, wrong, expired, or other-session bearer fails | HTTP integration tests | not-started |
+| X12 | yes | Loopback ingress enforces body, concurrency, and protocol-version limits | HTTP integration/load tests | not-started |
+| X13 | yes | Session bearer cannot bypass RP, operation, evidence, or audit checks | Adversarial integration test | not-started |
+
+## Browser API and lifecycle compatibility
+
+| ID | Mandatory | Requirement | Required evidence | Status |
+|---|---:|---|---|---|
+| W01 | yes | Non-public-key Credentials API calls use the original browser API | Browser test | not-started |
+| W02 | yes | Authentication and registration option serialization is lossless for supported fields | JS unit test with binary fixtures | not-started |
+| W03 | yes | Abort before dispatch rejects with `AbortError` and creates no credential use | Browser E2E | not-started |
+| W04 | yes | Abort during processing consumes operation and prevents later success | Browser/provider synchronization E2E | not-started |
+| W05 | yes | Timeout uses the strictest applicable deadline | Deterministic browser/daemon test | not-started |
+| W06 | yes | Tab/browser shutdown invalidates or consumes pending authority | Browser E2E | not-started |
+| W07 | yes | Errors map to appropriate DOMException classes | Browser parameterized test | not-started |
+| W08 | yes | Response exposes required fields and methods, including `toJSON()` and extension results | Browser compatibility test | not-started |
+| W09 | yes | Multiple simultaneous frame requests cannot cross-correlate | Multi-frame race E2E | not-started |
+| W10 | yes | Agent path never unexpectedly opens native security-key UI | Real browser E2E/manual visual assertion | not-started |
+| W11 | optional | RP requiring native `instanceof PublicKeyCredential` works through an approved adapter | Compatibility E2E | not-started |
+
+## Audit and observability
+
+| ID | Mandatory | Requirement | Required evidence | Status |
+|---|---:|---|---|---|
+| L01 | yes | Audit reservation failure prevents storage or key-provider access | Failure-injection test | not-started |
+| L02 | yes | Every terminal operation has a finalized audit result | State-machine/audit property test | not-started |
+| L03 | yes | Audit contains mode, namespace, profile, principal, RP, origin context, action, policy generation, selection, evidence sources, result, and counter metadata | Snapshot tests | not-started |
+| L04 | yes | Audit does not contain key material, PIN, bearer, raw assertion signature, or unrestricted user secrets | Secret scan and snapshot tests | not-started |
+| L05 | yes | Same-user autonomous events are unmistakably labeled | Snapshot and operator UX test | not-started |
+| L06 | yes | Metrics use bounded labels and exclude RP, origin, credential, session, and operation identifiers | Metrics review/test | not-started |
+| L07 | yes | Replay, expiry, cancellation, audit failure, and provider failure are separately observable | Metric/log integration tests | not-started |
+| L08 | yes | Diagnostics show selected backend/provider without revealing secrets | Doctor snapshot test | not-started |
+
+## Isolation and adversarial tests
+
+| ID | Mandatory | Requirement | Required evidence | Status |
+|---|---:|---|---|---|
+| I01 | yes | Isolated profile cannot authenticate with a known human credential ID | Adversarial integration/E2E | not-started |
+| I02 | yes | Isolated profile cannot register into human backend | Adversarial integration test | not-started |
+| I03 | yes | Same-user profile cannot escape configured exact RP rules | Adversarial E2E | not-started |
+| I04 | yes | Credential ref for another RP is rejected before key use | Negative integration test | not-started |
+| I05 | yes | Policy reload narrowing credentials invalidates pending operations | Race integration test | not-started |
+| I06 | yes | A page cannot alter origin, RP, action, or challenge after operation binding | Mutation/race browser test | not-started |
+| I07 | yes | Local caller with stolen request body but no valid session binding fails | HTTP adversarial test | not-started |
+| I08 | yes | A session for one profile cannot call another profile's backend | Adversarial integration test | not-started |
+| I09 | yes | Human authenticator remains available when agent runtime or extension fails | Human-path regression E2E | not-started |
+| I10 | yes | Same-user threat statement is present in generated examples and CLI acknowledgement | Documentation/CLI test | not-started |
+
+## Real-RP release scenarios
+
+| ID | Mandatory | Scenario | Required evidence | Status |
+|---|---:|---|---|---|
+| P01 | yes | Same-user autonomous authentication with existing human passkey and username-first allow list | Captured E2E command, RP success, daemon audit | not-started |
+| P02 | yes | Same-user autonomous discoverable authentication with one candidate | Captured E2E and audit | not-started |
+| P03 | yes | Same-user autonomous RP-required UV | Captured E2E proving no human prompt and agent UV audit | not-started |
+| P04 | yes | Same-user human-forwarded UV | Captured E2E proving human prompt and human UV audit | not-started |
+| P05 | yes | Isolated autonomous authentication regression | Captured E2E and audit | not-started |
+| P06 | yes | Same-user software registration followed by authentication | Captured E2E and human-store inspection | not-started |
+| P07 | yes | Isolated software registration followed by authentication | Captured E2E and isolated-store inspection | not-started |
+| P08 | yes | Replay captured browser request | Captured failure and no counter/key reuse | not-started |
+| P09 | yes | Browser cancellation during authentication | Captured `AbortError`, consumed operation, audit | not-started |
+| P10 | yes | Valid origin with non-default port | Captured RP success | not-started |
+| P11 | yes | Portable-TPM same-user authentication before TPM support claim | Captured E2E, TPM provider evidence, audit | not-started |
+| P12 | yes | Portable-TPM isolated authentication before TPM support claim | Captured E2E, TPM provider evidence, audit | not-started |
+| P13 | optional | Portable-TPM registration in both modes | Captured E2E and cleanup validation | not-started |
+| P14 | optional | Approved cross-origin iframe ceremony | Multi-origin E2E and clientData inspection | not-started |
+
+## Exit gates by rollout phase
+
+### Gate A: Unified isolated pipeline
+
+Required rows:
+
+- all `C` rows except optional aliases;
+- `B02` through `B05`, `B07`, `B09`, `B10`;
+- all mandatory `S`, `O`, and `E` rows applicable to isolated;
+- `A03`, `A05` through `A12`, `A14`;
+- `R02` through `R10`, `R14` if registration is migrated;
+- mandatory top-level origin/browser/audit rows;
+- `I01`, `I02`, `I08`, `I09`;
+- `P05` and `P07` when registration is enabled.
+
+### Gate B: Experimental same-user authentication
+
+Required rows:
+
+- all mandatory configuration/backend/session/operation/evidence rows;
+- all mandatory discovery and authentication rows except TPM rows if TPM remains explicitly unadvertised;
+- all mandatory origin/browser/audit/isolation rows;
+- `P01` through `P05`, `P08`, `P09`, and `P10`.
+
+### Gate C: Same-user registration
+
+Required rows:
+
+- all mandatory registration rows except portable-TPM registration if explicitly unadvertised;
+- `P06` and `P07`;
+- adversarial registration and audit rows.
+
+### Gate D: Portable-TPM support claim
+
+Required rows:
+
+- `B06`, `B07`;
+- `A02`, `A04`;
+- `P11`, `P12`;
+- `R12` and `P13` only if TPM registration is advertised.
+
+### Gate E: Remove experimental flag
+
+Required rows:
+
+- every mandatory row is `passed`;
+- optional rows are either `passed` or explicitly documented as unsupported;
+- security review confirms no isolated-to-human backend path;
+- operator documentation and migration notes are complete;
+- old contradictory implementation paths are removed or disabled by an explicit compatibility policy.
+
+## Evidence recording
+
+When a row passes, update this file with:
+
+- `passed` status;
+- test name and path;
+- CI run or commit reference;
+- manual E2E date and environment where applicable;
+- limitations or backend-specific scope.
+
+Do not mark a row passed based solely on an implementation claim in a PR description.

--- a/passless-core/src/agent/config.rs
+++ b/passless-core/src/agent/config.rs
@@ -26,8 +26,73 @@ const HUMAN_DEVICE_PHYS: &str = "virtual-fido-001";
 const HUMAN_VENDOR_ID: u16 = 0x15d9;
 const HUMAN_PRODUCT_ID: u16 = 0x0a37;
 
+const DEFAULT_MAX_OPERATIONS: u16 = 64;
+const MAX_OPERATIONS: u16 = 4096;
+
+fn default_max_operations() -> u16 {
+    DEFAULT_MAX_OPERATIONS
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum CredentialSelection {
+    #[default]
+    Single,
+    FirstMatching,
+    Newest,
+    Credential(CredentialRef),
+}
+
+impl Serialize for CredentialSelection {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = match self {
+            Self::Single => "single".to_string(),
+            Self::FirstMatching => "first-matching".to_string(),
+            Self::Newest => "newest".to_string(),
+            Self::Credential(reference) => format!("credential:{reference}"),
+        };
+        serializer.serialize_str(&value)
+    }
+}
+
+impl<'de> Deserialize<'de> for CredentialSelection {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        match value.as_str() {
+            "single" => Ok(Self::Single),
+            "first-matching" | "first_matching" => Ok(Self::FirstMatching),
+            "newest" => Ok(Self::Newest),
+            _ => value
+                .strip_prefix("credential:")
+                .ok_or_else(|| serde::de::Error::custom(
+                    "credential_selection must be single, first-matching, newest, or credential:<ref>",
+                ))
+                .and_then(|reference| {
+                    CredentialRef::from_hex(reference)
+                        .map(Self::Credential)
+                        .map_err(serde::de::Error::custom)
+                }),
+        }
+    }
+}
+
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum HumanVerificationPrompt {
+    #[default]
+    Always,
+    WhenRequired,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum AgentMode {
+    #[serde(rename = "same-user", alias = "same_user")]
+    SameUser,
     #[serde(rename = "isolated")]
     Isolated,
 }
@@ -35,6 +100,7 @@ pub enum AgentMode {
 impl fmt::Display for AgentMode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            AgentMode::SameUser => write!(f, "same-user"),
             AgentMode::Isolated => write!(f, "isolated"),
         }
     }
@@ -45,8 +111,12 @@ impl std::str::FromStr for AgentMode {
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s {
+            "same-user" | "same_user" => Ok(AgentMode::SameUser),
             "isolated" => Ok(AgentMode::Isolated),
-            _ => Err(format!("Invalid agent mode '{}'. Must be: isolated", s)),
+            _ => Err(format!(
+                "Invalid agent mode '{}'. Must be: same-user, isolated",
+                s
+            )),
         }
     }
 }
@@ -102,10 +172,12 @@ impl fmt::Display for AgentAuthorization {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
 pub enum UserPresenceSource {
+    #[serde(rename = "human")]
     Human,
-    Policy,
+    #[serde(rename = "agent", alias = "policy")]
+    Agent,
+    #[serde(rename = "none")]
     None,
 }
 
@@ -113,17 +185,19 @@ impl fmt::Display for UserPresenceSource {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Human => f.write_str("human"),
-            Self::Policy => f.write_str("policy"),
+            Self::Agent => f.write_str("agent"),
             Self::None => f.write_str("none"),
         }
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
 pub enum UserVerificationSource {
+    #[serde(rename = "human")]
     Human,
-    Policy,
+    #[serde(rename = "agent", alias = "policy")]
+    Agent,
+    #[serde(rename = "none")]
     None,
 }
 
@@ -131,18 +205,56 @@ impl fmt::Display for UserVerificationSource {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Human => f.write_str("human"),
-            Self::Policy => f.write_str("policy"),
+            Self::Agent => f.write_str("agent"),
             Self::None => f.write_str("none"),
         }
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ConfigDoc)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ConfigDoc)]
 pub struct AgentCeremonyPolicy {
     pub authorization: AgentAuthorization,
     pub user_presence: UserPresenceSource,
     pub user_verification: UserVerificationSource,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AgentCeremonyPolicyFields {
+    authorization: AgentAuthorization,
+    user_presence: UserPresenceSource,
+    user_verification: UserVerificationSource,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum AgentCeremonyPolicyRepr {
+    Alias(String),
+    Fields(AgentCeremonyPolicyFields),
+}
+
+impl<'de> Deserialize<'de> for AgentCeremonyPolicy {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let repr = AgentCeremonyPolicyRepr::deserialize(deserializer)?;
+        match repr {
+            AgentCeremonyPolicyRepr::Alias(alias) => match alias.as_str() {
+                "deny" => Ok(Self::deny()),
+                "autonomous" => Ok(Self::autonomous()),
+                "supervised" => Ok(Self::supervised()),
+                other => Err(serde::de::Error::custom(format!(
+                    "unknown agent ceremony policy alias '{other}'; expected deny, autonomous, or supervised"
+                ))),
+            },
+            AgentCeremonyPolicyRepr::Fields(fields) => Ok(Self {
+                authorization: fields.authorization,
+                user_presence: fields.user_presence,
+                user_verification: fields.user_verification,
+            }),
+        }
+    }
 }
 
 impl AgentCeremonyPolicy {
@@ -184,6 +296,22 @@ impl AgentCeremonyPolicy {
             authorization: AgentAuthorization::Deny,
             user_presence: UserPresenceSource::None,
             user_verification: UserVerificationSource::None,
+        }
+    }
+
+    pub fn autonomous() -> Self {
+        Self {
+            authorization: AgentAuthorization::Allow,
+            user_presence: UserPresenceSource::Agent,
+            user_verification: UserVerificationSource::Agent,
+        }
+    }
+
+    pub fn supervised() -> Self {
+        Self {
+            authorization: AgentAuthorization::Confirm,
+            user_presence: UserPresenceSource::Human,
+            user_verification: UserVerificationSource::Human,
         }
     }
 }
@@ -408,7 +536,7 @@ impl<'de> Deserialize<'de> for BoundedDuration {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, ConfigDoc)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ConfigDoc)]
 #[serde(deny_unknown_fields)]
 pub struct DeviceIdentity {
     pub name: String,
@@ -479,8 +607,18 @@ pub struct AgentProfileConfig {
     pub credential_refs: Option<Vec<CredentialRef>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_grant_ttl: Option<BoundedDuration>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        alias = "session_ttl",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub max_session_ttl: Option<BoundedDuration>,
+    #[serde(default = "default_max_operations")]
+    pub max_operations: u16,
+    #[serde(default)]
+    pub credential_selection: CredentialSelection,
+    #[serde(default)]
+    pub human_verification_prompt: HumanVerificationPrompt,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub storage: Option<AgentStorageConfig>,
@@ -490,6 +628,7 @@ pub struct AgentProfileConfig {
     #[serde(default)]
     pub rules: Vec<AgentRpRule>,
 
+    #[serde(default)]
     pub device: DeviceIdentity,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -570,6 +709,23 @@ impl AgentProfileConfig {
                 profile_id
             )));
         }
+        if self.max_operations == 0 || self.max_operations > MAX_OPERATIONS {
+            return Err(Error::Config(format!(
+                "agent profile '{}': max_operations must be between 1 and {}",
+                profile_id, MAX_OPERATIONS
+            )));
+        }
+        if let CredentialSelection::Credential(reference) = &self.credential_selection
+            && self
+                .credential_refs
+                .as_ref()
+                .is_some_and(|refs| !refs.contains(reference))
+        {
+            return Err(Error::Config(format!(
+                "agent profile '{}': credential_selection reference must be included in credential_refs",
+                profile_id
+            )));
+        }
 
         if !self.rules.is_empty()
             && (!self.rp_ids.is_empty() || self.registration_allowed || self.require_uv)
@@ -597,8 +753,6 @@ impl AgentProfileConfig {
                 .validate(profile_id, &rule.rp_id, "authentication")?;
         }
 
-        self.device.validate(profile_id)?;
-
         if let Some(ref cmd) = self.browser_command {
             if cmd.is_empty() {
                 return Err(Error::Config(format!(
@@ -617,7 +771,25 @@ impl AgentProfileConfig {
         }
 
         match self.mode {
+            AgentMode::SameUser => {
+                if self.storage.is_some() {
+                    return Err(Error::Config(format!(
+                        "agent profile '{}': same-user mode uses the human backend and must not specify storage",
+                        profile_id
+                    )));
+                }
+            }
             AgentMode::Isolated => {
+                if self.device.name.is_empty()
+                    || self.device.phys.is_empty()
+                    || self.device.uniq.is_empty()
+                {
+                    return Err(Error::Config(format!(
+                        "agent profile '{}': isolated mode requires a complete device identity",
+                        profile_id
+                    )));
+                }
+                self.device.validate(profile_id)?;
                 if self.storage.is_none() {
                     return Err(Error::Config(format!(
                         "agent profile '{}': isolated mode requires storage backend configuration",
@@ -738,6 +910,9 @@ impl AgentConfig {
 
         let mut device_keys: std::collections::HashSet<String> = std::collections::HashSet::new();
         for (pid, profile) in &validated_profiles {
+            if profile.mode == AgentMode::SameUser {
+                continue;
+            }
             let key = format!(
                 "{}:{}:{}:{}:{}",
                 profile.device.name,
@@ -1038,6 +1213,82 @@ mod tests {
     }
 
     #[test]
+    fn test_agent_mode_serde_same_user() {
+        let mode = AgentMode::SameUser;
+        let json = serde_json::to_string(&mode).unwrap();
+        assert_eq!(json, "\"same-user\"");
+        assert_eq!(serde_json::from_str::<AgentMode>(&json).unwrap(), mode);
+        assert_eq!("same_user".parse::<AgentMode>().unwrap(), mode);
+    }
+
+    #[test]
+    fn test_ceremony_policy_aliases() {
+        let autonomous: AgentCeremonyPolicy = serde_json::from_str("\"autonomous\"").unwrap();
+        assert_eq!(autonomous, AgentCeremonyPolicy::autonomous());
+
+        let supervised: AgentCeremonyPolicy = serde_json::from_str("\"supervised\"").unwrap();
+        assert_eq!(supervised, AgentCeremonyPolicy::supervised());
+
+        let denied: AgentCeremonyPolicy = serde_json::from_str("\"deny\"").unwrap();
+        assert_eq!(denied, AgentCeremonyPolicy::deny());
+    }
+
+    #[test]
+    fn test_legacy_policy_evidence_alias_normalizes_to_agent() {
+        let policy: AgentCeremonyPolicy = serde_json::from_str(
+            r#"{"authorization":"allow","user_presence":"policy","user_verification":"policy"}"#,
+        )
+        .unwrap();
+        assert_eq!(policy.user_presence, UserPresenceSource::Agent);
+        assert_eq!(policy.user_verification, UserVerificationSource::Agent);
+        let serialized = serde_json::to_string(&policy).unwrap();
+        assert!(serialized.contains("\"agent\""));
+        assert!(!serialized.contains("\"policy\""));
+    }
+
+    #[test]
+    fn test_same_user_profile_parses_without_storage_or_device() {
+        let toml_str = r#"
+enabled = true
+audit_path = "/tmp/passless-agent-audit.jsonl"
+
+[profiles.opencode]
+mode = "same-user"
+principal_user = "alice"
+session_ttl = 600
+max_operations = 16
+
+[[profiles.opencode.rules]]
+rp_id = "github.com"
+authenticate = "autonomous"
+register = "deny"
+"#;
+        let config: AgentConfig = toml::from_str(toml_str).unwrap();
+        let profile = config.profiles.get("opencode").unwrap();
+        assert_eq!(profile.mode, AgentMode::SameUser);
+        assert_eq!(profile.max_operations, 16);
+        assert_eq!(profile.max_session_ttl.unwrap().as_secs(), 600);
+        assert!(profile.storage.is_none());
+        assert_eq!(
+            profile.rules[0].authenticate,
+            AgentCeremonyPolicy::autonomous()
+        );
+        assert!(config.validate(None).is_ok());
+    }
+
+    #[test]
+    fn test_same_user_profile_rejects_storage() {
+        let mut profile = make_isolated_profile();
+        profile.mode = AgentMode::SameUser;
+        profile.device = DeviceIdentity::default();
+        assert!(
+            profile
+                .validate(&ProfileId::new("same-user").unwrap())
+                .is_err()
+        );
+    }
+
+    #[test]
     fn test_agent_config_default_disabled() {
         let config = AgentConfig::default();
         assert!(!config.enabled);
@@ -1052,6 +1303,9 @@ mod tests {
 
     fn make_isolated_profile() -> AgentProfileConfig {
         AgentProfileConfig {
+            max_operations: 64,
+            credential_selection: CredentialSelection::Single,
+            human_verification_prompt: HumanVerificationPrompt::Always,
             mode: AgentMode::Isolated,
             principal_user: "test-user".to_string(),
             rp_ids: vec!["example.com".to_string()],
@@ -1119,8 +1373,8 @@ mod tests {
             rp_id: "example.com".to_string(),
             register: policy(
                 AgentAuthorization::Allow,
-                UserPresenceSource::Policy,
-                UserVerificationSource::Policy,
+                UserPresenceSource::Agent,
+                UserVerificationSource::Agent,
             ),
             authenticate: policy(
                 AgentAuthorization::Confirm,
@@ -1169,7 +1423,7 @@ mod tests {
     fn test_deny_rejects_evidence() {
         let err = policy(
             AgentAuthorization::Deny,
-            UserPresenceSource::Policy,
+            UserPresenceSource::Agent,
             UserVerificationSource::None,
         )
         .validate(
@@ -1192,7 +1446,7 @@ mod tests {
             register: AgentCeremonyPolicy::deny(),
             authenticate: policy(
                 AgentAuthorization::Allow,
-                UserPresenceSource::Policy,
+                UserPresenceSource::Agent,
                 UserVerificationSource::None,
             ),
         };
@@ -1359,6 +1613,9 @@ verbose = false
         profiles.insert(
             "a".to_string(),
             AgentProfileConfig {
+                max_operations: 64,
+                credential_selection: CredentialSelection::Single,
+                human_verification_prompt: HumanVerificationPrompt::Always,
                 mode: AgentMode::Isolated,
                 principal_user: "u1".to_string(),
                 rp_ids: vec!["a.com".to_string()],
@@ -1384,6 +1641,9 @@ verbose = false
         profiles.insert(
             "b".to_string(),
             AgentProfileConfig {
+                max_operations: 64,
+                credential_selection: CredentialSelection::Single,
+                human_verification_prompt: HumanVerificationPrompt::Always,
                 mode: AgentMode::Isolated,
                 principal_user: "u2".to_string(),
                 rp_ids: vec!["b.com".to_string()],
@@ -1421,6 +1681,9 @@ verbose = false
         profiles.insert(
             "a".to_string(),
             AgentProfileConfig {
+                max_operations: 64,
+                credential_selection: CredentialSelection::Single,
+                human_verification_prompt: HumanVerificationPrompt::Always,
                 mode: AgentMode::Isolated,
                 principal_user: "u1".to_string(),
                 rp_ids: vec!["a.com".to_string()],
@@ -1468,6 +1731,9 @@ verbose = false
         profiles.insert(
             "a".to_string(),
             AgentProfileConfig {
+                max_operations: 64,
+                credential_selection: CredentialSelection::Single,
+                human_verification_prompt: HumanVerificationPrompt::Always,
                 mode: AgentMode::Isolated,
                 principal_user: "u1".to_string(),
                 rp_ids: vec!["a.com".to_string()],
@@ -1689,6 +1955,9 @@ product_id = 2
         profiles.insert(
             "myprofile".to_string(),
             AgentProfileConfig {
+                max_operations: 64,
+                credential_selection: CredentialSelection::Single,
+                human_verification_prompt: HumanVerificationPrompt::Always,
                 mode: AgentMode::Isolated,
                 principal_user: "u1".to_string(),
                 rp_ids: vec!["a.com".to_string()],
@@ -1734,6 +2003,9 @@ product_id = 2
             profiles.insert(
                 name.to_string(),
                 AgentProfileConfig {
+                    max_operations: 64,
+                    credential_selection: CredentialSelection::Single,
+                    human_verification_prompt: HumanVerificationPrompt::Always,
                     mode: AgentMode::Isolated,
                     principal_user: format!("u-{}", name),
                     rp_ids: vec!["a.com".to_string()],
@@ -1864,6 +2136,9 @@ backend_type = "local"
         profiles.insert(
             "a".to_string(),
             AgentProfileConfig {
+                max_operations: 64,
+                credential_selection: CredentialSelection::Single,
+                human_verification_prompt: HumanVerificationPrompt::Always,
                 mode: AgentMode::Isolated,
                 principal_user: "u1".to_string(),
                 rp_ids: vec!["a.com".to_string()],
@@ -1921,6 +2196,9 @@ backend_type = "local"
         profiles.insert(
             "a".to_string(),
             AgentProfileConfig {
+                max_operations: 64,
+                credential_selection: CredentialSelection::Single,
+                human_verification_prompt: HumanVerificationPrompt::Always,
                 mode: AgentMode::Isolated,
                 principal_user: "u1".to_string(),
                 rp_ids: vec!["a.com".to_string()],
@@ -1970,6 +2248,9 @@ backend_type = "local"
         profiles.insert(
             "a".to_string(),
             AgentProfileConfig {
+                max_operations: 64,
+                credential_selection: CredentialSelection::Single,
+                human_verification_prompt: HumanVerificationPrompt::Always,
                 mode: AgentMode::Isolated,
                 principal_user: "u1".to_string(),
                 rp_ids: vec!["a.com".to_string()],
@@ -2315,6 +2596,9 @@ pin_path = "/var/lib/passless-agent/secure/pin"
         profiles.insert(
             "a".to_string(),
             AgentProfileConfig {
+                max_operations: 64,
+                credential_selection: CredentialSelection::Single,
+                human_verification_prompt: HumanVerificationPrompt::Always,
                 mode: AgentMode::Isolated,
                 principal_user: "u1".to_string(),
                 rp_ids: vec!["a.com".to_string()],
@@ -2346,6 +2630,9 @@ pin_path = "/var/lib/passless-agent/secure/pin"
         profiles.insert(
             "b".to_string(),
             AgentProfileConfig {
+                max_operations: 64,
+                credential_selection: CredentialSelection::Single,
+                human_verification_prompt: HumanVerificationPrompt::Always,
                 mode: AgentMode::Isolated,
                 principal_user: "u2".to_string(),
                 rp_ids: vec!["b.com".to_string()],
@@ -2420,6 +2707,9 @@ pin_path = "/var/lib/passless-agent/secure/pin"
         profiles.insert(
             "a".to_string(),
             AgentProfileConfig {
+                max_operations: 64,
+                credential_selection: CredentialSelection::Single,
+                human_verification_prompt: HumanVerificationPrompt::Always,
                 mode: AgentMode::Isolated,
                 principal_user: "u1".to_string(),
                 rp_ids: vec!["a.com".to_string()],
@@ -2451,6 +2741,9 @@ pin_path = "/var/lib/passless-agent/secure/pin"
         profiles.insert(
             "b".to_string(),
             AgentProfileConfig {
+                max_operations: 64,
+                credential_selection: CredentialSelection::Single,
+                human_verification_prompt: HumanVerificationPrompt::Always,
                 mode: AgentMode::Isolated,
                 principal_user: "u2".to_string(),
                 rp_ids: vec!["b.com".to_string()],
@@ -2496,6 +2789,9 @@ pin_path = "/var/lib/passless-agent/secure/pin"
         profiles.insert(
             "a".to_string(),
             AgentProfileConfig {
+                max_operations: 64,
+                credential_selection: CredentialSelection::Single,
+                human_verification_prompt: HumanVerificationPrompt::Always,
                 mode: AgentMode::Isolated,
                 principal_user: "u1".to_string(),
                 rp_ids: vec!["a.com".to_string()],

--- a/passless-core/src/agent/mod.rs
+++ b/passless-core/src/agent/mod.rs
@@ -5,8 +5,8 @@ pub mod protocol;
 
 pub use config::{
     AgentAuthorization, AgentCeremonyPolicy, AgentConfig, AgentMode, AgentProfileConfig,
-    AgentRpRule, AgentStorageConfig, BoundedDuration, DeviceIdentity, UserPresenceSource,
-    UserVerificationSource, validate_rp_id,
+    AgentRpRule, AgentStorageConfig, BoundedDuration, CredentialSelection, DeviceIdentity,
+    HumanVerificationPrompt, UserPresenceSource, UserVerificationSource, validate_rp_id,
 };
 pub use ids::{
     BrowserLeaseId, CredentialRef, EndpointId, GrantId, IdError, IntentId, PendingRequestId,

--- a/passless-core/src/agent/policy.rs
+++ b/passless-core/src/agent/policy.rs
@@ -1030,8 +1030,8 @@ mod tests {
         let mut allow = confirm.clone();
         allow.rules[0].authenticate = AgentCeremonyPolicy {
             authorization: AgentAuthorization::Allow,
-            user_presence: UserPresenceSource::Policy,
-            user_verification: UserVerificationSource::Policy,
+            user_presence: UserPresenceSource::Agent,
+            user_verification: UserVerificationSource::Agent,
         };
 
         assert_ne!(confirm.digest(), allow.digest());

--- a/passless-core/src/agent/protocol.rs
+++ b/passless-core/src/agent/protocol.rs
@@ -151,6 +151,7 @@ pub enum ErrorCode {
     Forbidden,
     NotFound,
     Conflict,
+    InteractionRequired,
     Internal,
     VersionMismatch,
     MessageTooLarge,
@@ -165,6 +166,7 @@ impl fmt::Display for ErrorCode {
             Self::Forbidden => write!(f, "forbidden"),
             Self::NotFound => write!(f, "not_found"),
             Self::Conflict => write!(f, "conflict"),
+            Self::InteractionRequired => write!(f, "interaction_required"),
             Self::Internal => write!(f, "internal"),
             Self::VersionMismatch => write!(f, "version_mismatch"),
             Self::MessageTooLarge => write!(f, "message_too_large"),
@@ -538,6 +540,8 @@ const MAX_ALLOW_CREDENTIALS: usize = 64;
 #[serde(deny_unknown_fields)]
 pub struct RegisterCredentialRequest {
     pub origin: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub top_origin: Option<String>,
     pub rp_id: String,
     pub challenge_b64u: String,
     pub user_id_b64u: String,
@@ -547,6 +551,8 @@ pub struct RegisterCredentialRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rp_name: Option<String>,
     pub exclude_credentials: Vec<String>,
+    #[serde(default)]
+    pub pub_key_cred_params: Vec<i32>,
     pub user_verification: bool,
     pub cross_origin: bool,
 }
@@ -555,6 +561,7 @@ pub struct RegisterCredentialRequest {
 #[serde(deny_unknown_fields)]
 pub struct RegisterCredentialResponse {
     pub credential_id_b64u: String,
+    pub public_key_algorithm: i32,
     pub authenticator_data_b64u: String,
     pub attestation_object_b64u: String,
     pub client_data_json_b64u: String,
@@ -564,6 +571,8 @@ pub struct RegisterCredentialResponse {
 #[serde(deny_unknown_fields)]
 pub struct SignAssertionRequest {
     pub origin: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub top_origin: Option<String>,
     pub rp_id: String,
     pub challenge_b64u: String,
     #[serde(default)]
@@ -1318,6 +1327,9 @@ impl Validate for PrincipalRequest {
             }
             Self::SignAssertion(req) => {
                 check_str(&req.origin, "origin", MAX_ORIGIN_LEN, &mut errors);
+                if let Some(ref top_origin) = req.top_origin {
+                    check_str(top_origin, "top_origin", MAX_ORIGIN_LEN, &mut errors);
+                }
                 check_str(&req.rp_id, "rp_id", MAX_RP_ID_LEN, &mut errors);
                 check_str(
                     &req.challenge_b64u,
@@ -1349,6 +1361,9 @@ impl Validate for RegisterCredentialRequest {
     fn validate(&self) -> Result<(), ValidationErrors> {
         let mut errors = Vec::new();
         check_str(&self.origin, "origin", MAX_REG_ORIGIN_LEN, &mut errors);
+        if let Some(ref top_origin) = self.top_origin {
+            check_str(top_origin, "top_origin", MAX_REG_ORIGIN_LEN, &mut errors);
+        }
         check_str(&self.rp_id, "rp_id", MAX_RP_ID_LEN, &mut errors);
         check_str(
             &self.challenge_b64u,
@@ -1374,6 +1389,12 @@ impl Validate for RegisterCredentialRequest {
         }
         if let Some(ref name) = self.rp_name {
             check_str(name, "rp_name", MAX_DISPLAY_NAME_LEN, &mut errors);
+        }
+        if self.pub_key_cred_params.is_empty() {
+            errors.push("pub_key_cred_params: must contain at least one algorithm".into());
+        }
+        if self.pub_key_cred_params.len() > 16 {
+            errors.push("pub_key_cred_params: exceeds maximum count 16".into());
         }
         if self.exclude_credentials.len() > MAX_REG_EXCLUDE_CREDENTIALS {
             errors.push(format!(
@@ -1804,6 +1825,7 @@ mod tests {
             ErrorCode::Forbidden,
             ErrorCode::NotFound,
             ErrorCode::Conflict,
+            ErrorCode::InteractionRequired,
             ErrorCode::Internal,
             ErrorCode::VersionMismatch,
             ErrorCode::MessageTooLarge,
@@ -2973,6 +2995,7 @@ mod tests {
     fn valid_sign_request() -> SignAssertionRequest {
         SignAssertionRequest {
             origin: "https://example.com".to_string(),
+            top_origin: None,
             rp_id: "example.com".to_string(),
             challenge_b64u: "dGVzdA".to_string(),
             allow_credentials: vec![],

--- a/tools/agent-validation/browser/principal-driver.sh
+++ b/tools/agent-validation/browser/principal-driver.sh
@@ -69,7 +69,7 @@ browser_evaluate() {
         <<<"$response"
 }
 
-run_delegated() {
+run_same_user() {
     local session_ttl="${AV_SESSION_TTL_SECS:-30}"
     local wrong_rp="${AV_WRONG_RP_ID:-wrong.invalid}"
     local wrong_credential="0000000000000000000000000000000000000000000000000000000000000000"
@@ -103,17 +103,17 @@ run_delegated() {
 
     result=$(browser_evaluate '(async()=>{const l=document.getElementById("log");const b=(l.innerText.match(/AUTH OK/g)||[]).length;document.getElementById("btnAuthenticate").click();for(let i=0;i<300;i++){await new Promise(r=>setTimeout(r,100));const t=l.innerText;if((t.match(/AUTH OK/g)||[]).length>b)return "auth_ok";if(t.includes("AUTH FAIL")||t.includes("Authentication error"))return "auth_failed";}return "timeout";})()')
     [[ "$result" == "auth_ok" ]] || exit 23
-    write_event delegated_authentication approved
+    write_event same_user_authentication approved
 
-    result=$(browser_evaluate '(async()=>{const l=document.getElementById("log");const b=(l.innerText.match(/AUTH FAIL|Authentication error/g)||[]).length;document.getElementById("btnAuthenticate").click();for(let i=0;i<300;i++){await new Promise(r=>setTimeout(r,100));const n=(l.innerText.match(/AUTH FAIL|Authentication error/g)||[]).length;if(n>b)return "denied";}return "not_denied";})()')
-    [[ "$result" == "denied" ]] || exit 24
-    write_event second_assertion_denied denied
+    result=$(browser_evaluate '(async()=>{const l=document.getElementById("log");const b=(l.innerText.match(/AUTH OK/g)||[]).length;document.getElementById("btnAuthenticate").click();for(let i=0;i<300;i++){await new Promise(r=>setTimeout(r,100));const t=l.innerText;if((t.match(/AUTH OK/g)||[]).length>b)return "auth_ok";if(t.includes("AUTH FAIL")||t.includes("Authentication error"))return "auth_failed";}return "timeout";})()')
+    [[ "$result" == "auth_ok" ]] || exit 24
+    write_event second_assertion_approved approved
 
-    jq -n '{flow:"delegated",wrong_rp:"denied",wrong_credential:"denied",authentication:"approved",second_assertion:"denied"}'
+    jq -n '{flow:"same-user",wrong_rp:"denied",wrong_credential:"denied",authentication:"approved",second_assertion:"approved"}'
 }
 
 case "$FLOW" in
     isolated) run_isolated ;;
-    delegated) run_delegated ;;
+    same-user) run_same_user ;;
     *) exit 2 ;;
 esac

--- a/tools/agent-validation/stages/agent-ceremonies.sh
+++ b/tools/agent-validation/stages/agent-ceremonies.sh
@@ -78,7 +78,7 @@ stage_agent_ceremonies() {
     local results_file="${EVIDENCE_DIR:-/tmp}/agent-ceremonies-results.json"
     local passless_bin="${AV_PASSLESS_BIN:-}"
     local isolated_profile="${AV_ISOLATED_PROFILE_ID:-}"
-    local delegated_profile="${AV_DELEGATED_PROFILE_ID:-}"
+    local same_user_profile="${AV_SAME_USER_PROFILE_ID:-}"
     local rp_id="${AV_RP_ID:-}"
     local rp_url="${AV_RP_URL:-}"
     local browser_user="${AV_BROWSER_USER:-}"
@@ -92,7 +92,7 @@ stage_agent_ceremonies() {
         return 0
     fi
 
-    if [[ -z "$passless_bin" || -z "$isolated_profile" || -z "$delegated_profile" \
+    if [[ -z "$passless_bin" || -z "$isolated_profile" || -z "$same_user_profile" \
         || -z "$rp_id" || -z "$rp_url" || -z "$browser_user" \
         || -z "$principal_user" || -z "$shared_root" ]]; then
         _av_ceremony_skip "$results_file" "live ceremony variables are incomplete"
@@ -174,24 +174,24 @@ stage_agent_ceremonies() {
     jq -e '.flow == "isolated" and .registration == "approved" and .authentication == "approved"' \
         "$isolated_dir/result.json" >/dev/null
 
-    local delegated_dir="$coord_root/delegated"
-    mkdir -p "$delegated_dir"
+    local same_user_dir="$coord_root/same-user"
+    mkdir -p "$same_user_dir"
     if [[ $EUID -eq 0 ]]; then
-        chown "$(id -u):$principal_gid" "$delegated_dir"
+        chown "$(id -u):$principal_gid" "$same_user_dir"
     else
-        sudo -- chown "$(id -u):$principal_gid" "$delegated_dir"
+        sudo -- chown "$(id -u):$principal_gid" "$same_user_dir"
     fi
-    chmod 770 "$delegated_dir"
+    chmod 770 "$same_user_dir"
 
-    _av_run_principal "$delegated_profile" \
-        AV_PASSLESS_BIN="$passless_bin" AV_PROFILE_ID="$delegated_profile" AV_RP_ID="$rp_id" \
-        AV_PRINCIPAL_FLOW=delegated \
-        AV_COORD_DIR="$delegated_dir" \
-        >"$delegated_dir/result.json" 2>"$delegated_dir/launch.stderr"
-    jq -e '.flow == "delegated" and .authentication == "approved" and .second_assertion == "denied" \
+    _av_run_principal "$same_user_profile" \
+        AV_PASSLESS_BIN="$passless_bin" AV_PROFILE_ID="$same_user_profile" AV_RP_ID="$rp_id" \
+        AV_PRINCIPAL_FLOW=same-user \
+        AV_COORD_DIR="$same_user_dir" \
+        >"$same_user_dir/result.json" 2>"$same_user_dir/launch.stderr"
+    jq -e '.flow == "same-user" and .authentication == "approved" and .second_assertion == "approved" \
         and .wrong_rp == "denied" and .wrong_credential == "denied"' \
-        "$delegated_dir/result.json" >/dev/null
+        "$same_user_dir/result.json" >/dev/null
 
-    jq -n '{status:"passed",isolated:{registration:"approved",authentication:"approved"},delegated:{authentication:"approved",second_assertion:"denied",wrong_rp:"denied",wrong_credential:"denied"}}' \
+    jq -n '{status:"passed",isolated:{registration:"approved",authentication:"approved"},same_user:{authentication:"approved",second_assertion:"approved",wrong_rp:"denied",wrong_credential:"denied"}}' \
         > "$results_file"
 }

--- a/tools/agent-validation/stages/browser-lease.sh
+++ b/tools/agent-validation/stages/browser-lease.sh
@@ -15,9 +15,9 @@ stage_browser_lease() {
     local ceremony_file="${evidence_dir}/agent-ceremonies-results.json"
 
     if [[ ! -f "$ceremony_file" ]] \
-        || ! jq -e '.status == "passed" and .delegated.authentication == "approved" \
-            and .delegated.second_assertion == "denied"' "$ceremony_file" >/dev/null 2>&1; then
-        jq -n '{status:"skipped",reason:"live delegated ceremony evidence unavailable"}' \
+        || ! jq -e '.status == "passed" and .same_user.authentication == "approved" \
+            and .same_user.second_assertion == "approved"' "$ceremony_file" >/dev/null 2>&1; then
+        jq -n '{status:"skipped",reason:"live same-user ceremony evidence unavailable"}' \
             > "$results_file"
         # shellcheck disable=SC2034
         STAGE_SKIPPED=true
@@ -33,7 +33,8 @@ stage_browser_lease() {
         agent::browser::tests::test_pid_mismatch_cleanup_quarantines
         agent::browser::tests::test_login_timeout_expires_pending_lease
         agent::browser::tests::test_transport_failure_pending_cleanup
-        agent::grant::tests::test_claim_one_shot_cannot_reuse
+        agent::sign::tests::test_registry_request_budget_is_shared_for_one_bearer
+        agent::sign::tests::sign_handler_tests::dynamic_grant_discovers_credential_created_after_approval
     )
     local test_name
     local log_file="${evidence_dir}/browser-lease-tests.log"
@@ -61,6 +62,6 @@ stage_browser_lease() {
     done
 
     jq -n --argjson count "${#tests[@]}" \
-        '{status:"passed",live_one_shot:true,deterministic_lifecycle_tests:$count}' \
+        '{status:"passed",live_bounded_session:true,deterministic_lifecycle_tests:$count}' \
         > "$results_file"
 }

--- a/tools/agent-validation/stages/uninstall-rehearsal.sh
+++ b/tools/agent-validation/stages/uninstall-rehearsal.sh
@@ -313,7 +313,7 @@ stage_uninstall_rehearsal() {
     local profile_ids=()
     IFS=',' read -ra profile_ids <<< "$profile_ids_csv"
     if [[ ${#profile_ids[@]} -lt 2 ]]; then
-        add_check "PREREQ-07" "profile_set" "skip" "isolated and delegated profile IDs are required"
+        add_check "PREREQ-07" "profile_set" "skip" "isolated and same-user profile IDs are required"
         jq -n --argjson checks "$checks_json" \
             '{violations:0,checks:$checks,status:"skipped"}' > "$report_file"
         # shellcheck disable=SC2034

--- a/tools/agent-validation/tests/test-tier2-stages.sh
+++ b/tools/agent-validation/tests/test-tier2-stages.sh
@@ -459,7 +459,7 @@ test_tier2_no_skip_stage_in_tier2() {
 }
 
 test_browser_lease_requires_semantics() {
-    log_test "browser-lease requires live one-shot and exact lifecycle tests"
+    log_test "browser-lease requires live bounded-session and exact lifecycle tests"
 
     if grep -q 'agent-ceremonies-results.json' "${STAGES_DIR}/browser-lease.sh"; then
         log_pass "browser-lease requires live ceremony evidence"
@@ -489,10 +489,10 @@ test_agent_ceremonies_requires_explicit_config() {
         log_fail "agent-ceremonies does not require AV_ISOLATED_PROFILE_ID"
     fi
 
-    if grep -q "AV_DELEGATED_PROFILE_ID" "${STAGES_DIR}/agent-ceremonies.sh"; then
-        log_pass "agent-ceremonies requires AV_DELEGATED_PROFILE_ID"
+    if grep -q "AV_SAME_USER_PROFILE_ID" "${STAGES_DIR}/agent-ceremonies.sh"; then
+        log_pass "agent-ceremonies requires AV_SAME_USER_PROFILE_ID"
     else
-        log_fail "agent-ceremonies does not require AV_DELEGATED_PROFILE_ID"
+        log_fail "agent-ceremonies does not require AV_SAME_USER_PROFILE_ID"
     fi
 
     if grep -q "AV_RP_URL" "${STAGES_DIR}/agent-ceremonies.sh"; then
@@ -519,7 +519,7 @@ test_agent_ceremonies_uses_intents() {
 }
 
 test_agent_ceremonies_uses_delegation() {
-    log_test "agent-ceremonies uses delegation for delegated flow"
+    log_test "agent-ceremonies uses delegation grants for same-user flow"
 
     if grep -q "delegation request" "${VALIDATION_DIR}/browser/principal-driver.sh"; then
         log_pass "agent-ceremonies uses delegation request"

--- a/tools/agent-validation/tests/test-tier3-stages.sh
+++ b/tools/agent-validation/tests/test-tier3-stages.sh
@@ -174,7 +174,7 @@ test_stage_uninstall_rehearsal_dry_run() {
     source "${STAGES_DIR}/uninstall-rehearsal.sh"
 
     export AV_UNINSTALL_PASSLESS_BIN="/usr/bin/passless"
-    export AV_UNINSTALL_PROFILE_IDS="test-isolated,test-delegated"
+    export AV_UNINSTALL_PROFILE_IDS="test-isolated,test-same-user"
     export AV_UNINSTALL_HUMAN_STORE="/tmp/human-store"
     export AV_UNINSTALL_STORE_FORMAT="local-json"
     export AV_UNINSTALL_RP_URL="http://127.0.0.1:8443"

--- a/tools/agent-validation/tests/test-uninstall-rehearsal.sh
+++ b/tools/agent-validation/tests/test-uninstall-rehearsal.sh
@@ -455,7 +455,7 @@ test_stage_dry_run_always_skips() {
     source "${STAGES_DIR}/uninstall-rehearsal.sh"
 
     export AV_UNINSTALL_PASSLESS_BIN="/usr/bin/passless"
-    export AV_UNINSTALL_PROFILE_IDS="test-isolated,test-delegated"
+    export AV_UNINSTALL_PROFILE_IDS="test-isolated,test-same-user"
     export AV_UNINSTALL_HUMAN_STORE="/tmp/human-store"
     export AV_UNINSTALL_STORE_FORMAT="local-json"
     export AV_UNINSTALL_RP_URL="http://127.0.0.1:8443"
@@ -502,7 +502,7 @@ test_stage_skips_with_unsupported_format() {
     source "${STAGES_DIR}/uninstall-rehearsal.sh"
 
     export AV_UNINSTALL_PASSLESS_BIN="/usr/bin/passless"
-    export AV_UNINSTALL_PROFILE_IDS="test-isolated,test-delegated"
+    export AV_UNINSTALL_PROFILE_IDS="test-isolated,test-same-user"
     export AV_UNINSTALL_HUMAN_STORE="${TEST_TMP_DIR}/some-store"
     export AV_UNINSTALL_STORE_FORMAT="tpm"
     export AV_UNINSTALL_RP_URL="http://127.0.0.1:8443"


### PR DESCRIPTION
## Summary

Implements the unified Passless agent authentication model described by ADR 0007:

- **`same-user`** uses the existing human credential backend, PIN service, key provider, counters, and operation lock.
- **`isolated`** retains a separate credential namespace, provider, browser state, and revocation lifecycle.
- Both modes use the daemon-backed MV3 WebAuthn extension and the same bounded operation pipeline.

This replaces closed PR #401. Its head branch was moved to an unrelated AUR/release commit; GitHub would not reopen it after the original branch was reconstructed. The overwritten head is preserved at `backup/unified-agent-modes-adr-overwrite-20260806`.

## Implementation

- Add fail-closed `same-user` and `isolated` mode validation.
- Add `deny`, `autonomous`, and `supervised` ceremony-policy aliases.
- Distinguish agent-derived UP/UV from genuine human-derived evidence.
- Bind storage, PIN storage, key provider, namespace, and operation lock in one backend handle.
- Route same-user operations through the actual human backend and isolated operations through profile-owned backends.
- Propagate software and portable-TPM key providers without silent substitution.
- Perform scoped multi-credential discovery and deterministic selection.
- Negotiate registration algorithms and propagate correct UP/UV/AT flags.
- Support immediate authentication with credentials registered during the same browser session.
- Share one bounded operation budget across registration and authentication.
- Reject replayed operation bodies and re-evaluate policy for every distinct request.
- Validate caller origin, top origin, RP relationship, cross-origin context, and Permissions Policy.
- Support extension timeout, cancellation, native fallback, serialization, and `toJSON()` behavior.
- Replace obsolete delegated-session validation and documentation with same-user migration guidance.

## Automated validation completed

The implementation has passed:

- repository pre-commit and commit-message checks;
- Rustfmt;
- Clippy across the workspace, all targets and all features, with warnings denied;
- x86_64 build and unit/integration tests;
- AArch64 build and unit/integration tests;
- 59 agent-extension behavioral scenarios;
- the complete twelve-phase `make test-agent-validation` harness;
- 33 Tier 2 browser/principal validation scenarios;
- 15 Tier 3 lifecycle scenarios;
- 39 uninstall/rehearsal scenarios;
- shell syntax and ShellCheck across the release-lab harness.

Regression coverage includes audit denials, interaction-required status mapping, RP and credential-scope denial, shared bearer budgets, replay rejection, deterministic credential selection, and post-registration credential discovery.

## Environment-dependent release evidence

These cannot be honestly certified by ordinary GitHub-hosted CI and remain explicit external gates:

- a live relying-party same-user registration/authentication round trip;
- a live relying-party isolated-mode regression round trip;
- portable-TPM registration/authentication against physical or recorded TPM laboratory hardware;
- independent security review of autonomous agent-derived UV and the browser-extension trust boundary.

A real Chromium MV3 integration harness was attempted in the available container. Chromium headless did not load the unpacked extension, while the headed Xvfb process did not expose a usable DevTools endpoint, so that environment did not produce trustworthy browser E2E evidence. This is reported as unverified rather than passed.

## Review status

Ready for implementation and security review once the final clean CI run on the squashed commit is green. External hardware/live-RP gates remain release evidence, not hidden software-test claims.