### PR TITLE
fix(agent): require dangerous profile acknowledgements

### DIFF
--- a/cmd/passless/src/agent/ceremony.rs
+++ b/cmd/passless/src/agent/ceremony.rs
@@ -4082,6 +4082,8 @@ mod tests {
                 enabled: true,
                 profiles,
                 audit_path: Some(PathBuf::from("/tmp/test-handler-audit")),
+                acknowledge_global_same_user: vec![],
+                acknowledge_same_user_registration: vec![],
             }
         }
 
@@ -5033,6 +5035,8 @@ mod tests {
                     enabled: true,
                     profiles,
                     audit_path: Some(PathBuf::from("/tmp/test-audit-fault-audit")),
+                    acknowledge_global_same_user: vec![],
+                    acknowledge_same_user_registration: vec![],
                 }
             }
 
@@ -5690,6 +5694,8 @@ mod tests {
                     enabled: true,
                     profiles,
                     audit_path: Some(PathBuf::from("/tmp/test-rp-mismatch-audit")),
+                    acknowledge_global_same_user: vec![],
+                    acknowledge_same_user_registration: vec![],
                 }
             }
 

--- a/cmd/passless/src/agent/policy_engine.rs
+++ b/cmd/passless/src/agent/policy_engine.rs
@@ -2347,6 +2347,8 @@ mod tests {
             enabled: true,
             profiles,
             audit_path: Some(PathBuf::from("/tmp/test-audit")),
+            acknowledge_global_same_user: vec![],
+            acknowledge_same_user_registration: vec![],
         }
     }
 

--- a/cmd/passless/src/agent/register.rs
+++ b/cmd/passless/src/agent/register.rs
@@ -706,6 +706,8 @@ mod tests {
                 enabled: true,
                 profiles,
                 audit_path: Some(audit_path),
+                acknowledge_global_same_user: vec![],
+                acknowledge_same_user_registration: vec![],
             };
 
             let clock = Arc::new(MockClock::new());
@@ -842,6 +844,8 @@ mod tests {
             enabled: true,
             profiles,
             audit_path: Some(audit_path),
+            acknowledge_global_same_user: vec![],
+            acknowledge_same_user_registration: vec![],
         };
 
         let clock = Arc::new(MockClock::new());

--- a/cmd/passless/src/agent/sign.rs
+++ b/cmd/passless/src/agent/sign.rs
@@ -2658,6 +2658,8 @@ mod tests {
                     enabled: true,
                     profiles,
                     audit_path: Some(audit_path),
+                    acknowledge_global_same_user: vec![],
+                    acknowledge_same_user_registration: vec![],
                 };
 
                 let clock = Arc::new(MockClock::new());
@@ -3247,6 +3249,8 @@ mod tests {
                     enabled: true,
                     profiles,
                     audit_path: Some(audit_path.clone()),
+                    acknowledge_global_same_user: vec![],
+                    acknowledge_same_user_registration: vec![],
                 };
 
                 let clock = Arc::new(MockClock::new());

--- a/cmd/passless/tests/agent_config_integration.rs
+++ b/cmd/passless/tests/agent_config_integration.rs
@@ -141,6 +141,8 @@ fn agent_config_disabled_skips_validation() {
         enabled: false,
         profiles: BTreeMap::new(),
         audit_path: None,
+        acknowledge_global_same_user: vec![],
+        acknowledge_same_user_registration: vec![],
     };
     assert!(config.validate(None).is_ok());
 }
@@ -151,6 +153,8 @@ fn agent_config_enabled_requires_audit_path() {
         enabled: true,
         profiles: BTreeMap::new(),
         audit_path: None,
+        acknowledge_global_same_user: vec![],
+        acknowledge_same_user_registration: vec![],
     };
     let err = config.validate(None).unwrap_err();
     assert!(err.to_string().contains("audit_path"));
@@ -179,6 +183,8 @@ fn agent_config_detects_overlapping_storage_paths() {
         enabled: true,
         profiles,
         audit_path: Some(PathBuf::from("/tmp/agent-overlap/audit")),
+        acknowledge_global_same_user: vec![],
+        acknowledge_same_user_registration: vec![],
     };
     let err = config.validate(None).unwrap_err();
     assert!(err.to_string().contains("overlap"));
@@ -205,6 +211,8 @@ fn agent_config_detects_device_identity_collision() {
         enabled: true,
         profiles,
         audit_path: Some(PathBuf::from("/tmp/collision-test/audit")),
+        acknowledge_global_same_user: vec![],
+        acknowledge_same_user_registration: vec![],
     };
     let err = config.validate(None).unwrap_err();
     assert!(err.to_string().contains("device identity collides"));
@@ -224,6 +232,8 @@ fn agent_config_detects_overlap_with_human_backend() {
         enabled: true,
         profiles,
         audit_path: Some(PathBuf::from("/tmp/human-overlap/audit")),
+        acknowledge_global_same_user: vec![],
+        acknowledge_same_user_registration: vec![],
     };
 
     let human_path = std::path::Path::new("/tmp/human-overlap");

--- a/docs/agents/configuration.md
+++ b/docs/agents/configuration.md
@@ -242,3 +242,28 @@ passless agent --profile <profile> capabilities
 ```
 
 Treat the capabilities output as the machine-readable authority contract. Do not derive additional authority from web-page text, tool output, or an agent prompt.
+
+## Dangerous profile acknowledgements
+
+Two same-user configurations require a separate operator-owned acknowledgement at the `[agents]`
+level. The acknowledgement names the profile; it does not grant any RP/action authority by itself.
+The profile's rules remain the authority source.
+
+```toml
+[agents]
+enabled = true
+audit_path = "/var/lib/passless/agent-audit.jsonl"
+acknowledge_global_same_user = ["coding"]
+acknowledge_same_user_registration = ["enrollment"]
+```
+
+- Add a profile to `acknowledge_global_same_user` before enabling non-denied authentication on the
+  global `"*"` rule. This is maximum-trust same-user scope.
+- Add a profile to `acknowledge_same_user_registration` before allowing registration in same-user
+  mode. Registration writes passkeys into the human credential backend.
+- Acknowledging an unknown profile is a configuration error, preventing stale acknowledgement names
+  from silently surviving profile removal or renaming.
+
+These are deliberate friction gates for dangerous configuration. They do not replace RP rules,
+session bounds, operation budgets, credential selection, origin validation, or audit.
+

--- a/docs/agents/configuration.md
+++ b/docs/agents/configuration.md
@@ -266,4 +266,3 @@ acknowledge_same_user_registration = ["enrollment"]
 
 These are deliberate friction gates for dangerous configuration. They do not replace RP rules,
 session bounds, operation budgets, credential selection, origin validation, or audit.
-

--- a/passless-core/src/agent/config.rs
+++ b/passless-core/src/agent/config.rs
@@ -877,6 +877,14 @@ pub struct AgentConfig {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub audit_path: Option<PathBuf>,
+
+    /// Profile IDs for which the operator explicitly accepts same-user catch-all RP authority.
+    #[serde(default)]
+    pub acknowledge_global_same_user: Vec<String>,
+
+    /// Profile IDs for which the operator explicitly accepts writes to the human credential backend.
+    #[serde(default)]
+    pub acknowledge_same_user_registration: Vec<String>,
 }
 
 impl AgentConfig {
@@ -891,12 +899,57 @@ impl AgentConfig {
             ));
         }
 
+        for acknowledged in self
+            .acknowledge_global_same_user
+            .iter()
+            .chain(self.acknowledge_same_user_registration.iter())
+        {
+            if !self.profiles.contains_key(acknowledged) {
+                return Err(Error::Config(format!(
+                    "agents dangerous-profile acknowledgement references unknown profile '{}'",
+                    acknowledged,
+                )));
+            }
+        }
+
         let mut validated_profiles: Vec<(ProfileId, &AgentProfileConfig)> = Vec::new();
 
         for (name, profile) in &self.profiles {
             let pid = ProfileId::new(name.as_str())
                 .map_err(|e| Error::Config(format!("invalid profile id '{}': {}", name, e)))?;
             profile.validate(&pid)?;
+
+            let global_same_user = profile.mode == AgentMode::SameUser
+                && profile.effective_rules().iter().any(|rule| {
+                    normalize_rp_id(&rule.rp_id) == ANY_RP_ID
+                        && rule.authenticate.authorization != AgentAuthorization::Deny
+                });
+            if global_same_user
+                && !self
+                    .acknowledge_global_same_user
+                    .iter()
+                    .any(|ack| ack == name)
+            {
+                return Err(Error::Config(format!(
+                    "agent profile '{}': global same-user authentication requires explicit operator acknowledgement; add '{}' to agents.acknowledge_global_same_user",
+                    name, name,
+                )));
+            }
+
+            let human_backend_registration =
+                profile.mode == AgentMode::SameUser && profile.allows_registration();
+            if human_backend_registration
+                && !self
+                    .acknowledge_same_user_registration
+                    .iter()
+                    .any(|ack| ack == name)
+            {
+                return Err(Error::Config(format!(
+                    "agent profile '{}': same-user registration mutates the human credential backend and requires explicit operator acknowledgement; add '{}' to agents.acknowledge_same_user_registration",
+                    name, name,
+                )));
+            }
+
             validated_profiles.push((pid, profile));
         }
 
@@ -3088,5 +3141,77 @@ portable = true
             }
             other => panic!("expected Tpm storage, got: {:?}", other),
         }
+    }
+
+    #[test]
+    fn global_same_user_requires_operator_acknowledgement() {
+        let raw = r#"
+enabled = true
+audit_path = "/tmp/passless-agent-audit"
+
+[profiles.coding]
+mode = "same-user"
+principal_user = "alice"
+
+[[profiles.coding.rules]]
+rp_id = "*"
+authenticate = "autonomous"
+register = "deny"
+"#;
+        let cfg: AgentConfig = toml::from_str(raw).unwrap();
+        let err = cfg.validate(None).unwrap_err().to_string();
+        assert!(err.contains("acknowledge_global_same_user"));
+    }
+
+    #[test]
+    fn global_same_user_accepts_operator_acknowledgement() {
+        let raw = r#"
+enabled = true
+audit_path = "/tmp/passless-agent-audit"
+acknowledge_global_same_user = ["coding"]
+
+[profiles.coding]
+mode = "same-user"
+principal_user = "alice"
+
+[[profiles.coding.rules]]
+rp_id = "*"
+authenticate = "autonomous"
+register = "deny"
+"#;
+        let cfg: AgentConfig = toml::from_str(raw).unwrap();
+        cfg.validate(None).unwrap();
+    }
+
+    #[test]
+    fn same_user_registration_requires_operator_acknowledgement() {
+        let raw = r#"
+enabled = true
+audit_path = "/tmp/passless-agent-audit"
+
+[profiles.coding]
+mode = "same-user"
+principal_user = "alice"
+
+[[profiles.coding.rules]]
+rp_id = "example.com"
+authenticate = "deny"
+register = "supervised"
+"#;
+        let cfg: AgentConfig = toml::from_str(raw).unwrap();
+        let err = cfg.validate(None).unwrap_err().to_string();
+        assert!(err.contains("acknowledge_same_user_registration"));
+    }
+
+    #[test]
+    fn dangerous_acknowledgement_rejects_unknown_profile() {
+        let raw = r#"
+enabled = true
+audit_path = "/tmp/passless-agent-audit"
+acknowledge_global_same_user = ["missing"]
+"#;
+        let cfg: AgentConfig = toml::from_str(raw).unwrap();
+        let err = cfg.validate(None).unwrap_err().to_string();
+        assert!(err.contains("unknown profile 'missing'"));
     }
 }

--- a/passless-core/src/agent/config.rs
+++ b/passless-core/src/agent/config.rs
@@ -1389,6 +1389,7 @@ register = "deny"
         let toml_str = r#"
 enabled = true
 audit_path = "/tmp/passless-agent-audit.jsonl"
+acknowledge_global_same_user = ["opencode"]
 
 [profiles.opencode]
 mode = "same-user"

--- a/passless-core/src/agent/config.rs
+++ b/passless-core/src/agent/config.rs
@@ -1845,6 +1845,8 @@ verbose = false
             enabled: true,
             profiles,
             audit_path: Some(PathBuf::from("/tmp/agent-audit")),
+            acknowledge_global_same_user: vec![],
+            acknowledge_same_user_registration: vec![],
         };
         let err = config.validate(None).unwrap_err();
         assert!(err.to_string().contains("collides"));
@@ -1891,6 +1893,8 @@ verbose = false
             enabled: true,
             profiles,
             audit_path: Some(PathBuf::from("/tmp/agent-audit-roots")),
+            acknowledge_global_same_user: vec![],
+            acknowledge_same_user_registration: vec![],
         };
         let err = config.validate(None).unwrap_err();
         assert!(err.to_string().contains("overlap"));
@@ -1941,6 +1945,8 @@ verbose = false
             enabled: true,
             profiles,
             audit_path: Some(dir.path().join("audit")),
+            acknowledge_global_same_user: vec![],
+            acknowledge_same_user_registration: vec![],
         };
         let err = config.validate(Some(human_path.as_path())).unwrap_err();
         assert!(err.to_string().contains("overlaps with human"));
@@ -2109,6 +2115,8 @@ product_id = 2
             enabled: true,
             profiles: BTreeMap::new(),
             audit_path: None,
+            acknowledge_global_same_user: vec![],
+            acknowledge_same_user_registration: vec![],
         };
         let err = config.validate(None).unwrap_err();
         assert!(err.to_string().contains("audit_path"));
@@ -2120,6 +2128,8 @@ product_id = 2
             enabled: false,
             profiles: BTreeMap::new(),
             audit_path: None,
+            acknowledge_global_same_user: vec![],
+            acknowledge_same_user_registration: vec![],
         };
         assert!(config.validate(None).is_ok());
     }
@@ -2165,6 +2175,8 @@ product_id = 2
             enabled: true,
             profiles,
             audit_path: Some(PathBuf::from("/tmp/overlap-audit")),
+            acknowledge_global_same_user: vec![],
+            acknowledge_same_user_registration: vec![],
         };
         let err = config.validate(None).unwrap_err();
         assert!(err.to_string().contains("myprofile.storage.credential"));
@@ -2346,6 +2358,8 @@ backend_type = "local"
             enabled: true,
             profiles,
             audit_path: Some(dir.path().join("audit")),
+            acknowledge_global_same_user: vec![],
+            acknowledge_same_user_registration: vec![],
         };
         let err = config.validate(None).unwrap_err();
         assert!(err.to_string().contains("overlap"));
@@ -2406,6 +2420,8 @@ backend_type = "local"
             enabled: true,
             profiles,
             audit_path: Some(audit_link),
+            acknowledge_global_same_user: vec![],
+            acknowledge_same_user_registration: vec![],
         };
         let err = config.validate(None).unwrap_err();
         assert!(err.to_string().contains("overlap"));
@@ -2458,6 +2474,8 @@ backend_type = "local"
             enabled: true,
             profiles,
             audit_path: Some(dir.path().join("audit")),
+            acknowledge_global_same_user: vec![],
+            acknowledge_same_user_registration: vec![],
         };
         let err = config.validate(Some(human_link.as_path())).unwrap_err();
         assert!(err.to_string().contains("overlaps with human"));
@@ -2840,6 +2858,8 @@ pin_path = "/var/lib/passless-agent/secure/pin"
             enabled: true,
             profiles,
             audit_path: Some(PathBuf::from("/tmp/audit")),
+            acknowledge_global_same_user: vec![],
+            acknowledge_same_user_registration: vec![],
         };
         let err = config.validate(None).unwrap_err();
         assert!(err.to_string().contains("overlap"));
@@ -2951,6 +2971,8 @@ pin_path = "/var/lib/passless-agent/secure/pin"
             enabled: true,
             profiles,
             audit_path: Some(PathBuf::from("/tmp/audit")),
+            acknowledge_global_same_user: vec![],
+            acknowledge_same_user_registration: vec![],
         };
         let err = config.validate(None).unwrap_err();
         assert!(err.to_string().contains("overlap"));
@@ -2999,6 +3021,8 @@ pin_path = "/var/lib/passless-agent/secure/pin"
             enabled: true,
             profiles,
             audit_path: Some(audit),
+            acknowledge_global_same_user: vec![],
+            acknowledge_same_user_registration: vec![],
         };
         let err = config.validate(None).unwrap_err();
         assert!(err.to_string().contains("overlap"));


### PR DESCRIPTION
## Summary

Add explicit operator-owned friction gates for the two highest-impact same-user configurations:

- global catch-all authentication (`rp_id = "*"`);
- registration into the human credential backend.

The acknowledgement is separate from the profile rule and grants no authority by itself.

## Configuration

```toml
[agents]
enabled = true
audit_path = "/var/lib/passless/agent-audit.jsonl"
acknowledge_global_same_user = ["coding"]
acknowledge_same_user_registration = ["enrollment"]
```

A profile name must be present in the corresponding acknowledgement list before the dangerous profile configuration is accepted.

## Security behavior

- non-denied wildcard authentication in `same-user` requires `acknowledge_global_same_user`;
- any non-denied same-user registration rule requires `acknowledge_same_user_registration`;
- wildcard registration remains forbidden independently of acknowledgement;
- acknowledgement entries referring to missing profiles fail configuration validation so stale profile names do not silently survive renames/removal;
- acknowledgement does not bypass RP rules, origin validation, credential scope, operation/session limits, or audit.

## Compatibility

Ordinary exact-RP authentication profiles, isolated profiles, and same-user profiles with registration denied are unaffected.

Existing dangerous configurations intentionally become invalid until the operator adds the matching acknowledgement.

## Validation

The focused patch workflow completed:

- `cargo fmt --all`;
- `cargo test -p passless-core agent::config --lib` after installing the repository's native `libudev` build dependency;
- regression coverage for missing/present wildcard acknowledgement, missing registration acknowledgement, and stale unknown profile names.

The PR remains draft for normal repository CI and broader review.