### PR TITLE
fix: avoid repeated pass sync for PIN state

### DIFF
--- a/cmd/passless/src/authenticator.rs
+++ b/cmd/passless/src/authenticator.rs
@@ -1248,8 +1248,7 @@ impl<
             .pin_storage
             .as_ref()
             .and_then(|ps| ps.lock().ok())
-            .and_then(|ps| ps.load_pin_state().ok())
-            .map(|state| state.pin_hash.is_some())
+            .and_then(|ps| ps.is_pin_configured().ok())
             .unwrap_or(false);
 
         let state = if pin_configured {

--- a/cmd/passless/src/pin_storage/mod.rs
+++ b/cmd/passless/src/pin_storage/mod.rs
@@ -272,6 +272,10 @@ pub trait PinStorage: Send + Sync {
 
     /// Save PIN state to storage
     fn save_pin_state(&self, state: &PinState) -> Result<(), StatusCode>;
+
+    fn is_pin_configured(&self) -> Result<bool, StatusCode> {
+        Ok(self.load_pin_state()?.pin_hash.is_some())
+    }
 }
 
 /// No-op PIN storage implementation
@@ -292,5 +296,9 @@ impl PinStorage for Box<dyn PinStorage> {
 
     fn save_pin_state(&self, state: &PinState) -> Result<(), StatusCode> {
         (**self).save_pin_state(state)
+    }
+
+    fn is_pin_configured(&self) -> Result<bool, StatusCode> {
+        (**self).is_pin_configured()
     }
 }

--- a/cmd/passless/src/pin_storage/pass.rs
+++ b/cmd/passless/src/pin_storage/pass.rs
@@ -362,6 +362,20 @@ impl PassPinStorage {
 }
 
 impl PinStorage for PassPinStorage {
+    fn is_pin_configured(&self) -> std::result::Result<bool, soft_fido2::StatusCode> {
+        let cached = self.last_config.read().map_err(|e| {
+            warn!("Failed to acquire config lock: {:?}", e);
+            soft_fido2::StatusCode::Other
+        })?;
+
+        if let Some(config) = cached.as_ref() {
+            return Ok(config.is_pin_set());
+        }
+        drop(cached);
+
+        Ok(self.load_pin_state()?.pin_hash.is_some())
+    }
+
     fn load_pin_state(&self) -> std::result::Result<soft_fido2::PinState, soft_fido2::StatusCode> {
         self.sync.prepare_if_needed();
 
@@ -476,6 +490,32 @@ mod tests {
             credential_wrapping_generation: 0,
             modified_at: Some(1),
         }
+    }
+
+    #[test]
+    fn cached_pin_configuration_avoids_storage_load() {
+        let temp = tempfile::tempdir().unwrap();
+        let sync = PassGitSync::new(temp.path().to_path_buf(), false);
+        let storage = PassPinStorage::new_with_sync(
+            temp.path().to_path_buf(),
+            PathBuf::from("fido2"),
+            GpgBackend::GnupgBin,
+            sync,
+        );
+
+        *storage.last_config.write().unwrap() = Some(config());
+
+        assert!(storage.is_pin_configured().unwrap());
+
+        storage
+            .last_config
+            .write()
+            .unwrap()
+            .as_mut()
+            .unwrap()
+            .pin_hash = None;
+
+        assert!(!storage.is_pin_configured().unwrap());
     }
 
     #[test]


### PR DESCRIPTION
Fixes #446.

## Summary
- add a lightweight PIN-configuration query to the PIN storage abstraction
- use the pass backend's existing in-memory config state for repeated UV capability checks
- retain full storage loading on a cold cache and for backends without a specialized implementation

## Root cause
Every CTAP request refreshed the built-in UV state by loading the full PIN state. For the pass backend, that load performs Git synchronization and GPG decryption. Credential listing issues many CTAP commands, so it repeated a network-backed `git pull` for every command and could exceed the pinUvAuth token usage window.

## Validation
- `make lint`
- focused pass PIN storage unit tests
- workspace tests: 1510 unit tests passed; known `cli_agent_admin` integration tests fail because they invoke the installed `passless` binary, which does not expose the branch-only `agent-admin` command
- live pass backend: 21 RPs / 31 credentials, no errors, 1 Git pull, 9.95s (baseline: 21 RPs / 0 credentials, CtapError(51), 50 pulls, 57-68s)