### PR TITLE
feat: use systemd-journal-logger when running as systemd service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1789,6 +1789,7 @@ dependencies = [
  "soft-fido2",
  "soft-fido2-ctap",
  "soft-fido2-transport",
+ "systemd-journal-logger",
  "tempfile",
  "tokio",
  "toml",
@@ -2620,6 +2621,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "systemd-journal-logger"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7266304d24ca5a4b230545fc558c80e18bd3e1d2eb1be149b6bcd04398d3e79c"
+dependencies = [
+ "log",
+ "rustix",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2644,7 +2655,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ clap-serde-derive = "0.2"
 clap_complete = "4.5"
 log = "0.4"
 env_logger = "0.11"
+systemd-journal-logger = "2.2.2"
 sha2 = "0.11"
 serde_cbor = "0.11.2"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ dirs = "6.0"
 prs-lib = "0.5"
 serde_json = "1.0"
 libc = "0.2"
-nix = { version = "0.31", features = ["resource", "fs", "signal", "process", "dir"] }
+nix = { version = "0.31", features = ["resource", "fs", "signal", "process", "dir", "user"] }
 notify-rust = "4.11"
 aes-gcm = "0.11"
 rand = "0.8"

--- a/cmd/passless/Cargo.toml
+++ b/cmd/passless/Cargo.toml
@@ -34,6 +34,7 @@ soft-fido2-transport.workspace = true
 soft-fido2-ctap.workspace = true
 log.workspace = true
 env_logger.workspace = true
+systemd-journal-logger.workspace = true
 sha2.workspace = true
 serde_cbor.workspace = true
 serde.workspace = true

--- a/cmd/passless/src/main.rs
+++ b/cmd/passless/src/main.rs
@@ -432,12 +432,20 @@ fn run() -> Result<()> {
         log::LevelFilter::Info
     };
 
-    if systemd_journal_logger::connected_to_journal() {
-        systemd_journal_logger::JournalLog::new()
-            .unwrap()
-            .with_syslog_identifier("passless".to_string())
+    // Use syslog when running as systemd service
+    if systemd_journal_logger::connected_to_journal()
+        && let Ok(journal) = systemd_journal_logger::JournalLog::new()
+    {
+        // Assume only the agent is run as root
+        let syslog_identifier = if nix::unistd::Uid::effective().is_root() {
+            "passless-agent"
+        } else {
+            "passless"
+        };
+        journal
+            .with_syslog_identifier(syslog_identifier.to_string())
             .install()
-            .unwrap();
+            .expect("Logger was already installed.");
     } else {
         let env = Env::default()
             .filter("PASSLESS_LOG_LEVEL")

--- a/cmd/passless/src/main.rs
+++ b/cmd/passless/src/main.rs
@@ -432,13 +432,21 @@ fn run() -> Result<()> {
         log::LevelFilter::Info
     };
 
-    let env = Env::default()
-        .filter("PASSLESS_LOG_LEVEL")
-        .write_style("PASSLESS_LOG_STYLE");
-    Builder::from_env(env)
-        .filter_level(log::LevelFilter::Debug)
-        .format_timestamp_millis()
-        .init();
+    if systemd_journal_logger::connected_to_journal() {
+        systemd_journal_logger::JournalLog::new()
+            .unwrap()
+            .with_syslog_identifier("passless".to_string())
+            .install()
+            .unwrap();
+    } else {
+        let env = Env::default()
+            .filter("PASSLESS_LOG_LEVEL")
+            .write_style("PASSLESS_LOG_STYLE");
+        Builder::from_env(env)
+            .filter_level(log::LevelFilter::Debug)
+            .format_timestamp_millis()
+            .init();
+    }
     log::set_max_level(log_level);
 
     // Load config: CLI args + config file + defaults (CLI takes precedence)


### PR DESCRIPTION
This produces nicer logging output with colors for log levels and no duplicate time stamps.

Currently it looks like this:

```
Aug 21 14:03:34 maschine systemd[2827]: Started Passless FIDO2 Software Authenticator.
Aug 21 14:03:34 maschine passless[151280]: [2026-08-21T12:03:34.633Z INFO  passless_core::config] Loading configuration from: /nix/store/xgfdwsd064n55ycjn8c1vamicr73qyn7-passless.toml
Aug 21 14:03:34 maschine passless[151280]: [2026-08-21T12:03:34.633Z INFO  passless] Enabling verbose logging...
Aug 21 14:03:34 maschine passless[151280]: [2026-08-21T12:03:34.633Z DEBUG passless] Verbose logging enabled
Aug 21 14:03:34 maschine passless[151280]: [2026-08-21T12:03:34.633Z INFO  passless] Applying security hardening...
Aug 21 14:03:34 maschine passless[151280]: [2026-08-21T12:03:34.633Z DEBUG passless_core::config] Disabling core dumps to prevent credential leakage
Aug 21 14:03:34 maschine passless[151280]: [2026-08-21T12:03:34.633Z DEBUG passless_core::config] Check mlock capability
Aug 21 14:03:34 maschine passless[151280]: [2026-08-21T12:03:34.633Z DEBUG passless_core::config] MLOCK is enabled - sensitive data will not be swapped to disk
Aug 21 14:03:34 maschine passless[151280]: [2026-08-21T12:03:34.634Z INFO  passless] Acquiring instance lock...
Aug 21 14:03:34 maschine passless[151280]: [2026-08-21T12:03:34.634Z DEBUG passless] Instance lock acquired at /run/user/1001/passless/1acd256aa9f526d1cd5a3aab21ccd746.lock
Aug 21 14:03:34 maschine passless[151280]: [2026-08-21T12:03:34.634Z INFO  passless] Creating UHID device...
Aug 21 14:03:34 maschine passless[151280]: [2026-08-21T12:03:34.734Z INFO  passless] Creating authenticator service...
Aug 21 14:03:34 maschine passless[151280]: [2026-08-21T12:03:34.734Z INFO  passless::storage::pass] Using pass (password-store) backend
Aug 21 14:03:34 maschine passless[151280]: [2026-08-21T12:03:34.734Z INFO  passless::storage::pass] Store path: /home/kerstin/.local/share/password-store
Aug 21 14:03:34 maschine passless[151280]: [2026-08-21T12:03:34.734Z INFO  passless::storage::pass] Path: fido2
Aug 21 14:03:34 maschine passless[151280]: [2026-08-21T12:03:34.734Z INFO  passless::storage::pass] GPG backend: gpg
```