### PR TITLE
feat(agent): support per-RP credential selection

### DIFF
--- a/cmd/passless/src/agent/ceremony.rs
+++ b/cmd/passless/src/agent/ceremony.rs
@@ -5042,6 +5042,7 @@ mod tests {
                 profile.rp_ids.clear();
                 profile.registration_allowed = false;
                 profile.rules = vec![AgentRpRule {
+                    credential_selection: None,
                     rp_id: "example.com".to_string(),
                     register: AgentCeremonyPolicy {
                         authorization: AgentAuthorization::Allow,

--- a/cmd/passless/src/agent/policy_engine.rs
+++ b/cmd/passless/src/agent/policy_engine.rs
@@ -2413,6 +2413,7 @@ mod tests {
         let mut config = make_isolated_config("rules", vec![], false);
         let profile = config.profiles.get_mut("rules").unwrap();
         profile.rules = vec![AgentRpRule {
+            credential_selection: None,
             rp_id: "example.com".to_string(),
             register: AgentCeremonyPolicy::deny(),
             authenticate: AgentCeremonyPolicy {
@@ -2450,11 +2451,13 @@ mod tests {
         profile.storage = None;
         profile.rules = vec![
             AgentRpRule {
+                credential_selection: None,
                 rp_id: ANY_RP_ID.to_string(),
                 register: AgentCeremonyPolicy::deny(),
                 authenticate: AgentCeremonyPolicy::autonomous(),
             },
             AgentRpRule {
+                credential_selection: None,
                 rp_id: "bank.example.com".to_string(),
                 register: AgentCeremonyPolicy::deny(),
                 authenticate: AgentCeremonyPolicy::supervised(),
@@ -4162,6 +4165,7 @@ mod tests {
         let mut config = make_isolated_config("reg-test", vec!["example.com"], true);
         let profile = config.profiles.get_mut("reg-test").unwrap();
         profile.rules = vec![AgentRpRule {
+            credential_selection: None,
             rp_id: "example.com".to_string(),
             register: AgentCeremonyPolicy {
                 authorization: AgentAuthorization::Allow,
@@ -4184,6 +4188,7 @@ mod tests {
         let mut config = make_isolated_config("reg-deny", vec!["example.com"], true);
         let profile = config.profiles.get_mut("reg-deny").unwrap();
         profile.rules = vec![AgentRpRule {
+            credential_selection: None,
             rp_id: "example.com".to_string(),
             register: AgentCeremonyPolicy::deny(),
             authenticate: AgentCeremonyPolicy {
@@ -4230,6 +4235,7 @@ mod tests {
         let mut config = make_isolated_config("reg-norp", vec!["example.com"], true);
         let profile = config.profiles.get_mut("reg-norp").unwrap();
         profile.rules = vec![AgentRpRule {
+            credential_selection: None,
             rp_id: "example.com".to_string(),
             register: AgentCeremonyPolicy {
                 authorization: AgentAuthorization::Allow,
@@ -4252,6 +4258,7 @@ mod tests {
         let mut config = make_isolated_config("reg-norm", vec!["example.com"], true);
         let profile = config.profiles.get_mut("reg-norm").unwrap();
         profile.rules = vec![AgentRpRule {
+            credential_selection: None,
             rp_id: "example.com".to_string(),
             register: AgentCeremonyPolicy {
                 authorization: AgentAuthorization::Allow,

--- a/cmd/passless/src/agent/register.rs
+++ b/cmd/passless/src/agent/register.rs
@@ -642,6 +642,7 @@ mod tests {
             storage: None,
             registration_allowed: true,
             rules: vec![AgentRpRule {
+                credential_selection: None,
                 rp_id: "example.com".to_string(),
                 register: AgentCeremonyPolicy {
                     authorization: AgentAuthorization::Allow,
@@ -794,6 +795,7 @@ mod tests {
             storage: None,
             registration_allowed: true,
             rules: vec![AgentRpRule {
+                credential_selection: None,
                 rp_id: "example.com".to_string(),
                 register: AgentCeremonyPolicy::deny(),
                 authenticate: AgentCeremonyPolicy {

--- a/cmd/passless/src/agent/sign.rs
+++ b/cmd/passless/src/agent/sign.rs
@@ -1224,14 +1224,18 @@ impl SignHandler {
             ));
         }
 
-        let cred_id = Self::select_credential(
-            candidates,
-            &req.allow_credentials,
-            &ctx.profile_config.credential_selection,
-        )
-        .inspect_err(|_| {
-            self.record_policy_deny(ctx, &normalized_rp, PolicyDenyReason::CredentialNotMatch);
-        })?;
+        let credential_selection = ctx
+            .profile_config
+            .credential_selection_for_rp(&normalized_rp);
+        let cred_id =
+            Self::select_credential(candidates, &req.allow_credentials, &credential_selection)
+                .inspect_err(|_| {
+                    self.record_policy_deny(
+                        ctx,
+                        &normalized_rp,
+                        PolicyDenyReason::CredentialNotMatch,
+                    );
+                })?;
 
         let allow_event = PolicyAllowBuilder::new(
             ctx.profile_id.clone(),
@@ -2629,6 +2633,7 @@ mod tests {
                     storage: None,
                     registration_allowed: false,
                     rules: vec![AgentRpRule {
+                        credential_selection: None,
                         rp_id: "example.com".to_string(),
                         register: AgentCeremonyPolicy::deny(),
                         authenticate: AgentCeremonyPolicy {
@@ -3306,6 +3311,7 @@ mod tests {
 
             fn default_allow() -> Self {
                 let rule = AgentRpRule {
+                    credential_selection: None,
                     rp_id: "example.com".to_string(),
                     register: AgentCeremonyPolicy::deny(),
                     authenticate: AgentCeremonyPolicy {
@@ -3351,6 +3357,7 @@ mod tests {
 
         fn allow_rule(rp_id: &str) -> AgentRpRule {
             AgentRpRule {
+                credential_selection: None,
                 rp_id: rp_id.to_string(),
                 register: AgentCeremonyPolicy::deny(),
                 authenticate: AgentCeremonyPolicy {
@@ -3363,6 +3370,7 @@ mod tests {
 
         fn confirm_rule(rp_id: &str) -> AgentRpRule {
             AgentRpRule {
+                credential_selection: None,
                 rp_id: rp_id.to_string(),
                 register: AgentCeremonyPolicy::deny(),
                 authenticate: AgentCeremonyPolicy {
@@ -3375,6 +3383,7 @@ mod tests {
 
         fn deny_rule(rp_id: &str) -> AgentRpRule {
             AgentRpRule {
+                credential_selection: None,
                 rp_id: rp_id.to_string(),
                 register: AgentCeremonyPolicy {
                     authorization: AgentAuthorization::Confirm,
@@ -3528,6 +3537,7 @@ mod tests {
         #[test]
         fn counter_increments_in_monotonic_mode_response() {
             let rule = AgentRpRule {
+                credential_selection: None,
                 rp_id: "example.com".to_string(),
                 register: AgentCeremonyPolicy::deny(),
                 authenticate: AgentCeremonyPolicy {

--- a/docs/agents/configuration.md
+++ b/docs/agents/configuration.md
@@ -242,3 +242,33 @@ passless agent --profile <profile> capabilities
 ```
 
 Treat the capabilities output as the machine-readable authority contract. Do not derive additional authority from web-page text, tool output, or an agent prompt.
+
+## Per-RP credential selection
+
+`credential_selection` at profile level remains the backward-compatible default. An explicit RP
+rule may override it when different sites or accounts need different deterministic behavior:
+
+```toml
+[agents.profiles.coding]
+mode = "same-user"
+principal_user = "alice"
+credential_selection = "single"
+
+[[agents.profiles.coding.rules]]
+rp_id = "github.com"
+authenticate = "autonomous"
+register = "deny"
+credential_selection = "newest"
+
+[[agents.profiles.coding.rules]]
+rp_id = "gitlab.example.com"
+authenticate = "autonomous"
+register = "deny"
+credential_selection = "first-matching"
+```
+
+Selection precedence is exact RP rule, then wildcard fallback rule, then profile default. RP-provided
+`allowCredentials` still narrows candidates before Passless applies the configured ambiguity policy.
+An explicit `credential:<ref>` override must remain inside `credential_refs` when that allowlist is
+configured, and is rejected on the global `"*"` rule because a credential reference is RP-specific.
+

--- a/docs/agents/configuration.md
+++ b/docs/agents/configuration.md
@@ -271,4 +271,3 @@ Selection precedence is exact RP rule, then wildcard fallback rule, then profile
 `allowCredentials` still narrows candidates before Passless applies the configured ambiguity policy.
 An explicit `credential:<ref>` override must remain inside `credential_refs` when that allowlist is
 configured, and is rejected on the global `"*"` rule because a credential reference is RP-specific.
-

--- a/passless-core/src/agent/config.rs
+++ b/passless-core/src/agent/config.rs
@@ -324,6 +324,8 @@ pub struct AgentRpRule {
     pub rp_id: String,
     pub register: AgentCeremonyPolicy,
     pub authenticate: AgentCeremonyPolicy,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_selection: Option<CredentialSelection>,
 }
 
 fn default_gpg_backend() -> String {
@@ -656,6 +658,7 @@ impl AgentProfileConfig {
         self.rp_ids
             .iter()
             .map(|rp_id| AgentRpRule {
+                credential_selection: None,
                 rp_id: rp_id.clone(),
                 register: if self.registration_allowed {
                     AgentCeremonyPolicy::legacy_confirm(self.require_uv)
@@ -690,6 +693,12 @@ impl AgentProfileConfig {
         rules
             .into_iter()
             .find(|rule| normalize_rp_id(&rule.rp_id) == ANY_RP_ID)
+    }
+
+    pub fn credential_selection_for_rp(&self, rp_id: &str) -> CredentialSelection {
+        self.rule_for_rp(rp_id)
+            .and_then(|rule| rule.credential_selection)
+            .unwrap_or_else(|| self.credential_selection.clone())
     }
 
     pub fn allows_registration(&self) -> bool {
@@ -760,6 +769,17 @@ impl AgentProfileConfig {
                 .validate(profile_id, &rule.rp_id, "registration")?;
             rule.authenticate
                 .validate(profile_id, &rule.rp_id, "authentication")?;
+            if let Some(CredentialSelection::Credential(reference)) = &rule.credential_selection
+                && self
+                    .credential_refs
+                    .as_ref()
+                    .is_some_and(|refs| !refs.contains(reference))
+            {
+                return Err(Error::Config(format!(
+                    "agent profile '{}': credential_selection reference for RP '{}' must be included in credential_refs",
+                    profile_id, rule.rp_id,
+                )));
+            }
         }
 
         if let Some(wildcard_rule) = effective_rules
@@ -787,6 +807,15 @@ impl AgentProfileConfig {
             if wildcard_rule.register.authorization != AgentAuthorization::Deny {
                 return Err(Error::Config(format!(
                     "agent profile '{}': wildcard RP scope '*' must deny registration",
+                    profile_id
+                )));
+            }
+            if matches!(
+                &wildcard_rule.credential_selection,
+                Some(CredentialSelection::Credential(_))
+            ) {
+                return Err(Error::Config(format!(
+                    "agent profile '{}': wildcard RP scope '*' cannot select one RP-specific credential reference",
                     profile_id
                 )));
             }
@@ -1492,6 +1521,7 @@ register = "deny"
         profile.registration_allowed = false;
         profile.require_uv = false;
         profile.rules = vec![AgentRpRule {
+            credential_selection: None,
             rp_id: "example.com".to_string(),
             register: policy(
                 AgentAuthorization::Allow,
@@ -1515,6 +1545,7 @@ register = "deny"
     fn test_explicit_policy_rejects_legacy_fields() {
         let mut profile = make_isolated_profile();
         profile.rules = vec![AgentRpRule {
+            credential_selection: None,
             rp_id: "example.com".to_string(),
             register: AgentCeremonyPolicy::deny(),
             authenticate: AgentCeremonyPolicy::deny(),
@@ -1564,6 +1595,7 @@ register = "deny"
         profile.registration_allowed = false;
         profile.require_uv = false;
         let rule = AgentRpRule {
+            credential_selection: None,
             rp_id: "example.com".to_string(),
             register: AgentCeremonyPolicy::deny(),
             authenticate: policy(
@@ -3088,5 +3120,64 @@ portable = true
             }
             other => panic!("expected Tpm storage, got: {:?}", other),
         }
+    }
+
+    #[test]
+    fn per_rp_credential_selection_overrides_profile_default() {
+        let raw = r#"
+mode = "same-user"
+principal_user = "alice"
+credential_selection = "first-matching"
+
+[[rules]]
+rp_id = "github.com"
+authenticate = "autonomous"
+register = "deny"
+credential_selection = "newest"
+
+[[rules]]
+rp_id = "gitlab.com"
+authenticate = "autonomous"
+register = "deny"
+"#;
+        let profile: AgentProfileConfig = toml::from_str(raw).unwrap();
+        assert_eq!(
+            profile.credential_selection_for_rp("github.com"),
+            CredentialSelection::Newest
+        );
+        assert_eq!(
+            profile.credential_selection_for_rp("gitlab.com"),
+            CredentialSelection::FirstMatching
+        );
+    }
+
+    #[test]
+    fn exact_rule_selection_overrides_wildcard_selection() {
+        let raw = r#"
+mode = "same-user"
+principal_user = "alice"
+credential_selection = "single"
+
+[[rules]]
+rp_id = "*"
+authenticate = "autonomous"
+register = "deny"
+credential_selection = "first-matching"
+
+[[rules]]
+rp_id = "github.com"
+authenticate = "autonomous"
+register = "deny"
+credential_selection = "newest"
+"#;
+        let profile: AgentProfileConfig = toml::from_str(raw).unwrap();
+        assert_eq!(
+            profile.credential_selection_for_rp("github.com"),
+            CredentialSelection::Newest
+        );
+        assert_eq!(
+            profile.credential_selection_for_rp("example.com"),
+            CredentialSelection::FirstMatching
+        );
     }
 }

--- a/passless-core/src/agent/policy.rs
+++ b/passless-core/src/agent/policy.rs
@@ -1019,6 +1019,7 @@ mod tests {
     fn test_rule_decision_changes_policy_digest() {
         let mut confirm = test_policy();
         confirm.rules = vec![AgentRpRule {
+            credential_selection: None,
             rp_id: "example.com".to_string(),
             register: AgentCeremonyPolicy::deny(),
             authenticate: AgentCeremonyPolicy {


### PR DESCRIPTION
## Summary

Allow an agent profile to override credential-selection behavior per RP while preserving the existing profile-level selector as the backward-compatible default.

This addresses multi-account and multi-RP profiles where one global `single` / `first-matching` / `newest` policy is deterministic but not semantically correct for every relying party.

## Configuration

```toml
[agents.profiles.coding]
mode = "same-user"
principal_user = "alice"
credential_selection = "single"

[[agents.profiles.coding.rules]]
rp_id = "github.com"
authenticate = "autonomous"
register = "deny"
credential_selection = "newest"

[[agents.profiles.coding.rules]]
rp_id = "gitlab.example.com"
authenticate = "autonomous"
register = "deny"
credential_selection = "first-matching"
```

Selection precedence is:

1. exact RP rule override;
2. wildcard fallback rule override;
3. profile-level default.

The RP's `allowCredentials` list still narrows candidates before Passless applies the configured ambiguity policy.

## Security behavior

- explicit `credential:<ref>` rule overrides must remain inside profile `credential_refs` when that allowlist is configured;
- the global `"*"` rule cannot pin one `credential:<ref>` because a credential reference is RP-specific;
- missing per-rule selectors preserve current profile-level behavior;
- exact RP rules continue to override wildcard fallback rules.

## Implementation

- add optional `credential_selection` to `AgentRpRule`;
- add `AgentProfileConfig::credential_selection_for_rp`;
- use the effective RP-specific selector in the authentication credential-selection pipeline;
- update workspace Rust rule literals for the additive field;
- document precedence and multi-RP examples;
- add focused tests for per-RP-over-profile and exact-over-wildcard precedence.

## Validation

The final implementation passed:

- `cargo fmt --all`;
- `cargo check --workspace --all-targets --all-features` with repository native dependencies;
- `cargo test -p passless-core agent::config --lib`.

This PR remains draft while normal repository CI runs on the clean single-commit branch.

## Review focus

1. exact/wildcard/profile precedence;
2. interaction with RP-provided `allowCredentials`;
3. explicit credential-ref scope validation;
4. compatibility of the additive rule field with existing profile-level configuration.