### PR TITLE
feat: improve Playwright MCP browser integration

### DIFF
--- a/cmd/passless/src/agent/browser.rs
+++ b/cmd/passless/src/agent/browser.rs
@@ -1045,16 +1045,31 @@ impl BrowserProcessManager {
         ids.iter().filter_map(|id| self.snapshot(id)).collect()
     }
 
-    pub fn find_live_lease_for_profile(&self, profile_id: &ProfileId) -> Option<LeaseSnapshot> {
-        for (id, lease) in &self.leases {
+    pub fn find_live_lease_for_profile(&mut self, profile_id: &ProfileId) -> Option<LeaseSnapshot> {
+        let lease_ids: Vec<BrowserLeaseId> = self.leases.keys().cloned().collect();
+        for id in lease_ids {
+            let lease = self.leases.get_mut(&id)?;
             if &lease.profile_id == profile_id
                 && matches!(
                     lease.state,
                     LeaseState::Active | LeaseState::AuthenticationPending
                 )
-                && let Some(snapshot) = self.snapshot(id)
             {
-                return Some(snapshot);
+                if let Some(ref mut child) = lease.child {
+                    match child.try_wait() {
+                        Ok(Some(_)) => {
+                            lease.child_reaped = true;
+                            continue;
+                        }
+                        Ok(None) => {}
+                        Err(_) => {
+                            continue;
+                        }
+                    }
+                }
+                if let Some(snapshot) = self.snapshot(&id) {
+                    return Some(snapshot);
+                }
             }
         }
         None
@@ -3456,7 +3471,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let clock = test_clock();
         let mut mgr = BrowserProcessManager::new(clock);
-        let config = test_config(dir.path());
+        let mut config = test_config(dir.path());
+        config.executable = std::path::PathBuf::from("/bin/sleep");
+        config.extra_args = vec!["60".to_string()];
 
         let lease_id = mgr
             .launch(&config, test_endpoint_id(), test_profile_id())
@@ -3471,6 +3488,9 @@ mod tests {
             snapshot.state,
             LeaseState::Active | LeaseState::AuthenticationPending
         ));
+
+        mgr.terminate(&lease_id).ok();
+        mgr.cleanup(&lease_id).ok();
     }
 
     #[test]
@@ -3478,7 +3498,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let clock = test_clock();
         let mut mgr = BrowserProcessManager::new(clock);
-        let config = test_config(dir.path());
+        let mut config = test_config(dir.path());
+        config.executable = std::path::PathBuf::from("/bin/sleep");
+        config.extra_args = vec!["60".to_string()];
 
         let _lease_id = mgr
             .launch(&config, test_endpoint_id(), test_profile_id())
@@ -3487,6 +3509,9 @@ mod tests {
         let other_profile = ProfileId::new("other-profile").unwrap();
         let snapshot = mgr.find_live_lease_for_profile(&other_profile);
         assert!(snapshot.is_none());
+
+        mgr.terminate(&_lease_id).ok();
+        mgr.cleanup(&_lease_id).ok();
     }
 
     #[test]
@@ -3503,6 +3528,83 @@ mod tests {
 
         let snapshot = mgr.find_live_lease_for_profile(&test_profile_id());
         assert!(snapshot.is_none());
+    }
+
+    #[test]
+    fn test_find_live_lease_for_profile_skips_exited_child() {
+        let dir = tempfile::tempdir().unwrap();
+        let clock = test_clock();
+        let mut mgr = BrowserProcessManager::new(clock);
+        let mut config = test_config(dir.path());
+        config.executable = std::path::PathBuf::from("/bin/true");
+        config.start_url = None;
+        config.extra_args = vec![];
+
+        let _lease_id = mgr
+            .launch(&config, test_endpoint_id(), test_profile_id())
+            .unwrap();
+
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        let snapshot = mgr.find_live_lease_for_profile(&test_profile_id());
+        assert!(snapshot.is_none());
+    }
+
+    #[test]
+    fn test_find_live_lease_for_profile_reuses_sleeping_child() {
+        let dir = tempfile::tempdir().unwrap();
+        let clock = test_clock();
+        let mut mgr = BrowserProcessManager::new(clock);
+        let mut config = test_config(dir.path());
+        config.executable = std::path::PathBuf::from("/bin/sleep");
+        config.start_url = None;
+        config.extra_args = vec!["60".to_string()];
+
+        let lease_id = mgr
+            .launch(&config, test_endpoint_id(), test_profile_id())
+            .unwrap();
+
+        let snapshot = mgr.find_live_lease_for_profile(&test_profile_id());
+        assert!(snapshot.is_some());
+        assert_eq!(snapshot.unwrap().id, lease_id);
+
+        mgr.terminate(&lease_id).ok();
+        mgr.cleanup(&lease_id).ok();
+    }
+
+    #[test]
+    fn test_idempotent_launch_reuses_existing_lease() {
+        let dir = tempfile::tempdir().unwrap();
+        let clock = test_clock();
+        let mut mgr = BrowserProcessManager::new(clock);
+        let mut config = test_config(dir.path());
+        config.executable = std::path::PathBuf::from("/bin/sleep");
+        config.start_url = Some("https://example.com".to_string());
+        config.extra_args = vec!["60".to_string()];
+
+        let first_lease_id = mgr
+            .launch(&config, test_endpoint_id(), test_profile_id())
+            .unwrap();
+
+        let first_snapshot = mgr.find_live_lease_for_profile(&test_profile_id());
+        assert!(first_snapshot.is_some());
+        let first_snapshot = first_snapshot.unwrap();
+        assert_eq!(first_snapshot.id, first_lease_id);
+        assert_eq!(
+            first_snapshot.start_url,
+            Some("https://example.com".to_string())
+        );
+
+        let second_snapshot = mgr.find_live_lease_for_profile(&test_profile_id());
+        assert!(second_snapshot.is_some());
+        let second_snapshot = second_snapshot.unwrap();
+        assert_eq!(second_snapshot.id, first_lease_id);
+        assert_eq!(second_snapshot.pid, first_snapshot.pid);
+
+        assert_eq!(mgr.lease_count(), 1);
+
+        mgr.terminate(&first_lease_id).ok();
+        mgr.cleanup(&first_lease_id).ok();
     }
 
     #[test]

--- a/cmd/passless/src/agent/browser.rs
+++ b/cmd/passless/src/agent/browser.rs
@@ -499,6 +499,7 @@ pub struct BrowserLease {
     pub cdp_read_buf: Vec<u8>,
     pub child_reaped: bool,
     pub cdp_endpoint: Option<String>,
+    pub start_url: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -513,6 +514,7 @@ pub struct LeaseSnapshot {
     pub pid: u32,
     #[allow(dead_code)]
     pub ttl_remaining_secs: u64,
+    pub start_url: Option<String>,
 }
 
 pub struct BrowserProcessManager {
@@ -739,6 +741,7 @@ impl BrowserProcessManager {
             cdp_read_buf: Vec::with_capacity(CDP_READ_BUF_SIZE),
             child_reaped: false,
             cdp_endpoint: cdp_endpoint_url,
+            start_url: config.start_url.clone(),
         };
 
         if let Some(mut consumed) = consumed_pipes {
@@ -1033,12 +1036,28 @@ impl BrowserProcessManager {
             state: lease.state,
             pid: lease.manifest.pid,
             ttl_remaining_secs: remaining,
+            start_url: lease.start_url.clone(),
         })
     }
 
     pub fn list_snapshots(&self) -> Vec<LeaseSnapshot> {
         let ids: Vec<BrowserLeaseId> = self.leases.keys().cloned().collect();
         ids.iter().filter_map(|id| self.snapshot(id)).collect()
+    }
+
+    pub fn find_live_lease_for_profile(&self, profile_id: &ProfileId) -> Option<LeaseSnapshot> {
+        for (id, lease) in &self.leases {
+            if &lease.profile_id == profile_id
+                && matches!(
+                    lease.state,
+                    LeaseState::Active | LeaseState::AuthenticationPending
+                )
+                && let Some(snapshot) = self.snapshot(id)
+            {
+                return Some(snapshot);
+            }
+        }
+        None
     }
 
     pub fn check_expired(&mut self) -> Vec<BrowserLeaseId> {
@@ -3430,6 +3449,60 @@ mod tests {
             .launch(&config, test_endpoint_id(), test_profile_id())
             .unwrap();
         assert_eq!(mgr.list_snapshots().len(), 2);
+    }
+
+    #[test]
+    fn test_find_live_lease_for_profile_returns_active_lease() {
+        let dir = tempfile::tempdir().unwrap();
+        let clock = test_clock();
+        let mut mgr = BrowserProcessManager::new(clock);
+        let config = test_config(dir.path());
+
+        let lease_id = mgr
+            .launch(&config, test_endpoint_id(), test_profile_id())
+            .unwrap();
+
+        let snapshot = mgr.find_live_lease_for_profile(&test_profile_id());
+        assert!(snapshot.is_some());
+        let snapshot = snapshot.unwrap();
+        assert_eq!(snapshot.id, lease_id);
+        assert_eq!(snapshot.profile_id, test_profile_id());
+        assert!(matches!(
+            snapshot.state,
+            LeaseState::Active | LeaseState::AuthenticationPending
+        ));
+    }
+
+    #[test]
+    fn test_find_live_lease_for_profile_returns_none_for_different_profile() {
+        let dir = tempfile::tempdir().unwrap();
+        let clock = test_clock();
+        let mut mgr = BrowserProcessManager::new(clock);
+        let config = test_config(dir.path());
+
+        let _lease_id = mgr
+            .launch(&config, test_endpoint_id(), test_profile_id())
+            .unwrap();
+
+        let other_profile = ProfileId::new("other-profile").unwrap();
+        let snapshot = mgr.find_live_lease_for_profile(&other_profile);
+        assert!(snapshot.is_none());
+    }
+
+    #[test]
+    fn test_find_live_lease_for_profile_skips_terminal_leases() {
+        let dir = tempfile::tempdir().unwrap();
+        let clock = test_clock();
+        let mut mgr = BrowserProcessManager::new(clock);
+        let config = test_config(dir.path());
+
+        let lease_id = mgr
+            .launch(&config, test_endpoint_id(), test_profile_id())
+            .unwrap();
+        mgr.revoke(&lease_id).unwrap();
+
+        let snapshot = mgr.find_live_lease_for_profile(&test_profile_id());
+        assert!(snapshot.is_none());
     }
 
     #[test]

--- a/cmd/passless/src/agent/runtime.rs
+++ b/cmd/passless/src/agent/runtime.rs
@@ -4923,6 +4923,22 @@ impl AgentRuntime {
             )
         })?;
 
+        if let Some(existing_snapshot) = browser_manager.find_live_lease_for_profile(profile_id) {
+            let cdp_endpoint = browser_manager
+                .lease_cdp_endpoint(&existing_snapshot.id)
+                .flatten();
+
+            return Ok(AdminResponse::BrowserLaunched(
+                passless_core::agent::protocol::BrowserLaunchedResponse {
+                    lease_id: existing_snapshot.id.to_string(),
+                    profile_id: profile_id.to_string(),
+                    pid: existing_snapshot.pid,
+                    start_url: existing_snapshot.start_url,
+                    cdp_endpoint,
+                },
+            ));
+        }
+
         // Generate bearer token for this browser session
         let bearer_token = super::sign::generate_bearer_token().map_err(|e| {
             ProtocolError::new(
@@ -5102,12 +5118,15 @@ impl AgentRuntime {
             );
         }
 
+        let cdp_endpoint = browser_manager.lease_cdp_endpoint(&lease_id).flatten();
+
         Ok(AdminResponse::BrowserLaunched(
             passless_core::agent::protocol::BrowserLaunchedResponse {
                 lease_id: lease_id.to_string(),
                 profile_id: profile_id.to_string(),
                 pid,
                 start_url: config.start_url,
+                cdp_endpoint,
             },
         ))
     }

--- a/cmd/passless/src/commands/agent_admin.rs
+++ b/cmd/passless/src/commands/agent_admin.rs
@@ -780,6 +780,9 @@ fn dispatch_browser(output: OutputFormat, action: &AdminBrowserAction) -> Result
                         if let Some(ref url) = info.start_url {
                             println!("start_url: {}", url);
                         }
+                        if let Some(ref endpoint) = info.cdp_endpoint {
+                            println!("cdp_endpoint: {}", endpoint);
+                        }
                         Ok(())
                     }
                 },

--- a/passless-core/src/agent/protocol.rs
+++ b/passless-core/src/agent/protocol.rs
@@ -3194,4 +3194,34 @@ mod tests {
         let json = r#"{"origin":"https://example.com","rp_id":"example.com","challenge_b64u":"dGVzdA","allow_credentials":[],"user_verification":false,"cross_origin":false,"extra":"bad"}"#;
         assert!(serde_json::from_str::<SignAssertionRequest>(json).is_err());
     }
+
+    #[test]
+    fn browser_launched_response_serializes_without_cdp_endpoint_when_none() {
+        let resp = BrowserLaunchedResponse {
+            lease_id: "lease-123".into(),
+            profile_id: "test-profile".into(),
+            pid: 1234,
+            start_url: Some("https://example.com".into()),
+            cdp_endpoint: None,
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(!json.contains("cdp_endpoint"));
+        let decoded: BrowserLaunchedResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, resp);
+    }
+
+    #[test]
+    fn browser_launched_response_serializes_with_cdp_endpoint_when_some() {
+        let resp = BrowserLaunchedResponse {
+            lease_id: "lease-456".into(),
+            profile_id: "test-profile".into(),
+            pid: 5678,
+            start_url: None,
+            cdp_endpoint: Some("http://127.0.0.1:9222".into()),
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("cdp_endpoint"));
+        let decoded: BrowserLaunchedResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, resp);
+    }
 }

--- a/passless-core/src/agent/protocol.rs
+++ b/passless-core/src/agent/protocol.rs
@@ -839,6 +839,8 @@ pub struct BrowserLaunchedResponse {
     pub profile_id: String,
     pub pid: u32,
     pub start_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cdp_endpoint: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

- include the discovered CDP endpoint in browser launch responses
- make browser launch idempotent by reusing a live lease for the profile
- verify process liveness before reuse and preserve the original start URL
- expose the endpoint in plain and JSON CLI output

## Configuration

```toml
[profiles.coding]
browser_cdp_expose = "port"
browser_cdp_port = 9222
```

## Testing

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build`
- `cargo test`

Closes #422