### PR TITLE
fix(agent): handle SIGTERM and detect orphaned sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1786,6 +1786,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "shadow-rs",
+ "signal-hook",
  "soft-fido2",
  "soft-fido2-ctap",
  "soft-fido2-transport",
@@ -2417,6 +2418,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2644,7 +2655,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ notify-rust = "4.11"
 aes-gcm = "0.11"
 rand = "0.8"
 ctrlc = "3.4"
+signal-hook = "0.3"
 zeroize = { version = "1.8", features = ["zeroize_derive"] }
 hex = "0.4"
 shadow-rs = "2.0"

--- a/cmd/passless/Cargo.toml
+++ b/cmd/passless/Cargo.toml
@@ -45,6 +45,7 @@ notify-rust.workspace = true
 aes-gcm.workspace = true
 rand.workspace = true
 ctrlc.workspace = true
+signal-hook.workspace = true
 clap.workspace = true
 zeroize.workspace = true
 hex.workspace = true

--- a/cmd/passless/src/agent/launcher.rs
+++ b/cmd/passless/src/agent/launcher.rs
@@ -696,6 +696,10 @@ impl HardenedChildSetup {
             return Err(io::Error::last_os_error());
         }
 
+        if unsafe { libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM, 0, 0, 0) } < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
         if !self.same_user() {
             if unsafe { libc::setgroups(0, std::ptr::null()) } < 0 {
                 return Err(io::Error::last_os_error());

--- a/cmd/passless/src/agent/runtime.rs
+++ b/cmd/passless/src/agent/runtime.rs
@@ -490,6 +490,7 @@ pub struct ManagedPrincipalSession {
     pub process_digest: super::intent::ProcessIdentityDigest,
     pub created_at: Instant,
     pub deadline: Instant,
+    pub client_pid: i32,
 }
 
 impl std::fmt::Debug for ManagedPrincipalSession {
@@ -501,6 +502,7 @@ impl std::fmt::Debug for ManagedPrincipalSession {
             .field("process_digest", &self.process_digest)
             .field("created_at", &self.created_at)
             .field("deadline", &self.deadline)
+            .field("client_pid", &self.client_pid)
             .finish()
     }
 }
@@ -2335,6 +2337,7 @@ impl AgentRuntime {
         &self,
         profile_id: &ProfileId,
         command: &[String],
+        cred: &PeerCred,
         ctx: &super::ipc::AdminRequestContext,
     ) -> Result<AdminResponse, ProtocolError> {
         let profile = self.profiles.get(profile_id).ok_or_else(|| {
@@ -2457,7 +2460,12 @@ impl AgentRuntime {
         let pid = session.child.id();
         let session_id = PrincipalSessionId::new();
         let now = Instant::now();
-        let deadline = now + Duration::from_secs(3600);
+        let ttl_secs = profile
+            .profile_config
+            .max_session_ttl
+            .map(|ttl| ttl.as_secs())
+            .unwrap_or(3600);
+        let deadline = now + Duration::from_secs(ttl_secs);
 
         let process_digest = super::intent::ProcessIdentityDigest::compute_from_session_identity(
             &super::intent::SessionIdentityParams {
@@ -2479,6 +2487,7 @@ impl AgentRuntime {
             process_digest,
             created_at: now,
             deadline,
+            client_pid: cred.pid,
         });
 
         info!(
@@ -2646,6 +2655,11 @@ impl AgentRuntime {
         }
     }
 
+    fn is_pid_alive(pid: i32) -> bool {
+        let stat_path = format!("/proc/{}/stat", pid);
+        std::fs::metadata(&stat_path).is_ok()
+    }
+
     fn prune_completed_before_insert(
         map: &mut std::collections::BTreeMap<String, CompletedSession>,
     ) {
@@ -2687,6 +2701,12 @@ impl AgentRuntime {
                     debug!(
                         "Session {} for profile {} expired, reaping",
                         sessions[index].session_id, profile_id
+                    );
+                    true
+                } else if !Self::is_pid_alive(sessions[index].client_pid) {
+                    debug!(
+                        "Session {} for profile {} orphaned (client pid {} dead), reaping",
+                        sessions[index].session_id, profile_id, sessions[index].client_pid
                     );
                     true
                 } else {
@@ -5189,7 +5209,7 @@ impl AdminHandler for AgentRuntime {
             AdminRequest::LaunchPrincipal {
                 profile_id,
                 command,
-            } => self.handle_launch_principal(profile_id, command, ctx),
+            } => self.handle_launch_principal(profile_id, command, cred, ctx),
             AdminRequest::TerminatePrincipal { profile_id } => {
                 self.handle_terminate_principal(profile_id)
             }

--- a/cmd/passless/src/commands/agent.rs
+++ b/cmd/passless/src/commands/agent.rs
@@ -979,7 +979,7 @@ fn dispatch_run(output: OutputFormat, profile: &str, command: &[PathBuf]) -> Res
                     Err(Error::Other(format!("child exited with code {}", code)))
                 }
             } else {
-                Ok(())
+                Err(Error::Other("terminated by signal".to_string()))
             }
         }
         _ => Err(Error::Other("unexpected response".to_string())),

--- a/cmd/passless/src/commands/agent.rs
+++ b/cmd/passless/src/commands/agent.rs
@@ -916,34 +916,30 @@ fn dispatch_run(output: OutputFormat, profile: &str, command: &[PathBuf]) -> Res
                 eprintln!("profile_id: {}", launched.profile_id);
             }
 
-            let ctrlc_session_id = session_id.clone();
-            let ctrlc_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-            let ctrlc_flag_clone = ctrlc_flag.clone();
+            let terminate_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let terminate_flag_clone = terminate_flag.clone();
 
-            ctrlc::set_handler(move || {
-                if ctrlc_flag_clone.load(std::sync::atomic::Ordering::SeqCst) {
-                    std::process::exit(130);
-                }
-                ctrlc_flag_clone.store(true, std::sync::atomic::Ordering::SeqCst);
-
-                match connect_admin() {
-                    Ok(mut terminate_client) => {
-                        let _ = terminate_client.request(AdminRequest::RevokeSession {
-                            session_id: ctrlc_session_id.clone(),
-                        });
-                    }
-                    Err(_) => {
-                        std::process::exit(130);
-                    }
+            ctrlc::set_handler({
+                let flag = terminate_flag_clone.clone();
+                move || {
+                    flag.store(true, std::sync::atomic::Ordering::SeqCst);
                 }
             })
             .map_err(|e| Error::Other(format!("failed to set Ctrl+C handler: {}", e)))?;
+
+            signal_hook::flag::register(libc::SIGTERM, terminate_flag_clone)
+                .map_err(|e| Error::Other(format!("failed to register SIGTERM handler: {}", e)))?;
 
             let mut exit_code: Option<i32> = None;
             let mut signal: Option<i32> = None;
 
             loop {
-                if ctrlc_flag.load(std::sync::atomic::Ordering::SeqCst) {
+                if terminate_flag.load(std::sync::atomic::Ordering::SeqCst) {
+                    if let Ok(mut client) = connect_admin() {
+                        let _ = client.request(AdminRequest::RevokeSession {
+                            session_id: session_id.clone(),
+                        });
+                    }
                     break;
                 }
 

--- a/cmd/passless/src/storage/pass_refresh.rs
+++ b/cmd/passless/src/storage/pass_refresh.rs
@@ -39,6 +39,7 @@ pub struct PassStorageAdapter {
 }
 
 impl PassStorageAdapter {
+    #[allow(dead_code)]
     pub fn new_with_options(
         store_path: PathBuf,
         path: PathBuf,


### PR DESCRIPTION
## Problem

When OpenCode restarts, the Playwright MCP server process (launched via `passless agent playwright-mcp`) becomes orphaned but keeps running. Passless tracks this as an active session and refuses to start a new one, returning "profile 'coding' already has an active session (pid XXXX)".

## Root Causes

1. **No SIGTERM handling in the client** - Only SIGINT was handled via `ctrlc::set_handler`. When OpenCode sends SIGTERM, the client died without calling `terminate_principal`.
2. **No client-liveness tracking** - The daemon had no concept of which admin client requested the session, so it couldn't detect when the client died.
3. **Hardcoded 1-hour session TTL** - Ignored the profile's `max_session_ttl` config.
4. **No `PR_SET_PDEATHSIG` on principal** - The principal wouldn't receive a signal if the daemon died.

## Changes

- Add SIGTERM signal handler in `dispatch_run` to properly revoke sessions when the client process receives SIGTERM
- Track requesting client PID in `ManagedPrincipalSession` and detect orphaned sessions in `reap_expired_sessions` by checking if client is alive via `/proc/{pid}/stat`
- Use profile's `max_session_ttl` instead of hardcoded 3600s for session deadline
- Add `PR_SET_PDEATHSIG` on principal process so it receives SIGTERM if daemon dies
- Add `signal-hook` dependency for portable signal handling

## Testing

- All 1465 existing tests pass
- Build succeeds with `--features agent`
- Manual testing confirms orphaned sessions are now cleaned up when client dies