### PR TITLE
fix(agent): prevent PR_SET_PDEATHSIG from killing principals on thread exit

### DIFF
--- a/cmd/passless/src/agent/ipc.rs
+++ b/cmd/passless/src/agent/ipc.rs
@@ -700,7 +700,7 @@ impl IpcServer {
         &self,
         client_fd: OwnedFd,
         handler: &A,
-    ) -> Result<(), IpcError> {
+    ) -> Result<Option<libc::pid_t>, IpcError> {
         self.handle_one_admin_inner(client_fd, handler)
     }
 
@@ -708,7 +708,7 @@ impl IpcServer {
         &self,
         client_fd: OwnedFd,
         handler: &A,
-    ) -> Result<(), IpcError> {
+    ) -> Result<Option<libc::pid_t>, IpcError> {
         let _guard = self
             .conn_counter
             .try_acquire()
@@ -838,16 +838,23 @@ impl IpcServer {
 
         match handler.handle_admin(&admin_frame.action, &_cred, &ctx) {
             Ok(response_action) => {
+                let child_pid =
+                    if let AdminResponse::PrincipalLaunched(ref launched) = response_action {
+                        Some(launched.pid as libc::pid_t)
+                    } else {
+                        None
+                    };
                 let response =
                     ResponseFrame::Admin(AdminResponseFrame::ok(admin_frame.seq, response_action));
                 send_response(raw_fd, &response)?;
+                return Ok(child_pid);
             }
             Err(pe) => {
                 let _ = send_error_responses(raw_fd, Role::Admin, admin_frame.seq, pe);
             }
         }
 
-        Ok(())
+        Ok(None)
     }
 
     pub fn handle_one_principal<P: PrincipalHandler>(

--- a/cmd/passless/src/agent/runtime.rs
+++ b/cmd/passless/src/agent/runtime.rs
@@ -1939,7 +1939,11 @@ impl AgentRuntime {
                         loop {
                             let ret = unsafe { libc::kill(child_pid, 0) };
                             if ret != 0 {
-                                break;
+                                let errno = std::io::Error::last_os_error();
+                                if errno.raw_os_error() == Some(libc::ESRCH) {
+                                    break;
+                                }
+                                debug!("kill({}, 0) failed: {}", child_pid, errno);
                             }
                             std::thread::sleep(std::time::Duration::from_millis(100));
                         }

--- a/cmd/passless/src/agent/runtime.rs
+++ b/cmd/passless/src/agent/runtime.rs
@@ -1928,8 +1928,26 @@ impl AgentRuntime {
                     }
                 }
                 let _guard = WorkerExitGuard(runtime.clone());
-                if let Err(e) = ipc.handle_one_admin(client_fd, &*runtime) {
-                    debug!("Admin handler error: {}", e);
+                match ipc.handle_one_admin(client_fd, &*runtime) {
+                    Ok(Some(child_pid)) => {
+                        // Keep this thread alive until the child exits.
+                        // PR_SET_PDEATHSIG tracks the parent thread, so if this thread exits
+                        // the kernel delivers SIGTERM to the child.  By waiting here we ensure
+                        // the signal is only delivered when the daemon process itself dies.
+                        // We use kill(pid, 0) to poll without reaping the child, so that
+                        // handle_wait_principal can still reap it.
+                        loop {
+                            let ret = unsafe { libc::kill(child_pid, 0) };
+                            if ret != 0 {
+                                break;
+                            }
+                            std::thread::sleep(std::time::Duration::from_millis(100));
+                        }
+                    }
+                    Ok(None) => {}
+                    Err(e) => {
+                        debug!("Admin handler error: {}", e);
+                    }
                 }
             })
             .map_err(|e| {

--- a/cmd/passless/src/commands/agent.rs
+++ b/cmd/passless/src/commands/agent.rs
@@ -879,6 +879,14 @@ fn read_cdp_request_file(path: &Path) -> Result<String> {
 }
 
 fn dispatch_run(output: OutputFormat, profile: &str, command: &[PathBuf]) -> Result<()> {
+    let control_fd = crate::agent::launcher::CONTROL_FD;
+    let mut stat: libc::stat = unsafe { std::mem::zeroed() };
+    if unsafe { libc::fstat(control_fd, &mut stat) } == 0
+        && (stat.st_mode & libc::S_IFMT) == libc::S_IFSOCK
+    {
+        return exec_command_directly(command);
+    }
+
     let mut client = connect_admin()?;
     let argv: Vec<String> = command
         .iter()
@@ -984,6 +992,20 @@ fn dispatch_run(output: OutputFormat, profile: &str, command: &[PathBuf]) -> Res
         }
         _ => Err(Error::Other("unexpected response".to_string())),
     }
+}
+
+fn exec_command_directly(command: &[PathBuf]) -> Result<()> {
+    use std::os::unix::process::CommandExt;
+
+    if command.is_empty() {
+        return Err(Error::Other("no command to execute".to_string()));
+    }
+
+    let err = std::process::Command::new(&command[0])
+        .args(&command[1..])
+        .exec();
+
+    Err(Error::Other(format!("failed to exec command: {err}")))
 }
 
 #[cfg(test)]

--- a/cmd/passless/src/commands/agent.rs
+++ b/cmd/passless/src/commands/agent.rs
@@ -1191,4 +1191,53 @@ mod tests {
     fn pending_request_id_parse_rejects_non_hex() {
         assert!(parse_pending_request_id("not-hex").is_err());
     }
+
+    #[test]
+    fn exec_command_directly_rejects_empty_command() {
+        let result = exec_command_directly(&[]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("no command"));
+    }
+
+    #[test]
+    fn exec_command_directly_rejects_nonexistent_binary() {
+        let result = exec_command_directly(&[PathBuf::from("/nonexistent/binary")]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("failed to exec"));
+    }
+
+    #[test]
+    fn control_fd_socket_detection() {
+        let control_fd = crate::agent::launcher::CONTROL_FD;
+        let mut fds = [0i32; 2];
+        let ret = unsafe {
+            libc::socketpair(
+                libc::AF_UNIX,
+                libc::SOCK_SEQPACKET | libc::SOCK_CLOEXEC,
+                0,
+                fds.as_mut_ptr(),
+            )
+        };
+        assert_eq!(ret, 0, "socketpair failed");
+
+        let mut stat: libc::stat = unsafe { std::mem::zeroed() };
+        let stat_ret = unsafe { libc::fstat(fds[0], &mut stat) };
+        assert_eq!(stat_ret, 0);
+        assert_eq!(
+            (stat.st_mode & libc::S_IFMT),
+            libc::S_IFSOCK,
+            "socketpair fd should be detected as socket"
+        );
+
+        unsafe {
+            libc::close(fds[0]);
+            libc::close(fds[1]);
+        }
+
+        let invalid_fd = 9999;
+        let stat_ret = unsafe { libc::fstat(invalid_fd, &mut stat) };
+        assert_ne!(stat_ret, 0, "fstat on invalid fd should fail");
+
+        let _ = control_fd;
+    }
 }


### PR DESCRIPTION
## Problem

The Playwright MCP server (and all `agent run` principals) failed immediately with `child killed by signal 15`. The daemon logs showed the session was launched and then immediately reaped.

## Root Cause

`PR_SET_PDEATHSIG` in Linux tracks the parent **thread**, not just the parent process. The daemon spawns a short-lived admin worker thread for each request via `accept_and_dispatch_admin()`. When that thread exits after handling `LaunchPrincipal`, the kernel delivers SIGTERM to the child process.

The chain:
1. Daemon spawns admin worker thread → thread calls `fork()` to create child
2. Child has `PR_SET_PDEATHSIG = SIGTERM` set in `pre_exec`
3. Admin worker thread sends response and **exits**
4. Kernel delivers SIGTERM to child (because parent thread died)
5. Child dies before it can exec or do any work

A secondary bug: `dispatch_run()` didn't check for fd 3 (CONTROL_FD), causing the child to recursively re-launch through the admin socket instead of executing the command directly.

## Fix

1. **`runtime.rs`**: Admin worker thread now stays alive (polling `kill(child_pid, 0)`) until the child exits, preventing premature `PR_SET_PDEATHSIG` delivery
2. **`ipc.rs`**: `handle_one_admin()` returns the child PID for `LaunchPrincipal` responses so the worker thread knows which PID to monitor
3. **`agent.rs`**: `dispatch_run()` checks for fd 3 and execs directly if already inside a principal context, preventing infinite recursion

## Testing

- Verified `passless agent run --profile coding -- /usr/bin/sleep 3` completes successfully
- Verified `passless agent playwright-mcp --profile coding -- /usr/bin/npx -y @playwright/mcp@latest` starts and stays alive
- All existing tests pass
- Clippy and fmt checks pass