### PR TITLE
fix(logging): preserve filters with journald

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ dirs = "6.0"
 prs-lib = "0.5"
 serde_json = "1.0"
 libc = "0.2"
-nix = { version = "0.31", features = ["resource", "fs", "signal", "process", "dir", "user"] }
+nix = { version = "0.31", features = ["resource", "fs", "signal", "process", "dir"] }
 notify-rust = "4.11"
 aes-gcm = "0.11"
 rand = "0.8"

--- a/cmd/passless/src/logging.rs
+++ b/cmd/passless/src/logging.rs
@@ -1,0 +1,107 @@
+use env_logger::Builder;
+use log::{LevelFilter, Log, Metadata, Record};
+use systemd_journal_logger::JournalLog;
+
+const LOG_LEVEL_ENV: &str = "PASSLESS_LOG_LEVEL";
+const LOG_STYLE_ENV: &str = "PASSLESS_LOG_STYLE";
+const SYSLOG_IDENTIFIER_ENV: &str = "PASSLESS_SYSLOG_IDENTIFIER";
+const DEFAULT_SYSLOG_IDENTIFIER: &str = "passless";
+
+struct FilteredJournalLog {
+    filter: env_logger::Logger,
+    journal: JournalLog,
+}
+
+impl Log for FilteredJournalLog {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        Log::enabled(&self.filter, metadata)
+    }
+
+    fn log(&self, record: &Record<'_>) {
+        if self.filter.matches(record) {
+            Log::log(&self.journal, record);
+        }
+    }
+
+    fn flush(&self) {
+        Log::flush(&self.journal);
+    }
+}
+
+fn configured_builder(filter: Option<&str>, style: Option<&str>) -> Builder {
+    let mut builder = Builder::new();
+    builder.filter_level(LevelFilter::Debug);
+
+    // Environment configuration overrides the default filter, matching the
+    // documented env_logger precedence.
+    if let Some(filter) = filter {
+        builder.parse_filters(filter);
+    }
+    if let Some(style) = style {
+        builder.parse_write_style(style);
+    }
+
+    builder
+}
+
+fn log_builder() -> Builder {
+    let filter = std::env::var(LOG_LEVEL_ENV).ok();
+    let style = std::env::var(LOG_STYLE_ENV).ok();
+    configured_builder(filter.as_deref(), style.as_deref())
+}
+
+pub fn init(max_level: LevelFilter) {
+    if systemd_journal_logger::connected_to_journal() {
+        match JournalLog::new() {
+            Ok(journal) => {
+                let identifier = std::env::var(SYSLOG_IDENTIFIER_ENV)
+                    .unwrap_or_else(|_| DEFAULT_SYSLOG_IDENTIFIER.to_string());
+                let filter = log_builder().build();
+                let journal = journal.with_syslog_identifier(identifier);
+
+                log::set_boxed_logger(Box::new(FilteredJournalLog { filter, journal }))
+                    .expect("Logger was already installed.");
+                log::set_max_level(max_level);
+                return;
+            }
+            Err(error) => {
+                eprintln!(
+                    "Failed to initialize native journald logging ({error}); falling back to stderr"
+                );
+            }
+        }
+    }
+
+    let mut builder = log_builder();
+    builder.format_timestamp_millis().init();
+    log::set_max_level(max_level);
+}
+
+#[cfg(test)]
+mod tests {
+    use log::{Level, LevelFilter, Log, Metadata};
+
+    use super::configured_builder;
+
+    #[test]
+    fn default_filter_is_debug() {
+        let logger = configured_builder(None, None).build();
+        assert_eq!(logger.filter(), LevelFilter::Debug);
+    }
+
+    #[test]
+    fn global_filter_overrides_default() {
+        let logger = configured_builder(Some("warn"), None).build();
+        assert_eq!(logger.filter(), LevelFilter::Warn);
+    }
+
+    #[test]
+    fn module_filter_is_preserved() {
+        let logger = configured_builder(Some("soft_fido2=warn"), None).build();
+        let metadata = Metadata::builder()
+            .level(Level::Debug)
+            .target("soft_fido2::ctap")
+            .build();
+        assert!(!Log::enabled(&logger, &metadata));
+    }
+}

--- a/cmd/passless/src/main.rs
+++ b/cmd/passless/src/main.rs
@@ -4,6 +4,7 @@ mod authenticator;
 mod commands;
 mod credential_backup;
 mod instance_lock;
+mod logging;
 mod notification;
 mod pin_storage;
 mod storage;
@@ -26,7 +27,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use authenticator::AuthenticatorService;
 use clap::Parser;
 use commands::custom::register_yubikey_credential_mgmt;
-use env_logger::{Builder, Env};
 use log::{debug, error, info, warn};
 #[cfg(feature = "tpm")]
 use pin_storage::TpmPinStorage;
@@ -431,31 +431,7 @@ fn run() -> Result<()> {
     } else {
         log::LevelFilter::Info
     };
-
-    // Use syslog when running as systemd service
-    if systemd_journal_logger::connected_to_journal()
-        && let Ok(journal) = systemd_journal_logger::JournalLog::new()
-    {
-        // Assume only the agent is run as root
-        let syslog_identifier = if nix::unistd::Uid::effective().is_root() {
-            "passless-agent"
-        } else {
-            "passless"
-        };
-        journal
-            .with_syslog_identifier(syslog_identifier.to_string())
-            .install()
-            .expect("Logger was already installed.");
-    } else {
-        let env = Env::default()
-            .filter("PASSLESS_LOG_LEVEL")
-            .write_style("PASSLESS_LOG_STYLE");
-        Builder::from_env(env)
-            .filter_level(log::LevelFilter::Debug)
-            .format_timestamp_millis()
-            .init();
-    }
-    log::set_max_level(log_level);
+    logging::init(log_level);
 
     // Load config: CLI args + config file + defaults (CLI takes precedence)
     let config = AppConfig::load(&mut args).inspect_err(|e| {

--- a/contrib/systemd/passless-agent.service
+++ b/contrib/systemd/passless-agent.service
@@ -46,6 +46,7 @@ PrivateDevices=false
 # node. Never grant /dev/uhid to principals or browser users.
 
 # Logging
+Environment=PASSLESS_SYSLOG_IDENTIFIER=passless-agent
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=passless-agent


### PR DESCRIPTION
Follow-up to #437.

This keeps native journald logging while preserving Passless logging semantics:

- apply `PASSLESS_LOG_LEVEL` filtering before forwarding records to journald
- make environment filters override the default `debug` filter as intended
- use `PASSLESS_SYSLOG_IDENTIFIER` instead of inferring agent mode from UID
- set `PASSLESS_SYSLOG_IDENTIFIER=passless-agent` in the agent systemd unit
- fall back to stderr with a diagnostic if the native journal socket cannot be initialized
- drop the now-unused `nix/user` feature

Includes focused tests for default, global, and module-specific filtering.