### PR TITLE
release: Version 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.17.0](https://github.com/pando85/passless/tree/v0.17.0) - 2026-08-16
+
+### Added
+
+- Improve Playwright MCP browser integration (#423) ([06eec5e](https://github.com/pando85/passless/commit/06eec5e4b834997b7f1a4c9b113d5379204c1545))
+
+### Testing
+
+- Make browser lease tests deterministic (#424) ([6cc76c0](https://github.com/pando85/passless/commit/6cc76c00f97358134dbe38e8dd52455446af61a8))
+
 ## [v0.16.0](https://github.com/pando85/passless/tree/v0.16.0) - 2026-08-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,7 +1718,7 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "passless-config-doc"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "passless-core"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "clap",
  "clap-serde-derive",
@@ -1752,7 +1752,7 @@ dependencies = [
 
 [[package]]
 name = "passless-rs"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1799,7 +1799,7 @@ dependencies = [
 
 [[package]]
 name = "passless-uhid"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "libc",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,15 @@ resolver = "2"
 [workspace.package]
 authors = ["Pando85 <pando855@gmail.com>"]
 edition = "2024"
-version = "0.16.0"
+version = "0.17.0"
 license-file = "./LICENSE"
 homepage = "https://github.com/pando85/passless"
 repository = "https://github.com/pando85/passless"
 [workspace.dependencies]
 # Workspace crates
-passless-core = { path = "./passless-core", version = "0.16.0" }
-passless-config-doc = { path = "./passless-config-doc", version = "0.16.0" }
-passless-uhid = { path = "./passless-uhid", version = "0.16.0" }
+passless-core = { path = "./passless-core", version = "0.17.0" }
+passless-config-doc = { path = "./passless-config-doc", version = "0.17.0" }
+passless-uhid = { path = "./passless-uhid", version = "0.17.0" }
 
 soft-fido2 = "0.17.0"
 soft-fido2-ctap = "0.17.0"


### PR DESCRIPTION
Release v0.17.0

### Changes since v0.16.0

**Added**
- Improve Playwright MCP browser integration (#423)

**Testing**
- Make browser lease tests deterministic (#424)

---
After merge, CI will automatically create the signed tag and publish the release.