### PR TITLE
feat: add same-user catch-all RP authentication

### DIFF
--- a/cmd/passless/src/agent/browser.rs
+++ b/cmd/passless/src/agent/browser.rs
@@ -15,7 +15,7 @@ use std::process::{Child, Command, ExitStatus, Stdio};
 use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
-use passless_core::agent::config::CdpExposeMode;
+use passless_core::agent::config::{ANY_RP_ID, CdpExposeMode, validate_rp_id};
 use passless_core::agent::{BrowserLeaseId, EndpointId, ProfileId};
 
 use rand::Rng;
@@ -1524,6 +1524,10 @@ fn validate_start_url(url: &str, rp_ids: &[String]) -> Result<(), ()> {
     }
 
     let host_normalized = host.to_ascii_lowercase();
+
+    if rp_ids.iter().any(|rp_id| rp_id.trim() == ANY_RP_ID) {
+        return validate_rp_id(&host_normalized).map(|_| ()).map_err(|_| ());
+    }
 
     let matching: Vec<&str> = rp_ids
         .iter()

--- a/cmd/passless/src/agent/grant.rs
+++ b/cmd/passless/src/agent/grant.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 
+use passless_core::agent::config::ANY_RP_ID;
 use passless_core::agent::{
     CredentialRef, EndpointId, GrantId, PolicyDigest, PolicyGenerationId, PrincipalSessionId,
     ProfileId, RegistrationGrantId,
@@ -285,6 +286,18 @@ pub fn normalize_rp_id(raw: &str) -> Result<String, GrantError> {
     Ok(trimmed)
 }
 
+fn normalize_scope_rp_id(raw: &str) -> Result<String, GrantError> {
+    let trimmed = raw.trim().to_ascii_lowercase();
+    if trimmed == ANY_RP_ID {
+        return Ok(trimmed);
+    }
+    normalize_rp_id(&trimmed)
+}
+
+fn rp_scope_contains(scope: &BTreeSet<String>, rp_id: &str) -> bool {
+    scope.contains(rp_id) || scope.contains(ANY_RP_ID)
+}
+
 fn validate_rp_ids(rp_ids: &[String]) -> Result<BTreeSet<String>, GrantError> {
     if rp_ids.is_empty() {
         return Err(GrantError::EmptyRpIdSet);
@@ -294,7 +307,7 @@ fn validate_rp_ids(rp_ids: &[String]) -> Result<BTreeSet<String>, GrantError> {
     }
     let mut normalized = BTreeSet::new();
     for raw in rp_ids {
-        let n = normalize_rp_id(raw)?;
+        let n = normalize_scope_rp_id(raw)?;
         normalized.insert(n);
     }
     Ok(normalized)
@@ -793,7 +806,7 @@ impl GrantRegistry {
                     && g.principal_digest == *query.principal_digest
                     && g.policy_generation == *query.policy_generation
                     && g.policy_digest == *query.policy_digest
-                    && g.rp_ids.contains(&normalized_rp)
+                    && rp_scope_contains(&g.rp_ids, &normalized_rp)
                     && g.expiry_mono > now
                     && match (query.credential_ref, g.credentials.iter().next()) {
                         (Some(cr), _) => g.credentials.contains(cr),
@@ -833,7 +846,7 @@ impl GrantRegistry {
             return Err(GrantError::PolicyMismatch);
         }
 
-        if !grant.rp_ids.contains(&normalized_rp) {
+        if !rp_scope_contains(&grant.rp_ids, &normalized_rp) {
             return Err(GrantError::RpIdNotInGrant(normalized_rp));
         }
 
@@ -1362,6 +1375,15 @@ mod tests {
     }
 
     #[test]
+    fn test_global_wildcard_scope_normalizes() {
+        assert_eq!(normalize_scope_rp_id(" * ").unwrap(), ANY_RP_ID);
+        assert!(matches!(
+            normalize_scope_rp_id("*.example.com"),
+            Err(GrantError::WildcardRpId(_))
+        ));
+    }
+
+    #[test]
     fn test_normalize_rp_id_rejects_empty() {
         assert!(normalize_rp_id("").is_err());
         assert!(normalize_rp_id("   ").is_err());
@@ -1480,6 +1502,29 @@ mod tests {
         assert_eq!(snap.state, GrantState::Active);
         assert_eq!(snap.profile_id, test_profile_id());
         assert!(snap.rp_ids.contains("example.com"));
+    }
+
+    #[test]
+    fn test_global_wildcard_grant_allows_concrete_rp_claim() {
+        let clock = test_clock();
+        let mut registry = make_registry(&clock);
+        let session = test_session_id();
+        let cred = test_cred(b"c1");
+        let gid = request_and_approve(
+            &mut registry,
+            &session,
+            vec![ANY_RP_ID.to_string()],
+            vec![cred.clone()],
+            60,
+        );
+
+        let intent = ClaimIntent {
+            action: "get_assertion".to_string(),
+            rp_id: "example.com".to_string(),
+            credential_ref: cred,
+        };
+
+        assert!(registry.claim(&gid, &session, intent).is_ok());
     }
 
     #[test]
@@ -1998,7 +2043,7 @@ mod tests {
     }
 
     #[test]
-    fn test_no_wildcard_rp_ids() {
+    fn test_no_partial_wildcard_rp_ids() {
         let clock = test_clock();
         let mut registry = make_registry(&clock);
         let session = test_session_id();
@@ -2664,7 +2709,7 @@ mod tests {
             session,
             test_endpoint_id(),
             test_digest(1000),
-            "*.example.com".to_string(),
+            ANY_RP_ID.to_string(),
             60,
         );
         assert!(matches!(result, Err(GrantError::WildcardRpId(_))));

--- a/cmd/passless/src/agent/policy_engine.rs
+++ b/cmd/passless/src/agent/policy_engine.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 
+use passless_core::agent::config::{ANY_RP_ID, validate_rp_id};
 use passless_core::agent::protocol::IntentAction;
 use passless_core::agent::{
     AgentAuthorization, AgentCeremonyPolicy, AgentConfig, AgentMode, AgentProfileConfig,
@@ -193,17 +194,23 @@ impl PolicySnapshot {
     }
 
     pub fn is_rp_exact_match(&self, rp_id: &str) -> bool {
-        let normalized = rp_id.trim().to_ascii_lowercase();
+        let Ok(normalized) = validate_rp_id(rp_id) else {
+            return false;
+        };
         self.normalized_rp_ids.contains(&normalized)
+            || self.normalized_rp_ids.iter().any(|id| id == ANY_RP_ID)
     }
 
     pub fn is_suffix_only(&self, rp_id: &str) -> bool {
-        let normalized = rp_id.trim().to_ascii_lowercase();
+        let Ok(normalized) = validate_rp_id(rp_id) else {
+            return false;
+        };
         if self.is_rp_exact_match(&normalized) {
             return false;
         }
         self.normalized_rp_ids
             .iter()
+            .filter(|id| id.as_str() != ANY_RP_ID)
             .any(|id| normalized.ends_with(&format!(".{}", id)))
     }
 
@@ -220,14 +227,20 @@ impl PolicySnapshot {
         rp_id: &str,
         action: &IntentAction,
     ) -> Option<&AgentCeremonyPolicy> {
-        let normalized = rp_id.trim().to_ascii_lowercase();
-        self.rules
+        let normalized = validate_rp_id(rp_id).ok()?;
+        let rule = self
+            .rules
             .iter()
-            .find(|rule| rule.rp_id.trim().to_ascii_lowercase() == normalized)
-            .map(|rule| match action {
-                IntentAction::Register => &rule.register,
-                IntentAction::Authenticate => &rule.authenticate,
-            })
+            .find(|rule| rule.rp_id.trim().eq_ignore_ascii_case(&normalized))
+            .or_else(|| {
+                self.rules
+                    .iter()
+                    .find(|rule| rule.rp_id.trim() == ANY_RP_ID)
+            })?;
+        Some(match action {
+            IntentAction::Register => &rule.register,
+            IntentAction::Authenticate => &rule.authenticate,
+        })
     }
 }
 
@@ -2427,6 +2440,55 @@ mod tests {
         );
         assert!(snapshot.action_allowed(&IntentAction::Authenticate));
         assert!(!snapshot.action_allowed(&IntentAction::Register));
+    }
+
+    #[test]
+    fn test_compile_same_user_wildcard_policy_with_exact_override() {
+        let mut config = make_isolated_config("wildcard", vec![], false);
+        let profile = config.profiles.get_mut("wildcard").unwrap();
+        profile.mode = AgentMode::SameUser;
+        profile.storage = None;
+        profile.rules = vec![
+            AgentRpRule {
+                rp_id: ANY_RP_ID.to_string(),
+                register: AgentCeremonyPolicy::deny(),
+                authenticate: AgentCeremonyPolicy::autonomous(),
+            },
+            AgentRpRule {
+                rp_id: "bank.example.com".to_string(),
+                register: AgentCeremonyPolicy::deny(),
+                authenticate: AgentCeremonyPolicy::supervised(),
+            },
+        ];
+
+        let generation = PolicyRuntime::compile_generation(&config, 0).unwrap();
+        let snapshot = &generation.snapshots[0];
+
+        assert!(snapshot.is_rp_exact_match("github.com"));
+        assert_eq!(
+            snapshot
+                .ceremony_policy("github.com", &IntentAction::Authenticate)
+                .unwrap(),
+            &AgentCeremonyPolicy::autonomous()
+        );
+        assert_eq!(
+            snapshot
+                .ceremony_policy("bank.example.com", &IntentAction::Authenticate)
+                .unwrap(),
+            &AgentCeremonyPolicy::supervised()
+        );
+        assert_eq!(
+            snapshot
+                .ceremony_policy("github.com", &IntentAction::Register)
+                .unwrap(),
+            &AgentCeremonyPolicy::deny()
+        );
+        assert!(!snapshot.is_rp_exact_match("com"));
+        assert!(
+            snapshot
+                .ceremony_policy("com", &IntentAction::Authenticate)
+                .is_none()
+        );
     }
 
     #[test]

--- a/cmd/passless/src/agent/runtime.rs
+++ b/cmd/passless/src/agent/runtime.rs
@@ -4763,6 +4763,13 @@ impl AgentRuntime {
         // Request registration grants for all allowed RP IDs
         let mut registration_grants = std::collections::HashMap::new();
         for rp_id in &config.rp_ids {
+            let registration_allowed = profile_config.rule_for_rp(rp_id).is_some_and(|rule| {
+                rule.register.authorization != passless_core::agent::AgentAuthorization::Deny
+            });
+            if !registration_allowed {
+                continue;
+            }
+
             match self
                 .policy_runtime
                 .request_registration_grant(profile_id.clone(), rp_id.clone())

--- a/cmd/passless/src/agent/sign.rs
+++ b/cmd/passless/src/agent/sign.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use log::{debug, warn};
 use sha2::{Digest, Sha256};
 
-use passless_core::agent::config::CredentialSelection;
+use passless_core::agent::config::{ANY_RP_ID, CredentialSelection};
 use passless_core::agent::protocol::{
     ErrorCode, PrincipalResponse, ProtocolError, RecommendedAction, RegisterCredentialRequest,
     SignAssertionRequest, SignAssertionResponse,
@@ -1067,11 +1067,10 @@ impl SignHandler {
             ));
         }
 
-        if !grant_snapshot
-            .rp_ids
-            .iter()
-            .any(|id| normalize_rp_id(id) == normalized_rp)
-        {
+        if !grant_snapshot.rp_ids.iter().any(|id| {
+            let scope_rp = normalize_rp_id(id);
+            scope_rp == normalized_rp || scope_rp == ANY_RP_ID
+        }) {
             let deny_event = PolicyDenyBuilder::new(
                 ctx.profile_id.clone(),
                 AuditAction::Authenticate,

--- a/docs/agents/same-user.md
+++ b/docs/agents/same-user.md
@@ -1,6 +1,6 @@
 # Same-user mode
 
-> **EXPERIMENTAL** — Same-user mode deliberately gives the configured agent bounded authority to act as the human user for exact relying parties. Review the policy and verification evidence before enabling it.
+> **EXPERIMENTAL** — Same-user mode deliberately gives the configured agent bounded authority to act as the human user for its configured relying-party scope. Review the policy and verification evidence before enabling it.
 
 `same-user` uses the daemon's existing human credential backend. It does not copy, reopen, or export passkey material. Registration and authentication are performed by the daemon through the same storage, key provider, operation lock, signature counters, and local-verification services used by the human authenticator.
 
@@ -54,6 +54,33 @@ credential_selection = "credential:<credential-ref-hex>"
 ```
 
 Other selection policies are `single`, `first-matching`, and `newest`. `single` fails closed when more than one eligible credential exists.
+
+### Catch-all authentication
+
+A `same-user` profile can deliberately authorize authentication to any valid concrete WebAuthn RP by using the global `"*"` rule. This is the broadest same-user authority and should only be used when the agent is trusted to act as the human user across sites.
+
+```toml
+[agents.profiles.opencode]
+mode = "same-user"
+principal_user = "passless-opencode"
+browser_command = ["chromium"]
+browser_runtime_root = "/run/passless-agent/opencode"
+max_session_ttl = 600
+max_operations = 32
+credential_selection = "newest"
+# credential_refs intentionally omitted
+
+[[agents.profiles.opencode.rules]]
+rp_id = "*"
+authenticate = "autonomous"
+register = "deny"
+```
+
+The `"*"` value is a policy sentinel, not a WebAuthn RP ID. Every ceremony still carries and validates its concrete RP and origin, and dynamic discovery only considers human credentials whose stored RP matches that concrete ceremony RP. Partial wildcards such as `"*.example.com"` are rejected.
+
+Catch-all scope is intentionally limited to `same-user` authentication: `credential_refs` must be omitted, wildcard registration is denied, and isolated profiles cannot use it. Exact rules may coexist with `"*"` and take precedence, which allows a broad autonomous default with supervised or denied exceptions.
+
+When several discoverable credentials exist for the same RP, use a deterministic selection policy such as `newest`; an RP-provided `allowCredentials` list still constrains selection first. Prefer explicit RP rules whenever the broader authority is unnecessary.
 
 ## Registration
 

--- a/passless-core/src/agent/config.rs
+++ b/passless-core/src/agent/config.rs
@@ -26,6 +26,8 @@ const HUMAN_DEVICE_PHYS: &str = "virtual-fido-001";
 const HUMAN_VENDOR_ID: u16 = 0x15d9;
 const HUMAN_PRODUCT_ID: u16 = 0x0a37;
 
+pub const ANY_RP_ID: &str = "*";
+
 const DEFAULT_MAX_OPERATIONS: u16 = 64;
 const MAX_OPERATIONS: u16 = 4096;
 
@@ -677,10 +679,17 @@ impl AgentProfileConfig {
     }
 
     pub fn rule_for_rp(&self, rp_id: &str) -> Option<AgentRpRule> {
-        let normalized = rp_id.trim().to_ascii_lowercase();
-        self.effective_rules()
+        let normalized = validate_rp_id(rp_id).ok()?;
+        let rules = self.effective_rules();
+        if let Some(rule) = rules
+            .iter()
+            .find(|rule| normalize_rp_id(&rule.rp_id) == normalized)
+        {
+            return Some(rule.clone());
+        }
+        rules
             .into_iter()
-            .find(|rule| rule.rp_id.trim().to_ascii_lowercase() == normalized)
+            .find(|rule| normalize_rp_id(&rule.rp_id) == ANY_RP_ID)
     }
 
     pub fn allows_registration(&self) -> bool {
@@ -739,7 +748,7 @@ impl AgentProfileConfig {
         let effective_rules = self.effective_rules();
         let mut normalized_rules = std::collections::BTreeSet::new();
         for rule in &effective_rules {
-            validate_rp_id(&rule.rp_id)?;
+            validate_agent_rp_rule_id(&rule.rp_id)?;
             let normalized = rule.rp_id.trim().to_ascii_lowercase();
             if !normalized_rules.insert(normalized) {
                 return Err(Error::Config(format!(
@@ -751,6 +760,36 @@ impl AgentProfileConfig {
                 .validate(profile_id, &rule.rp_id, "registration")?;
             rule.authenticate
                 .validate(profile_id, &rule.rp_id, "authentication")?;
+        }
+
+        if let Some(wildcard_rule) = effective_rules
+            .iter()
+            .find(|rule| normalize_rp_id(&rule.rp_id) == ANY_RP_ID)
+        {
+            if self.rules.is_empty() {
+                return Err(Error::Config(format!(
+                    "agent profile '{}': wildcard RP scope '*' requires explicit rules",
+                    profile_id
+                )));
+            }
+            if self.mode != AgentMode::SameUser {
+                return Err(Error::Config(format!(
+                    "agent profile '{}': wildcard RP scope '*' is only supported in same-user mode",
+                    profile_id
+                )));
+            }
+            if self.credential_refs.is_some() {
+                return Err(Error::Config(format!(
+                    "agent profile '{}': wildcard RP scope '*' requires credential_refs to be omitted for dynamic credential discovery",
+                    profile_id
+                )));
+            }
+            if wildcard_rule.register.authorization != AgentAuthorization::Deny {
+                return Err(Error::Config(format!(
+                    "agent profile '{}': wildcard RP scope '*' must deny registration",
+                    profile_id
+                )));
+            }
         }
 
         if let Some(ref cmd) = self.browser_command {
@@ -937,14 +976,16 @@ impl AgentConfig {
     }
 
     pub fn profiles_for_rp_id(&self, rp_id: &str) -> Vec<(&String, &AgentProfileConfig)> {
-        let normalized = normalize_rp_id(rp_id);
+        let Ok(normalized) = validate_rp_id(rp_id) else {
+            return Vec::new();
+        };
         self.profiles
             .iter()
             .filter(|(_, profile)| {
-                profile
-                    .effective_rules()
-                    .iter()
-                    .any(|rule| normalize_rp_id(&rule.rp_id) == normalized)
+                profile.effective_rules().iter().any(|rule| {
+                    let rule_rp = normalize_rp_id(&rule.rp_id);
+                    rule_rp == normalized || rule_rp == ANY_RP_ID
+                })
             })
             .collect()
     }
@@ -993,6 +1034,14 @@ fn is_valid_dns_name(s: &str) -> bool {
 fn is_public_suffix(domain: &str) -> bool {
     use psl::Psl;
     psl::List.domain(domain.as_bytes()).is_none()
+}
+
+pub fn validate_agent_rp_rule_id(raw: &str) -> Result<String> {
+    let trimmed = raw.trim();
+    if trimmed == ANY_RP_ID {
+        return Ok(ANY_RP_ID.to_string());
+    }
+    validate_rp_id(trimmed)
 }
 
 pub fn validate_rp_id(raw: &str) -> Result<String> {
@@ -1109,6 +1158,12 @@ mod tests {
     fn test_rp_id_reject_wildcard() {
         assert!(validate_rp_id("*.example.com").is_err());
         assert!(validate_rp_id("*").is_err());
+    }
+
+    #[test]
+    fn test_agent_rp_rule_accepts_only_global_wildcard() {
+        assert_eq!(validate_agent_rp_rule_id(" * ").unwrap(), ANY_RP_ID);
+        assert!(validate_agent_rp_rule_id("*.example.com").is_err());
     }
 
     #[test]
@@ -1274,6 +1329,73 @@ register = "deny"
             AgentCeremonyPolicy::autonomous()
         );
         assert!(config.validate(None).is_ok());
+    }
+
+    #[test]
+    fn test_same_user_wildcard_rule_matches_valid_rps_and_exact_rule_wins() {
+        let toml_str = r#"
+enabled = true
+audit_path = "/tmp/passless-agent-audit.jsonl"
+
+[profiles.opencode]
+mode = "same-user"
+principal_user = "alice"
+
+[[profiles.opencode.rules]]
+rp_id = "*"
+authenticate = "autonomous"
+register = "deny"
+
+[[profiles.opencode.rules]]
+rp_id = "bank.example.com"
+authenticate = "supervised"
+register = "deny"
+"#;
+        let config: AgentConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.validate(None).is_ok());
+        let profile = config.profiles.get("opencode").unwrap();
+
+        assert_eq!(
+            profile.rule_for_rp("github.com").unwrap().authenticate,
+            AgentCeremonyPolicy::autonomous()
+        );
+        let exact = profile.rule_for_rp("bank.example.com").unwrap();
+        assert_eq!(exact.authenticate, AgentCeremonyPolicy::supervised());
+        assert_eq!(exact.register, AgentCeremonyPolicy::deny());
+        assert!(profile.rule_for_rp("com").is_none());
+
+        let matches = config.profiles_for_rp_id("github.com");
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].0, "opencode");
+
+        let mut restricted = profile.clone();
+        restricted.credential_refs = Some(vec![CredentialRef::with_default_domain(b"restricted")]);
+        let err = restricted
+            .validate(&ProfileId::new("restricted").unwrap())
+            .unwrap_err();
+        assert!(err.to_string().contains("credential_refs to be omitted"));
+
+        let mut registering = profile.clone();
+        registering.rules[0].register = AgentCeremonyPolicy::autonomous();
+        let err = registering
+            .validate(&ProfileId::new("registering").unwrap())
+            .unwrap_err();
+        assert!(err.to_string().contains("must deny registration"));
+
+        let mut isolated = profile.clone();
+        isolated.mode = AgentMode::Isolated;
+        let err = isolated
+            .validate(&ProfileId::new("isolated-wildcard").unwrap())
+            .unwrap_err();
+        assert!(err.to_string().contains("only supported in same-user mode"));
+
+        let mut legacy = profile.clone();
+        legacy.rules.clear();
+        legacy.rp_ids = vec![ANY_RP_ID.to_string()];
+        let err = legacy
+            .validate(&ProfileId::new("legacy-wildcard").unwrap())
+            .unwrap_err();
+        assert!(err.to_string().contains("requires explicit rules"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add an explicit catch-all RP policy sentinel for `same-user` authentication so a trusted agent can autonomously use any existing human credential for the concrete RP involved in a WebAuthn ceremony.

Example:

```toml
[agents.profiles.opencode]
mode = "same-user"
principal_user = "passless-opencode"
browser_command = ["chromium"]
browser_runtime_root = "/run/passless-agent/opencode"
max_session_ttl = 600
max_operations = 32
credential_selection = "newest"
# credential_refs intentionally omitted

[[agents.profiles.opencode.rules]]
rp_id = "*"
authenticate = "autonomous"
register = "deny"
```

## Security model

`*` is a policy/grant scope sentinel only; it is never treated as the concrete WebAuthn RP. Each ceremony still validates its real RP/origin, and dynamic credential discovery remains restricted to credentials whose stored RP matches that concrete ceremony RP.

The catch-all is intentionally constrained:

- only `same-user` mode may configure it
- it requires explicit `rules` syntax
- `credential_refs` must be omitted, enabling dynamic per-RP discovery
- wildcard registration must be denied
- the registration grant registry continues to reject `*`
- browser launch only creates registration grants for concrete RPs whose effective rule permits registration
- partial wildcards such as `*.example.com` remain invalid
- exact RP rules override the catch-all, allowing supervised/denied exceptions
- wildcard browser start URLs remain HTTPS-only and must resolve to a valid concrete RP host

## Implementation

- teach agent config/profile lookup about the `*` sentinel while preserving normal concrete RP validation
- allow authentication grant scopes to contain `*` and claim them for concrete RPs
- make policy snapshots fall back to the wildcard rule after exact matching
- allow sign-time authentication grant checks to resolve `*` while keeping credential discovery concrete
- keep registration grants concrete-RP-only and avoid creating grants for denied registration rules
- support valid HTTPS start URLs for catch-all browser sessions
- document the broad same-user authority and recommended deterministic credential selection
- add config/grant coverage for wildcard normalization, exact-rule precedence, and guardrails

Based directly on current `master`, including the already-merged background agent-runtime startup fix from #406.