### PR TITLE
feat(agent): make same-user enrollment ephemeral

### DIFF
--- a/cmd/passless/src/agent/policy_engine.rs
+++ b/cmd/passless/src/agent/policy_engine.rs
@@ -866,6 +866,7 @@ impl PolicyRuntime {
         &self,
         profile_id: ProfileId,
         rp_id: String,
+        ttl_secs: u64,
     ) -> Result<passless_core::agent::RegistrationGrantId, super::grant::GrantError> {
         let profile_key = profile_id.as_str().to_string();
         let mut reg_grants = self.registration_grants.lock().unwrap();
@@ -877,7 +878,46 @@ impl PolicyRuntime {
         let session_id = passless_core::agent::PrincipalSessionId::new();
         let endpoint_id = passless_core::agent::EndpointId::new();
 
-        registry.request_registration(profile_id, session_id, endpoint_id, [0u8; 32], rp_id, 300)
+        registry.request_registration(
+            profile_id,
+            session_id,
+            endpoint_id,
+            [0u8; 32],
+            rp_id,
+            ttl_secs,
+        )
+    }
+
+    pub fn active_registration_grant(
+        &self,
+        profile_id: &ProfileId,
+        rp_id: &str,
+    ) -> Option<super::grant::RegistrationGrantSnapshot> {
+        let normalized = super::grant::normalize_rp_id(rp_id).ok()?;
+        let now = self.clock.monotonic_secs();
+        let reg_grants = self.registration_grants.lock().ok()?;
+        let registry = reg_grants.get(profile_id.as_str())?;
+        registry
+            .list_all_snapshots()
+            .into_iter()
+            .filter(|grant| {
+                grant.state == super::grant::GrantState::Active
+                    && grant.rp_id == normalized
+                    && grant.expiry_mono > now
+            })
+            .max_by_key(|grant| grant.issued_at_mono)
+    }
+
+    pub fn consume_registration_grant(
+        &self,
+        profile_id: &ProfileId,
+        grant_id: &passless_core::agent::RegistrationGrantId,
+    ) -> Result<(), super::grant::GrantError> {
+        let reg_grants = self.registration_grants.lock().unwrap();
+        let registry = reg_grants
+            .get(profile_id.as_str())
+            .ok_or_else(|| super::grant::GrantError::RegistrationGrantNotFound(grant_id.clone()))?;
+        registry.revoke_registration(grant_id)
     }
 
     pub fn resolve_registration_grant(

--- a/cmd/passless/src/agent/prompt.rs
+++ b/cmd/passless/src/agent/prompt.rs
@@ -1019,7 +1019,7 @@ mod tests {
     fn test_prompt_sanitizer_truncates_utf8_on_character_boundaries() {
         let value = "é".repeat(MAX_UNTRUSTED_LEN);
         let sanitized = sanitize_prompt_text(&value, MAX_UNTRUSTED_LEN - 1);
-        assert!(sanitized.len() <= MAX_UNTRUSTED_LEN - 1);
+        assert!(sanitized.len() < MAX_UNTRUSTED_LEN);
         assert!(std::str::from_utf8(sanitized.as_bytes()).is_ok());
     }
 

--- a/cmd/passless/src/agent/register.rs
+++ b/cmd/passless/src/agent/register.rs
@@ -1074,13 +1074,14 @@ mod tests {
     fn test_register_rejects_invalid_grant_id() {
         let f = RegisterTestFixture::new();
         let handler = f.make_handler();
-        let mut registration_grants = HashMap::new();
-        registration_grants.insert("example.com".to_string(), RegistrationGrantId::new());
-        let ctx = RegisterContext {
-            profile_id: f.profile_id.clone(),
-            registration_grants,
-            profile_config: f.profile_config.clone(),
-        };
+        let grant = f
+            .policy_runtime
+            .active_registration_grant(&f.profile_id, "example.com")
+            .unwrap();
+        f.policy_runtime
+            .consume_registration_grant(&f.profile_id, &grant.grant_id)
+            .unwrap();
+        let ctx = f.make_ctx();
         let req = f.make_req();
 
         let result = handler.register(&ctx, &req);
@@ -1247,6 +1248,11 @@ mod tests {
     #[test]
     fn test_register_concurrent_requests_serialized() {
         let f = Arc::new(RegisterTestFixture::new());
+        for _ in 0..3 {
+            f.policy_runtime
+                .request_registration_grant(f.profile_id.clone(), "example.com".to_string(), 300)
+                .unwrap();
+        }
         let handler = Arc::new(f.make_handler());
         let mut handles = Vec::new();
 

--- a/cmd/passless/src/agent/register.rs
+++ b/cmd/passless/src/agent/register.rs
@@ -80,25 +80,7 @@ impl RegisterHandler {
 
         let grant_snapshot = self
             .policy_runtime
-            .resolve_registration_grant(
-                &ctx.profile_id,
-                ctx.registration_grants.get(&normalized_rp).ok_or_else(|| {
-                    let deny_event = PolicyDenyBuilder::new(
-                        ctx.profile_id.clone(),
-                        AuditAction::Register,
-                        &normalized_rp,
-                        PolicyDenyReason::GrantNotFound,
-                    )
-                    .build();
-                    let _ = self.audit_gate.record(deny_event);
-                    ProtocolError::new(
-                        ErrorCode::Forbidden,
-                        "registration grant not found for RP",
-                        RecommendedAction::FixRequest,
-                    )
-                })?,
-                &normalized_rp,
-            )
+            .active_registration_grant(&ctx.profile_id, &normalized_rp)
             .ok_or_else(|| {
                 let deny_event = PolicyDenyBuilder::new(
                     ctx.profile_id.clone(),
@@ -250,6 +232,16 @@ impl RegisterHandler {
                 RecommendedAction::Retry,
             )
         })?;
+
+        self.policy_runtime
+            .consume_registration_grant(&ctx.profile_id, &grant_snapshot.grant_id)
+            .map_err(|_| {
+                ProtocolError::new(
+                    ErrorCode::Conflict,
+                    "registration enrollment grant was already consumed",
+                    RecommendedAction::FixRequest,
+                )
+            })?;
 
         let algorithm = req
             .pub_key_cred_params
@@ -719,7 +711,7 @@ mod tests {
             registration_grants.insert(
                 "example.com".to_string(),
                 policy_runtime
-                    .request_registration_grant(profile_id.clone(), "example.com".to_string())
+                    .request_registration_grant(profile_id.clone(), "example.com".to_string(), 300)
                     .unwrap(),
             );
 
@@ -854,7 +846,7 @@ mod tests {
         registration_grants.insert(
             "example.com".to_string(),
             policy_runtime
-                .request_registration_grant(profile_id.clone(), "example.com".to_string())
+                .request_registration_grant(profile_id.clone(), "example.com".to_string(), 300)
                 .unwrap(),
         );
 

--- a/cmd/passless/src/agent/runtime.rs
+++ b/cmd/passless/src/agent/runtime.rs
@@ -4624,46 +4624,77 @@ impl AgentRuntime {
         max_session_ttl: u64,
         _reason: Option<&str>,
     ) -> Result<AdminResponse, ProtocolError> {
-        let _profile = self.profiles.get(profile_id).ok_or_else(|| {
+        let profile = self.profiles.get(profile_id).ok_or_else(|| {
             ProtocolError::new(
                 ErrorCode::NotFound,
                 format!("profile '{}' not found", profile_id),
                 RecommendedAction::FixRequest,
             )
         })?;
-
-        let (outcome, reason_code) = self
-            .policy_runtime
-            .authorize_registration(profile_id, rp_id);
-        if outcome == super::policy_engine::Outcome::Deny {
+        if !profile.enabled.load(Ordering::Acquire) {
             return Err(ProtocolError::new(
                 ErrorCode::Forbidden,
-                format!(
-                    "registration denied for profile '{}' and rp '{}': {}",
-                    profile_id, rp_id, reason_code
-                ),
+                format!("profile '{}' is disabled", profile_id),
                 RecommendedAction::FixRequest,
             ));
         }
 
-        let ttl = if max_session_ttl == 0 {
-            300
+        let normalized_rp = passless_core::agent::config::validate_rp_id(rp_id).map_err(|e| {
+            ProtocolError::new(
+                ErrorCode::BadRequest,
+                format!("invalid registration RP ID: {}", e),
+                RecommendedAction::FixRequest,
+            )
+        })?;
+        if normalized_rp == passless_core::agent::config::ANY_RP_ID {
+            return Err(ProtocolError::new(
+                ErrorCode::Forbidden,
+                "registration enrollment requires an exact RP ID",
+                RecommendedAction::FixRequest,
+            ));
+        }
+
+        let rule = profile
+            .profile_config
+            .rule_for_rp(&normalized_rp)
+            .ok_or_else(|| {
+                ProtocolError::new(
+                    ErrorCode::Forbidden,
+                    "registration RP has no configured rule",
+                    RecommendedAction::FixRequest,
+                )
+            })?;
+        if rule.register.authorization == passless_core::agent::AgentAuthorization::Deny {
+            return Err(ProtocolError::new(
+                ErrorCode::Forbidden,
+                "registration policy denies enrollment for RP",
+                RecommendedAction::FixRequest,
+            ));
+        }
+
+        let profile_ttl = profile
+            .profile_config
+            .max_session_ttl
+            .map(|ttl| ttl.as_secs())
+            .unwrap_or(300);
+        let enrollment_ceiling = profile_ttl.min(300).max(1);
+        let requested = if max_session_ttl == 0 {
+            enrollment_ceiling
         } else {
             max_session_ttl
         };
+        let ttl = requested.min(enrollment_ceiling).max(1);
 
         let reg_grant_id = self
             .policy_runtime
-            .request_registration_grant(profile_id.clone(), rp_id.to_string())
+            .request_registration_grant(profile_id.clone(), normalized_rp, ttl)
             .map_err(|e| {
                 ProtocolError::new(
-                    ErrorCode::Internal,
-                    format!("failed to request registration grant: {}", e),
-                    RecommendedAction::Retry,
+                    ErrorCode::Forbidden,
+                    format!("failed to create registration enrollment grant: {}", e),
+                    RecommendedAction::FixRequest,
                 )
             })?;
-
-        let _ = ttl;
 
         Ok(AdminResponse::RegistrationGranted {
             registration_grant_id: reg_grant_id,
@@ -4760,31 +4791,9 @@ impl AgentRuntime {
             )
         })?;
 
-        // Request registration grants for all allowed RP IDs
-        let mut registration_grants = std::collections::HashMap::new();
-        for rp_id in &config.rp_ids {
-            let registration_allowed = profile_config.rule_for_rp(rp_id).is_some_and(|rule| {
-                rule.register.authorization != passless_core::agent::AgentAuthorization::Deny
-            });
-            if !registration_allowed {
-                continue;
-            }
-
-            match self
-                .policy_runtime
-                .request_registration_grant(profile_id.clone(), rp_id.clone())
-            {
-                Ok(grant_id) => {
-                    registration_grants.insert(rp_id.clone(), grant_id);
-                }
-                Err(e) => {
-                    debug!(
-                        "failed to request registration grant for rp={}: {}",
-                        rp_id, e
-                    );
-                }
-            }
-        }
+        // Registration is never granted implicitly by browser launch. The operator must mint an
+        // exact-RP, short-lived enrollment grant through the admin request path.
+        let registration_grants = std::collections::HashMap::new();
 
         // Create registration context and handler
         let register_ctx = super::register::RegisterContext {

--- a/cmd/passless/src/agent/runtime.rs
+++ b/cmd/passless/src/agent/runtime.rs
@@ -4677,7 +4677,7 @@ impl AgentRuntime {
             .max_session_ttl
             .map(|ttl| ttl.as_secs())
             .unwrap_or(300);
-        let enrollment_ceiling = profile_ttl.min(300).max(1);
+        let enrollment_ceiling = profile_ttl.clamp(1, 300);
         let requested = if max_session_ttl == 0 {
             enrollment_ceiling
         } else {

--- a/cmd/passless/src/agent/sign.rs
+++ b/cmd/passless/src/agent/sign.rs
@@ -739,7 +739,11 @@ fn handle_http_connection(
         }
     };
     let is_register = path == "/register";
-    let entry = match registry.lookup_bound(token) {
+    let entry = match if is_register {
+        None
+    } else {
+        registry.lookup_bound(token)
+    } {
         Some(e) => e,
         None => {
             if is_register {

--- a/docs/agents/same-user.md
+++ b/docs/agents/same-user.md
@@ -134,3 +134,26 @@ passless agent --profile opencode instructions
 ```
 
 Review [security.md](security.md), [operations.md](operations.md), and [audit.md](audit.md) before deployment.
+
+## Ephemeral enrollment grants
+
+A same-user registration rule makes an exact RP eligible for enrollment; browser launch does not
+mint registration authority. Before a `navigator.credentials.create()` ceremony, the operator must
+create a short-lived exact-RP grant:
+
+```bash
+passless agent-admin delegation request-registration \
+  --profile <profile> \
+  --rp <rp-id> \
+  --session-ttl 300 \
+  --reason "enroll passkey"
+```
+
+The requested TTL is clamped to the profile session limit and to at most five minutes. The grant is
+one-shot: the registration service consumes it after policy/audit checks and before key generation
+or credential storage. A failed ceremony after consumption requires a fresh grant. Wildcard
+registration remains forbidden.
+
+This separates repeatable authentication authority from exceptional mutation of the human
+credential namespace. Keep the static registration rule denied when enrollment is not needed.
+

--- a/docs/agents/same-user.md
+++ b/docs/agents/same-user.md
@@ -156,4 +156,3 @@ registration remains forbidden.
 
 This separates repeatable authentication authority from exceptional mutation of the human
 credential namespace. Keep the static registration rule denied when enrollment is not needed.
-

--- a/passless-core/src/config.rs
+++ b/passless-core/src/config.rs
@@ -1100,7 +1100,7 @@ pub enum AdminDelegationAction {
         #[arg(long)]
         confirm: bool,
     },
-    /// Request a new registration
+    /// Create an exact-RP, short-lived, one-shot registration enrollment grant
     RequestRegistration {
         /// Profile identifier
         #[arg(long, value_name = "PROFILE")]
@@ -1108,7 +1108,7 @@ pub enum AdminDelegationAction {
         /// Relying party ID
         #[arg(long, value_name = "RP_ID")]
         rp: String,
-        /// Session TTL in seconds
+        /// Enrollment grant TTL in seconds (clamped to profile TTL and 300 seconds)
         #[arg(long, value_name = "SECONDS")]
         session_ttl: u64,
         /// Reason for the registration


### PR DESCRIPTION
## Summary

Turn same-user registration into an explicit, exact-RP, short-lived, one-shot enrollment capability instead of implicitly granting registration authority whenever the managed browser starts.

This reuses the existing registration-grant registry and existing admin request surface rather than introducing a parallel capability system.

## Security model

A static registration rule now means that an RP is eligible for enrollment. It does **not** by itself mint mutation authority for every browser session.

Before registration, the operator explicitly requests an enrollment grant for one concrete RP. The daemon clamps its lifetime to the profile session bound and an absolute five-minute ceiling.

The registration service consumes the grant after policy/audit checks and before key generation or credential storage. Consumption is one-shot: a later failure burns the grant and requires a fresh operator grant.

Expired grants are rejected by the active-grant lookup even if the registry has not yet performed an expiry cleanup pass.

## Implementation

- stop browser launch from automatically creating registration grants;
- allow the existing registration-grant request path to receive an explicit bounded TTL;
- require an exact concrete RP and a non-denied registration rule before minting the grant;
- add active exact-RP registration-grant lookup and one-shot consumption;
- reject expired grants at lookup time;
- dynamically resolve the explicit enrollment grant in the registration handler;
- consume the grant before key generation/storage mutation;
- route `/register` through the registration context before consulting the authentication context when the same browser bearer has both;
- retain the existing `delegation request-registration` CLI/protocol command for compatibility, while documenting its new enrollment semantics.

## Operator flow

```bash
passless agent-admin delegation request-registration \
  --profile <profile> \
  --rp <rp-id> \
  --session-ttl 300 \
  --reason "enroll passkey"
```

Wildcard registration remains forbidden.

## Validation

The final implementation was exercised with:

- `cargo fmt --all`;
- `cargo check --workspace --all-targets --all-features` with the same native TPM/libudev dependencies required by repository all-features builds;
- existing registration unit-test call sites migrated to explicit five-minute grant TTL;
- a second all-features validation after adding the expired-grant lookup guard.

This PR remains draft while normal repository CI runs on the clean single-commit branch.

## Review focus

1. one-shot consumption point relative to audit reservation and key generation;
2. exact-RP/TTL enforcement on explicit enrollment grants;
3. expired grant handling independently of registry cleanup;
4. browser HTTP context routing for registration;
5. compatibility of the retained admin command with the tightened semantics.