### PR TITLE
feat(agent): expose effective authority

### DIFF
--- a/cmd/passless/src/agent/client.rs
+++ b/cmd/passless/src/agent/client.rs
@@ -296,7 +296,7 @@ fn extract_admin_response(frame: ResponseFrame) -> Result<AdminResponse, ClientE
 
 fn extract_principal_response(frame: ResponseFrame) -> Result<PrincipalResponse, ClientError> {
     match frame {
-        ResponseFrame::Principal(PrincipalResponseFrame::Ok { action, .. }) => Ok(action),
+        ResponseFrame::Principal(PrincipalResponseFrame::Ok { action, .. }) => Ok(*action),
         ResponseFrame::Principal(PrincipalResponseFrame::Error { error, .. }) => {
             Err(ClientError::Protocol(error))
         }

--- a/cmd/passless/src/agent/ipc.rs
+++ b/cmd/passless/src/agent/ipc.rs
@@ -1379,7 +1379,7 @@ mod tests {
         assert_eq!(response.role(), Role::Principal);
         match response {
             ResponseFrame::Principal(PrincipalResponseFrame::Ok { action, .. }) => {
-                assert_eq!(action, PrincipalResponse::Pong);
+                assert_eq!(*action, PrincipalResponse::Pong);
             }
             _ => panic!("expected Principal Ok"),
         }

--- a/cmd/passless/src/agent/prompt.rs
+++ b/cmd/passless/src/agent/prompt.rs
@@ -1019,7 +1019,7 @@ mod tests {
     fn test_prompt_sanitizer_truncates_utf8_on_character_boundaries() {
         let value = "é".repeat(MAX_UNTRUSTED_LEN);
         let sanitized = sanitize_prompt_text(&value, MAX_UNTRUSTED_LEN - 1);
-        assert!(sanitized.len() <= MAX_UNTRUSTED_LEN - 1);
+        assert!(sanitized.len() < MAX_UNTRUSTED_LEN);
         assert!(std::str::from_utf8(sanitized.as_bytes()).is_ok());
     }
 

--- a/cmd/passless/src/agent/runtime.rs
+++ b/cmd/passless/src/agent/runtime.rs
@@ -12,9 +12,11 @@ use std::time::{Duration, Instant};
 use log::{debug, info};
 
 use passless_core::agent::protocol::{
-    AdminRequest, AdminResponse, DoctorResponse, ErrorCode, PeerCred, PrincipalCapabilities,
-    PrincipalInstructions, PrincipalLaunchedResponse, PrincipalRequest, PrincipalResponse,
-    PrincipalWaitResponse, ProtocolError, RecommendedAction,
+    AdminRequest, AdminResponse, AuthorityBrowser, AuthorityCeremony, AuthorityCredentialScope,
+    AuthorityIdentity, AuthorityRisk, AuthorityRpRule, AuthoritySession, DoctorResponse,
+    EffectiveAuthority, ErrorCode, PeerCred, PrincipalCapabilities, PrincipalInstructions,
+    PrincipalLaunchedResponse, PrincipalRequest, PrincipalResponse, PrincipalWaitResponse,
+    ProtocolError, RecommendedAction,
 };
 use passless_core::agent::{
     AgentConfig, AgentMode, AgentProfileConfig, BrowserLeaseId, DaemonStatus, EndpointId,
@@ -2139,6 +2141,144 @@ impl AgentRuntime {
 
     fn revoke_sign_context_for_lease(&self, lease_id: &BrowserLeaseId) {
         self.sign_registry.revoke_by_lease(lease_id.as_str());
+    }
+
+    fn build_effective_authority(
+        &self,
+        profile_id: &ProfileId,
+        profile: &ProfileRuntime,
+        managed: &ManagedPrincipalSession,
+    ) -> EffectiveAuthority {
+        let acts_as_human = profile.mode == AgentMode::SameUser;
+        let rules = profile.profile_config.effective_rules();
+        let wildcard = rules
+            .iter()
+            .any(|rule| rule.rp_id.trim() == passless_core::agent::config::ANY_RP_ID);
+        let autonomous_authentication = rules.iter().any(|rule| {
+            rule.authenticate.authorization == passless_core::agent::AgentAuthorization::Allow
+        });
+        let human_backend_registration = acts_as_human && rules.iter().any(|rule| {
+            rule.register.authorization != passless_core::agent::AgentAuthorization::Deny
+        });
+        let direct_cdp = profile.profile_config.browser_cdp_expose == Some(CdpExposeMode::Port);
+        let ambiguous_selection = matches!(
+            profile.profile_config.credential_selection,
+            passless_core::agent::config::CredentialSelection::FirstMatching
+                | passless_core::agent::config::CredentialSelection::Newest
+        );
+
+        let mut risk_flags = Vec::new();
+        if acts_as_human {
+            risk_flags.push(AuthorityRisk::HumanIdentity);
+        }
+        if wildcard {
+            risk_flags.push(AuthorityRisk::GlobalRpScope);
+        }
+        if autonomous_authentication {
+            risk_flags.push(AuthorityRisk::AutonomousAuthentication);
+        }
+        if human_backend_registration {
+            risk_flags.push(AuthorityRisk::HumanBackendRegistration);
+        }
+        if direct_cdp {
+            risk_flags.push(AuthorityRisk::DirectCdpPort);
+        }
+        if ambiguous_selection {
+            risk_flags.push(AuthorityRisk::AmbiguousCredentialSelection);
+        }
+
+        let active_lease = profile
+            .active_browser
+            .lock()
+            .ok()
+            .and_then(|active| active.as_ref().map(|lease| lease.lease_id.clone()))
+            .or_else(|| {
+                profile.current_pending.lock().ok().and_then(|pending| {
+                    pending
+                        .as_ref()
+                        .and_then(|pending| pending.browser_lease_id.clone())
+                })
+            });
+        let budget = active_lease.as_ref().and_then(|lease_id| {
+            self.sign_registry
+                .budget_snapshot_for_lease(lease_id.as_str())
+        });
+        let (operations_used, operations_remaining) = budget
+            .map(|(used, max)| {
+                (
+                    Some(u16::try_from(used).unwrap_or(u16::MAX)),
+                    Some(u16::try_from(max.saturating_sub(used)).unwrap_or(u16::MAX)),
+                )
+            })
+            .unwrap_or((None, None));
+
+        let selection = serde_json::to_value(&profile.profile_config.credential_selection)
+            .ok()
+            .and_then(|value| value.as_str().map(ToOwned::to_owned))
+            .unwrap_or_else(|| "unknown".to_string());
+        let generation = self.policy_runtime.current_generation();
+
+        EffectiveAuthority {
+            profile_id: profile_id.to_string(),
+            mode: profile.mode.to_string(),
+            identity: AuthorityIdentity {
+                acts_as_human,
+                credential_namespace: if acts_as_human { "human" } else { "isolated" }.into(),
+                rp_identity: if acts_as_human { "human" } else { "agent" }.into(),
+            },
+            policy_generation: generation.generation_id.as_str().to_string(),
+            rp_rules: rules
+                .into_iter()
+                .map(|rule| AuthorityRpRule {
+                    wildcard: rule.rp_id.trim() == passless_core::agent::config::ANY_RP_ID,
+                    rp_id: rule.rp_id,
+                    authenticate: AuthorityCeremony {
+                        authorization: rule.authenticate.authorization.to_string(),
+                        user_presence: rule.authenticate.user_presence.to_string(),
+                        user_verification: rule.authenticate.user_verification.to_string(),
+                    },
+                    register: AuthorityCeremony {
+                        authorization: rule.register.authorization.to_string(),
+                        user_presence: rule.register.user_presence.to_string(),
+                        user_verification: rule.register.user_verification.to_string(),
+                    },
+                })
+                .collect(),
+            credentials: AuthorityCredentialScope {
+                dynamic_per_rp: profile.profile_config.credential_refs.is_none(),
+                configured_reference_count: profile
+                    .profile_config
+                    .credential_refs
+                    .as_ref()
+                    .map_or(0, |refs| refs.len() as u32),
+                selection,
+            },
+            session: AuthoritySession {
+                max_session_ttl_secs: profile
+                    .profile_config
+                    .max_session_ttl
+                    .map(|ttl| ttl.as_secs())
+                    .unwrap_or(300),
+                principal_remaining_ttl_secs: managed
+                    .deadline
+                    .saturating_duration_since(Instant::now())
+                    .as_secs(),
+                max_operations: profile.profile_config.max_operations,
+                operations_used,
+                operations_remaining,
+            },
+            browser: AuthorityBrowser {
+                active: active_lease.is_some(),
+                cdp_exposure: profile
+                    .profile_config
+                    .browser_cdp_expose
+                    .unwrap_or(CdpExposeMode::Pipe)
+                    .to_string(),
+                direct_cdp,
+                full_session_authority: active_lease.is_some(),
+            },
+            risk_flags,
+        }
     }
 
     fn handle_launch_principal(
@@ -5222,6 +5362,9 @@ impl PrincipalHandler for AgentRuntime {
                     registration_allowed: profile.profile_config.allows_registration(),
                 }))
             }
+            PrincipalRequest::Authority => Ok(PrincipalResponse::Authority(
+                self.build_effective_authority(&profile_id, profile, managed),
+            )),
             PrincipalRequest::Instructions => {
                 let mode_str = format!("{:?}", profile.mode);
                 Ok(PrincipalResponse::Instructions(PrincipalInstructions {

--- a/cmd/passless/src/agent/runtime.rs
+++ b/cmd/passless/src/agent/runtime.rs
@@ -2157,9 +2157,10 @@ impl AgentRuntime {
         let autonomous_authentication = rules.iter().any(|rule| {
             rule.authenticate.authorization == passless_core::agent::AgentAuthorization::Allow
         });
-        let human_backend_registration = acts_as_human && rules.iter().any(|rule| {
-            rule.register.authorization != passless_core::agent::AgentAuthorization::Deny
-        });
+        let human_backend_registration = acts_as_human
+            && rules.iter().any(|rule| {
+                rule.register.authorization != passless_core::agent::AgentAuthorization::Deny
+            });
         let direct_cdp = profile.profile_config.browser_cdp_expose == Some(CdpExposeMode::Port);
         let ambiguous_selection = matches!(
             profile.profile_config.credential_selection,

--- a/cmd/passless/src/agent/sign.rs
+++ b/cmd/passless/src/agent/sign.rs
@@ -515,6 +515,18 @@ impl SignContextRegistry {
         self.len() == 0
     }
 
+    pub fn budget_snapshot_for_lease(&self, lease_id: &str) -> Option<(usize, usize)> {
+        let budget = {
+            let map = self.entries.lock().ok()?;
+            let entry = map
+                .values()
+                .find(|entry| entry.lease_id.as_deref() == Some(lease_id))?;
+            entry.request_budget.clone()
+        };
+        let used = budget.used_requests.lock().ok()?.len();
+        Some((used, budget.max_requests))
+    }
+
     #[cfg(test)]
     pub fn all_entries(&self) -> Vec<LeaseEntry> {
         let map = match self.entries.lock() {

--- a/cmd/passless/src/commands/agent.rs
+++ b/cmd/passless/src/commands/agent.rs
@@ -197,13 +197,22 @@ fn dispatch_capabilities(output: OutputFormat, profile: &str) -> Result<()> {
             OutputFormat::Plain => {
                 println!("profile: {}", authority.profile_id);
                 println!("mode: {}", authority.mode);
-                println!("credential_namespace: {}", authority.identity.credential_namespace);
+                println!(
+                    "credential_namespace: {}",
+                    authority.identity.credential_namespace
+                );
                 println!("rp_identity: {}", authority.identity.rp_identity);
                 println!("acts_as_human: {}", authority.identity.acts_as_human);
                 println!("policy_generation: {}", authority.policy_generation);
                 println!("credential_selection: {}", authority.credentials.selection);
-                println!("dynamic_credential_scope: {}", authority.credentials.dynamic_per_rp);
-                println!("max_session_ttl_secs: {}", authority.session.max_session_ttl_secs);
+                println!(
+                    "dynamic_credential_scope: {}",
+                    authority.credentials.dynamic_per_rp
+                );
+                println!(
+                    "max_session_ttl_secs: {}",
+                    authority.session.max_session_ttl_secs
+                );
                 println!(
                     "principal_remaining_ttl_secs: {}",
                     authority.session.principal_remaining_ttl_secs

--- a/cmd/passless/src/commands/agent.rs
+++ b/cmd/passless/src/commands/agent.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use passless_core::agent::protocol::{
-    DelegationState, IntentAction, IntentState, PrincipalCredentialSummary,
+    AuthorityRisk, DelegationState, IntentAction, IntentState, PrincipalCredentialSummary,
 };
 use passless_core::{
     AgentCommand, AgentCredentialAction, AgentDelegationAction, AgentIntentAction,
@@ -151,98 +151,100 @@ fn dispatch_doctor(output: OutputFormat, profile: &str) -> Result<()> {
     }
 }
 
-fn capability_mode(mode: &str) -> (&'static str, bool) {
-    match mode {
-        "same-user" | "same_user" | "SameUser" => ("same-user", true),
-        "isolated" | "Isolated" => ("isolated", false),
-        _ => ("unknown", false),
+fn authority_risk_message(risk: AuthorityRisk) -> (&'static str, &'static str, &'static str) {
+    match risk {
+        AuthorityRisk::HumanIdentity => (
+            "high",
+            "human_identity",
+            "same-user exercises the human credential/RP identity; application actions are unconstrained after login",
+        ),
+        AuthorityRisk::GlobalRpScope => (
+            "critical",
+            "global_rp_scope",
+            "global RP scope '*' permits authentication to any valid RP with a matching credential",
+        ),
+        AuthorityRisk::AutonomousAuthentication => (
+            "high",
+            "autonomous_authentication",
+            "at least one RP rule permits authentication without ceremony-time human approval",
+        ),
+        AuthorityRisk::HumanBackendRegistration => (
+            "high",
+            "human_backend_registration",
+            "registration can mutate the human credential backend",
+        ),
+        AuthorityRisk::DirectCdpPort => (
+            "high",
+            "direct_cdp_port",
+            "loopback CDP port grants direct full managed-browser authority",
+        ),
+        AuthorityRisk::AmbiguousCredentialSelection => (
+            "medium",
+            "ambiguous_credential_selection",
+            "profile may choose among multiple eligible credentials without requiring a single candidate",
+        ),
     }
 }
 
 fn dispatch_capabilities(output: OutputFormat, profile: &str) -> Result<()> {
     let mut client = connect_principal(profile)?;
     let resp = client
-        .request(passless_core::agent::PrincipalRequest::Capabilities)
+        .request(passless_core::agent::PrincipalRequest::Authority)
         .map_err(client_error_to_result)?;
     match resp {
-        passless_core::agent::PrincipalResponse::Capabilities(caps) => {
-            let (canonical_mode, acts_as_human) = capability_mode(&caps.mode);
-            let wildcard_rp_scope = caps.allowed_rp_ids.iter().any(|rp| rp.trim() == "*");
-            let credential_namespace = if acts_as_human { "human" } else { "isolated" };
-            let rp_identity = if acts_as_human { "human" } else { "agent" };
-            let mut security_warnings = Vec::new();
-            if acts_as_human {
-                security_warnings.push(
-                    "HIGH: same-user exercises the human credential/RP identity; after login Passless does not constrain application actions",
+        passless_core::agent::PrincipalResponse::Authority(authority) => match output {
+            OutputFormat::Json => output_json(&authority),
+            OutputFormat::Plain => {
+                println!("profile: {}", authority.profile_id);
+                println!("mode: {}", authority.mode);
+                println!("credential_namespace: {}", authority.identity.credential_namespace);
+                println!("rp_identity: {}", authority.identity.rp_identity);
+                println!("acts_as_human: {}", authority.identity.acts_as_human);
+                println!("policy_generation: {}", authority.policy_generation);
+                println!("credential_selection: {}", authority.credentials.selection);
+                println!("dynamic_credential_scope: {}", authority.credentials.dynamic_per_rp);
+                println!("max_session_ttl_secs: {}", authority.session.max_session_ttl_secs);
+                println!(
+                    "principal_remaining_ttl_secs: {}",
+                    authority.session.principal_remaining_ttl_secs
                 );
-            }
-            if wildcard_rp_scope {
-                security_warnings.push(
-                    "CRITICAL: global RP scope '*' permits authentication to any valid RP with a matching credential",
-                );
-            }
-            if acts_as_human && caps.registration_allowed {
-                security_warnings.push(
-                    "HIGH: registration is enabled for a profile that uses the human credential backend",
-                );
-            }
-
-            #[derive(Serialize)]
-            struct CapabilitiesOutput<'a> {
-                profile_id: &'a str,
-                mode: &'a str,
-                allowed_rp_ids: &'a [String],
-                registration_allowed: bool,
-                credential_namespace: &'a str,
-                rp_identity: &'a str,
-                acts_as_human: bool,
-                wildcard_rp_scope: bool,
-                security_warnings: &'a [&'static str],
-            }
-
-            let view = CapabilitiesOutput {
-                profile_id: &caps.profile_id,
-                mode: canonical_mode,
-                allowed_rp_ids: &caps.allowed_rp_ids,
-                registration_allowed: caps.registration_allowed,
-                credential_namespace,
-                rp_identity,
-                acts_as_human,
-                wildcard_rp_scope,
-                security_warnings: &security_warnings,
-            };
-
-            match output {
-                OutputFormat::Json => output_json(&view),
-                OutputFormat::Plain => {
-                    println!("profile: {}", view.profile_id);
-                    println!("mode: {}", view.mode);
-                    println!("credential_namespace: {}", view.credential_namespace);
-                    println!("rp_identity: {}", view.rp_identity);
-                    println!("acts_as_human: {}", view.acts_as_human);
-                    println!("wildcard_rp_scope: {}", view.wildcard_rp_scope);
-                    println!(
-                        "registration_allowed: {}",
-                        if view.registration_allowed {
-                            "true"
-                        } else {
-                            "false"
-                        }
-                    );
-                    println!("allowed_rp_ids:");
-                    for rp in view.allowed_rp_ids {
-                        println!("  - {}", rp);
-                    }
-                    if !view.security_warnings.is_empty() {
-                        println!("security_warnings:");
-                        for warning in view.security_warnings {
-                            println!("  - {}", warning);
-                        }
-                    }
-                    Ok(())
+                println!("max_operations: {}", authority.session.max_operations);
+                if let Some(used) = authority.session.operations_used {
+                    println!("operations_used: {}", used);
                 }
+                if let Some(remaining) = authority.session.operations_remaining {
+                    println!("operations_remaining: {}", remaining);
+                }
+                println!("browser_active: {}", authority.browser.active);
+                println!("cdp_exposure: {}", authority.browser.cdp_exposure);
+                println!(
+                    "full_session_authority: {}",
+                    authority.browser.full_session_authority
+                );
+                println!("rp_rules:");
+                for rule in &authority.rp_rules {
+                    println!(
+                        "  - {}: authenticate={} up={} uv={}; register={} up={} uv={}{}",
+                        rule.rp_id,
+                        rule.authenticate.authorization,
+                        rule.authenticate.user_presence,
+                        rule.authenticate.user_verification,
+                        rule.register.authorization,
+                        rule.register.user_presence,
+                        rule.register.user_verification,
+                        if rule.wildcard { " [wildcard]" } else { "" },
+                    );
+                }
+                if !authority.risk_flags.is_empty() {
+                    println!("risk_flags:");
+                    for risk in authority.risk_flags {
+                        let (severity, code, message) = authority_risk_message(risk);
+                        println!("  - {}: {}: {}", severity, code, message);
+                    }
+                }
+                Ok(())
             }
-        }
+        },
         _ => Err(Error::Other("unexpected response".to_string())),
     }
 }
@@ -969,14 +971,10 @@ mod tests {
     }
 
     #[test]
-    fn capabilities_derive_human_identity_and_wildcard_risk() {
-        let (same_user, acts_as_human) = capability_mode("SameUser");
-        assert_eq!(same_user, "same-user");
-        assert!(acts_as_human);
-
-        let (isolated, acts_as_human) = capability_mode("Isolated");
-        assert_eq!(isolated, "isolated");
-        assert!(!acts_as_human);
+    fn authority_risk_messages_are_stable() {
+        let (severity, code, _) = authority_risk_message(AuthorityRisk::GlobalRpScope);
+        assert_eq!(severity, "critical");
+        assert_eq!(code, "global_rp_scope");
     }
 
     #[test]

--- a/cmd/passless/tests/protocol_integration.rs
+++ b/cmd/passless/tests/protocol_integration.rs
@@ -37,7 +37,7 @@ fn version_negotiation_accepts_current_major() {
 fn version_negotiation_accepts_higher_minor() {
     let offer = ProtocolVersion::new(1, 99);
     let negotiated = ProtocolVersion::negotiate(offer).unwrap();
-    assert_eq!(negotiated.minor, 0);
+    assert_eq!(negotiated.minor, 1);
 }
 
 #[test]

--- a/passless-core/src/agent/protocol.rs
+++ b/passless-core/src/agent/protocol.rs
@@ -1063,7 +1063,7 @@ pub enum PrincipalResponseFrame {
     Ok {
         v: ProtocolVersion,
         seq: u64,
-        action: PrincipalResponse,
+        action: Box<PrincipalResponse>,
     },
     Error {
         v: ProtocolVersion,
@@ -1178,7 +1178,7 @@ impl PrincipalResponseFrame {
         Self::Ok {
             v: CURRENT_VERSION,
             seq,
-            action,
+            action: Box::new(action),
         }
     }
 

--- a/passless-core/src/agent/protocol.rs
+++ b/passless-core/src/agent/protocol.rs
@@ -16,7 +16,7 @@ const MAX_ARGV_COUNT: usize = 64;
 const MAX_CDP_REQUEST_LEN: usize = 8 * 1024;
 const MAX_CDP_TIMEOUT_MS: u32 = 30_000;
 
-pub const CURRENT_VERSION: ProtocolVersion = ProtocolVersion { major: 1, minor: 0 };
+pub const CURRENT_VERSION: ProtocolVersion = ProtocolVersion { major: 1, minor: 1 };
 
 const MAX_RP_ID_LEN: usize = 253;
 const MAX_PROFILE_ID_LEN: usize = 128;
@@ -439,6 +439,7 @@ pub enum PrincipalRequest {
     Ping,
     Status,
     Capabilities,
+    Authority,
     Instructions,
     Doctor,
     CreateIntent {
@@ -505,6 +506,7 @@ pub enum PrincipalResponse {
     Pong,
     Status(DaemonStatus),
     Capabilities(PrincipalCapabilities),
+    Authority(EffectiveAuthority),
     Instructions(PrincipalInstructions),
     Doctor(DoctorResponse),
     IntentCreated {
@@ -600,6 +602,85 @@ pub struct PrincipalCapabilities {
     pub mode: String,
     pub allowed_rp_ids: Vec<String>,
     pub registration_allowed: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EffectiveAuthority {
+    pub profile_id: String,
+    pub mode: String,
+    pub identity: AuthorityIdentity,
+    pub policy_generation: String,
+    pub rp_rules: Vec<AuthorityRpRule>,
+    pub credentials: AuthorityCredentialScope,
+    pub session: AuthoritySession,
+    pub browser: AuthorityBrowser,
+    pub risk_flags: Vec<AuthorityRisk>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuthorityIdentity {
+    pub acts_as_human: bool,
+    pub credential_namespace: String,
+    pub rp_identity: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuthorityRpRule {
+    pub rp_id: String,
+    pub wildcard: bool,
+    pub authenticate: AuthorityCeremony,
+    pub register: AuthorityCeremony,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuthorityCeremony {
+    pub authorization: String,
+    pub user_presence: String,
+    pub user_verification: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuthorityCredentialScope {
+    pub dynamic_per_rp: bool,
+    pub configured_reference_count: u32,
+    pub selection: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuthoritySession {
+    pub max_session_ttl_secs: u64,
+    pub principal_remaining_ttl_secs: u64,
+    pub max_operations: u16,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operations_used: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operations_remaining: Option<u16>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuthorityBrowser {
+    pub active: bool,
+    pub cdp_exposure: String,
+    pub direct_cdp: bool,
+    pub full_session_authority: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthorityRisk {
+    HumanIdentity,
+    GlobalRpScope,
+    AutonomousAuthentication,
+    HumanBackendRegistration,
+    DirectCdpPort,
+    AmbiguousCredentialSelection,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -1258,6 +1339,7 @@ impl Validate for PrincipalRequest {
             Self::Ping
             | Self::Status
             | Self::Capabilities
+            | Self::Authority
             | Self::Instructions
             | Self::Doctor
             | Self::BrowserStatus
@@ -1748,9 +1830,9 @@ mod tests {
     }
 
     #[test]
-    fn version_current_is_1_0() {
+    fn version_current_is_1_1() {
         assert_eq!(CURRENT_VERSION.major, 1);
-        assert_eq!(CURRENT_VERSION.minor, 0);
+        assert_eq!(CURRENT_VERSION.minor, 1);
     }
 
     #[test]
@@ -1770,7 +1852,7 @@ mod tests {
     fn version_negotiate_higher_minor_clamped() {
         let offer = ProtocolVersion::new(1, 5);
         let negotiated = ProtocolVersion::negotiate(offer).unwrap();
-        assert_eq!(negotiated, ProtocolVersion::new(1, 0));
+        assert_eq!(negotiated, ProtocolVersion::new(1, 1));
     }
 
     #[test]
@@ -1790,7 +1872,7 @@ mod tests {
 
     #[test]
     fn version_display() {
-        assert_eq!(CURRENT_VERSION.to_string(), "1.0");
+        assert_eq!(CURRENT_VERSION.to_string(), "1.1");
         assert_eq!(ProtocolVersion::new(2, 3).to_string(), "2.3");
     }
 
@@ -2028,6 +2110,16 @@ mod tests {
         let frame = RequestFrame::Principal(PrincipalRequestFrame::new(
             3,
             PrincipalRequest::Capabilities,
+            test_capability_proof(),
+        ));
+        assert_eq!(json_roundtrip(&frame), frame);
+    }
+
+    #[test]
+    fn principal_authority_request_roundtrip() {
+        let frame = RequestFrame::Principal(PrincipalRequestFrame::new(
+            4,
+            PrincipalRequest::Authority,
             test_capability_proof(),
         ));
         assert_eq!(json_roundtrip(&frame), frame);


### PR DESCRIPTION
## Summary

Make the daemon the source of truth for an agent principal's effective security authority instead of reconstructing that authority in CLI presentation code.

This adds a protocol-level effective-authority snapshot and makes `passless agent ... capabilities` consume it directly.

## What changes

- bump the compatible agent protocol minor version from 1.0 to 1.1;
- preserve the existing 1.0 `Capabilities` response and add a separate `Authority` request/response;
- report normalized identity semantics, exact/wildcard RP rules, authorization and UP/UV sources, credential scope/selection, policy generation, current session bounds, browser/CDP authority, and stable risk flags;
- expose the shared WebAuthn operation-budget snapshot for an active browser lease without exposing request hashes or bearer material;
- move human-identity, wildcard, autonomous-authentication, human-registration, direct-CDP, and ambiguous-selection classification into the daemon-owned authority object;
- keep human-readable severity/message rendering in the CLI.

## Security properties

The authority response contains no private keys, PINs, bearer capabilities, request bodies, cookies, assertion signatures, or unrestricted credential enumeration. Credential scope is summarized as dynamic-vs-configured and reference count only.

The response distinguishes configured maximum authority from current runtime state. Operation usage is returned only when an active sign lease can be resolved; otherwise the optional usage fields are omitted rather than guessed.

## Compatibility

This deliberately does not add fields to the existing `PrincipalCapabilities` struct because protocol structures reject unknown fields. A new request/response at protocol 1.1 keeps the 1.0 shape intact.

## Review focus

1. daemon-side authority derivation and risk classification;
2. protocol 1.1 compatibility semantics;
3. operation-budget snapshot lifetime/accounting;
4. whether the returned object contains enough information for autonomous clients without disclosing credential/session secrets;
5. CLI rendering as presentation only rather than policy inference.

## Validation

The branch was produced from current `master` after merged #408. Repository CI is the source of truth for full Rustfmt/Clippy/x86/aarch64/deterministic validation; this PR remains draft while those checks run.