### PR TITLE
fix: WebAuthn sign hardening — TOCTOU, Unix socket server, replay dedup, same-user batch

### DIFF
--- a/.ci/PKGBUILD-bin.j2
+++ b/.ci/PKGBUILD-bin.j2
@@ -23,6 +23,8 @@ sha256sums=('{{ checksum }}'
 
 package() {
 	install -Dm755 passless "${pkgdir}/usr/bin/passless"
+	install -Dm755 sign-proxy "${pkgdir}/usr/bin/sign-proxy"
+	install -Dm755 agent-prompt-probe "${pkgdir}/usr/bin/agent-prompt-probe"
 
 	# Install shell completions
 	if [ -f "passless.bash" ]; then

--- a/.ci/PKGBUILD.j2
+++ b/.ci/PKGBUILD.j2
@@ -53,6 +53,8 @@ check() {
 package() {
     cd "$srcdir/passless"
     install -Dm0755 -t "$pkgdir/usr/bin/" "target/release/passless"
+    install -Dm0755 -t "$pkgdir/usr/bin/" "target/release/sign-proxy"
+    install -Dm0755 -t "$pkgdir/usr/bin/" "target/release/agent-prompt-probe"
 
     # Install shell completions
     local _completion_dir="$(find target/release/build/passless-rs-*/out/completions -type d 2>/dev/null | head -1)"

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ tools/agent-uhid-feasibility/controlled-rp/node_modules/
 # Phase 0 evidence JSON (host-specific, machine-readable)
 tools/agent-uhid-feasibility/evidence/*.json
 .playwright-mcp
+.debug/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.2.2",
  "inout",
 ]
 
@@ -462,7 +462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
  "block-buffer",
- "crypto-common",
+ "crypto-common 0.2.2",
  "inout",
 ]
 
@@ -560,6 +560,12 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -629,6 +635,16 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
@@ -677,7 +693,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.11.2",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -731,12 +747,23 @@ dependencies = [
 
 [[package]]
 name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
- "const-oid",
- "pem-rfc7468",
+ "const-oid 0.10.2",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -751,13 +778,23 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer",
- "const-oid",
- "crypto-common",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -811,12 +848,12 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
 dependencies = [
- "der",
- "digest",
+ "der 0.8.0",
+ "digest 0.11.2",
  "elliptic-curve",
  "rfc6979",
- "signature",
- "spki",
+ "signature 3.0.0",
+ "spki 0.8.0",
  "zeroize",
 ]
 
@@ -826,7 +863,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
- "signature",
+ "signature 3.0.0",
 ]
 
 [[package]]
@@ -850,14 +887,14 @@ checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "crypto-common",
- "digest",
+ "crypto-common 0.2.2",
+ "digest 0.11.2",
  "ff",
  "group",
  "hkdf",
  "hybrid-array",
- "pem-rfc7468",
- "pkcs8",
+ "pem-rfc7468 1.0.0",
+ "pkcs8 0.11.0",
  "rand_core 0.10.1",
  "sec1",
  "subtle",
@@ -1017,6 +1054,16 @@ dependencies = [
  "futures-io",
  "parking",
  "pin-project-lite",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1194,7 +1241,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1434,6 +1481,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin 0.9.9",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -1458,6 +1508,12 @@ dependencies = [
  "libz-sys",
  "pkg-config",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -1596,6 +1652,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1613,12 +1685,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1780,6 +1872,7 @@ dependencies = [
  "prs-lib",
  "rand 0.8.5",
  "rpassword",
+ "rsa",
  "serde",
  "serde_bytes",
  "serde_cbor",
@@ -1805,6 +1898,15 @@ version = "0.18.1"
 dependencies = [
  "libc",
  "thiserror",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -1875,13 +1977,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
- "der",
- "spki",
+ "der 0.8.0",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -1971,7 +2094,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
 dependencies = [
  "crypto-bigint",
- "crypto-common",
+ "crypto-common 0.2.2",
  "ff",
  "rand_core 0.10.1",
  "subtle",
@@ -2206,6 +2329,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "signature 2.2.0",
+ "spki 0.7.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rtoolbox"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2266,7 +2409,7 @@ checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
  "base16ct",
  "ctutils",
- "der",
+ "der 0.8.0",
  "hybrid-array",
  "subtle",
  "zeroize",
@@ -2388,7 +2531,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2440,11 +2583,21 @@ dependencies = [
 
 [[package]]
 name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 dependencies = [
- "digest",
+ "digest 0.11.2",
  "rand_core 0.10.1",
 ]
 
@@ -2495,7 +2648,7 @@ dependencies = [
  "soft-fido2-crypto",
  "soft-fido2-ctap",
  "soft-fido2-transport",
- "spin",
+ "spin 0.12.1",
  "zeroize",
 ]
 
@@ -2552,6 +2705,12 @@ dependencies = [
 
 [[package]]
 name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+
+[[package]]
+name = "spin"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd5231412d905519dca6a5deb0327d407be68d6c941feec004533401d3a0a715"
@@ -2561,12 +2720,22 @@ dependencies = [
 
 [[package]]
 name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.8.0",
 ]
 
 [[package]]
@@ -2899,7 +3068,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -2950,6 +3119,12 @@ name = "version-compare"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ release:	## generate vendor.tar.gz, $(PKG_BASE_NAME).tar.gz, and completions
 	cargo vendor
 	tar -czf vendor.tar.gz vendor
 	cargo build --frozen --release --all-features --target ${CARGO_TARGET}
-	tar -czf $(PKG_BASE_NAME).tar.gz -C $(CARGO_TARGET_DIR)/$(CARGO_TARGET)/release passless
+	tar -czf $(PKG_BASE_NAME).tar.gz -C $(CARGO_TARGET_DIR)/$(CARGO_TARGET)/release passless sign-proxy agent-prompt-probe
 	@# Create completions tarball
 	@COMPLETION_DIR=$$(find $(CARGO_TARGET_DIR)/$(CARGO_TARGET)/release/build/passless-*/out/completions -type d 2>/dev/null | head -1); \
 	if [ -n "$$COMPLETION_DIR" ]; then \
@@ -94,7 +94,7 @@ release:	## generate vendor.tar.gz, $(PKG_BASE_NAME).tar.gz, and completions
 	else \
 		echo "Warning: Completions directory not found"; \
 	fi
-	@echo Released in $(CARGO_TARGET_DIR)/$(CARGO_TARGET)/release/passless
+	@echo Released binaries in $(CARGO_TARGET_DIR)/$(CARGO_TARGET)/release/: passless, sign-proxy, agent-prompt-probe
 
 .PHONY: update-version
 update-version: ## update version from VERSION file in all Cargo.toml manifests
@@ -111,7 +111,7 @@ publish:	## publish crate
 # Installation targets
 .PHONY: install-binary
 install-binary:	## install passless binary to ~/.cargo/bin
-	cargo install --path cmd/passless
+	cargo install --path cmd/passless --features agent
 
 .PHONY: install
 install: install-binary install-sysusers install-udev install-systemd install-modules	## install everything (binary, sysusers, udev, systemd)

--- a/cmd/passless/Cargo.toml
+++ b/cmd/passless/Cargo.toml
@@ -48,6 +48,7 @@ serde_json.workspace = true
 libc.workspace = true
 nix.workspace = true
 notify-rust.workspace = true
+zbus.workspace = true
 aes-gcm.workspace = true
 rand.workspace = true
 ctrlc.workspace = true

--- a/cmd/passless/Cargo.toml
+++ b/cmd/passless/Cargo.toml
@@ -63,11 +63,13 @@ hmac = "0.13"
 rpassword = "7.3"
 atty = "0.2"
 serde_bytes = "0.11.19"
+base64 = "0.23"
 tss-esapi = { version = "7.6.0", optional = true }
 p256 = { version = "0.14", features = ["ecdh", "arithmetic"], optional = true }
 hkdf = { version = "0.13", optional = true }
 aes = { version = "0.9", optional = true }
 cipher = { version = "0.5", optional = true }
+rsa = { version = "0.9", default-features = false, features = ["std", "pem"] }
 
 [dev-dependencies]
 base64 = "0.23"

--- a/cmd/passless/Cargo.toml
+++ b/cmd/passless/Cargo.toml
@@ -20,6 +20,11 @@ name = "agent-prompt-probe"
 path = "src/bin/agent-prompt-probe.rs"
 required-features = ["agent-validation"]
 
+[[bin]]
+name = "sign-proxy"
+path = "src/bin/sign-proxy.rs"
+required-features = ["agent"]
+
 [features]
 default = []
 tpm = ["passless-core/tpm", "tss-esapi", "p256", "hkdf", "aes", "cipher"]

--- a/cmd/passless/assets/agent-extension/broker.js
+++ b/cmd/passless/assets/agent-extension/broker.js
@@ -11,6 +11,16 @@
   var MAX_USER_NAME_LEN = 256;
   var MAX_USER_ID_B64U_LEN = 128;
   var MAX_ALGORITHMS = 16;
+  var marker = document.documentElement;
+  if (marker && marker.hasAttribute("data-passless-agent-broker")) return;
+  if (marker) marker.setAttribute("data-passless-agent-broker", "");
+  var initialized = window.__passlessAgentBrokerChannels;
+  if (!(initialized instanceof Set)) {
+    initialized = new Set();
+    window.__passlessAgentBrokerChannels = initialized;
+  }
+  if (initialized.has(channel)) return;
+  initialized.add(channel);
 
   function isValidGetRequest(req) {
     if (!req || typeof req !== "object") return false;
@@ -74,6 +84,7 @@
 
     chrome.runtime.sendMessage({
       source: "passless-agent-broker",
+      request_id: message.id,
       type: messageType,
       request: message.request
     }, function(response) {

--- a/cmd/passless/assets/agent-extension/manifest.json
+++ b/cmd/passless/assets/agent-extension/manifest.json
@@ -2,7 +2,6 @@
   "manifest_version": 3,
   "name": "passless-agent",
   "version": "1.0.0",
-  "host_permissions": ["http://127.0.0.1/*"],
   "background": {
     "service_worker": "worker.js"
   },

--- a/cmd/passless/assets/agent-extension/manifest.json
+++ b/cmd/passless/assets/agent-extension/manifest.json
@@ -2,6 +2,9 @@
   "manifest_version": 3,
   "name": "passless-agent",
   "version": "1.0.0",
+  "permissions": [
+    "nativeMessaging"
+  ],
   "background": {
     "service_worker": "worker.js"
   },

--- a/cmd/passless/assets/agent-extension/manifest.json
+++ b/cmd/passless/assets/agent-extension/manifest.json
@@ -5,6 +5,9 @@
   "permissions": [
     "nativeMessaging"
   ],
+  "host_permissions": [
+    "https://*/*"
+  ],
   "background": {
     "service_worker": "worker.js"
   },

--- a/cmd/passless/assets/agent-extension/worker.js
+++ b/cmd/passless/assets/agent-extension/worker.js
@@ -13,6 +13,12 @@
   var MAX_ALGORITHMS = 16;
 
   var NATIVE_HOST = "rs.passless.sign_proxy";
+  var MAX_COMPLETED_REQUESTS = 128;
+  var scope = typeof globalThis !== "undefined" ? globalThis : (typeof self !== "undefined" ? self : this);
+  if (!scope.__passlessPendingRequests) scope.__passlessPendingRequests = new Map();
+  if (!scope.__passlessCompletedRequests) scope.__passlessCompletedRequests = new Map();
+  var pendingRequests = scope.__passlessPendingRequests;
+  var completedRequests = scope.__passlessCompletedRequests;
 
   function parseHttpsOrigin(url) {
     if (typeof url !== "string") return null;
@@ -73,7 +79,21 @@
     return typeof req.user_verification === "boolean";
   }
 
-  function daemonRequest(path, request, sendResponse, responseField, type) {
+  function rememberCompletedRequest(requestId, response) {
+    completedRequests.set(requestId, response);
+    if (completedRequests.size > MAX_COMPLETED_REQUESTS) {
+      completedRequests.delete(completedRequests.keys().next().value);
+    }
+  }
+
+  function completeRequest(requestId, response) {
+    var callbacks = pendingRequests.get(requestId) || [];
+    pendingRequests.delete(requestId);
+    rememberCompletedRequest(requestId, response);
+    for (var i = 0; i < callbacks.length; i++) callbacks[i](response);
+  }
+
+  function daemonRequest(requestId, path, request, sendResponse, responseField, type) {
     var body;
     try {
       body = JSON.stringify(request);
@@ -86,6 +106,16 @@
       return false;
     }
 
+    if (completedRequests.has(requestId)) {
+      sendResponse(completedRequests.get(requestId));
+      return false;
+    }
+    if (pendingRequests.has(requestId)) {
+      pendingRequests.get(requestId).push(sendResponse);
+      return true;
+    }
+    pendingRequests.set(requestId, [sendResponse]);
+
     var message = {
       path: path,
       bearer: bearer,
@@ -95,15 +125,15 @@
 
     chrome.runtime.sendNativeMessage(NATIVE_HOST, message, function(response) {
       if (chrome.runtime.lastError) {
-        sendResponse({ ok: false, type: type, error: "transport_error" });
+        completeRequest(requestId, { ok: false, type: type, error: "transport_error" });
         return;
       }
       if (!response || typeof response !== "object") {
-        sendResponse({ ok: false, type: type, error: "invalid_daemon_response" });
+        completeRequest(requestId, { ok: false, type: type, error: "invalid_daemon_response" });
         return;
       }
       if (response.error) {
-        sendResponse({
+        completeRequest(requestId, {
           ok: false,
           type: type,
           error: response.error,
@@ -115,20 +145,20 @@
       try {
         payload = typeof response.body === "string" ? JSON.parse(response.body) : response.body;
       } catch (error) {
-        sendResponse({ ok: false, type: type, error: "invalid_daemon_response" });
+        completeRequest(requestId, { ok: false, type: type, error: "invalid_daemon_response" });
         return;
       }
       if (!payload || typeof payload !== "object" || !payload[responseField]) {
-        sendResponse({ ok: false, type: type, error: "invalid_daemon_response" });
+        completeRequest(requestId, { ok: false, type: type, error: "invalid_daemon_response" });
         return;
       }
-      sendResponse({ ok: true, response: payload[responseField], type: type });
+      completeRequest(requestId, { ok: true, response: payload[responseField], type: type });
     });
     return true;
   }
 
-  function handleGetRequest(req, origins, sendResponse) {
-    return daemonRequest("/sign", {
+  function handleGetRequest(requestId, req, origins, sendResponse) {
+    return daemonRequest(requestId, "/sign", {
       origin: origins.origin,
       top_origin: origins.top_origin,
       rp_id: req.rp_id,
@@ -139,8 +169,8 @@
     }, sendResponse, "sign_assertion_result", "get");
   }
 
-  function handleCreateRequest(req, origins, sendResponse) {
-    return daemonRequest("/register", {
+  function handleCreateRequest(requestId, req, origins, sendResponse) {
+    return daemonRequest(requestId, "/register", {
       origin: origins.origin,
       top_origin: origins.top_origin,
       rp_id: req.rp_id,
@@ -170,6 +200,11 @@
       return false;
     }
 
+    if (typeof message.request_id !== "string" || message.request_id.length === 0 || message.request_id.length > 128) {
+      sendResponse({ ok: false, error: "invalid_request" });
+      return false;
+    }
+
     var req = message.request;
     var messageType = message.type === "create" ? "create" : "get";
     if (messageType === "create") {
@@ -177,13 +212,13 @@
         sendResponse({ ok: false, type: "create", error: "invalid_request" });
         return false;
       }
-      return handleCreateRequest(req, origins, sendResponse);
+      return handleCreateRequest(message.request_id, req, origins, sendResponse);
     }
 
     if (!validateGetRequest(req)) {
       sendResponse({ ok: false, type: "get", error: "invalid_request" });
       return false;
     }
-    return handleGetRequest(req, origins, sendResponse);
+    return handleGetRequest(message.request_id, req, origins, sendResponse);
   });
 })(__PASSLESS_SOCKET_PATH__, __PASSLESS_BEARER__);

--- a/cmd/passless/assets/agent-extension/worker.js
+++ b/cmd/passless/assets/agent-extension/worker.js
@@ -1,4 +1,4 @@
-(function(port, bearer) {
+(function(socketPath, bearer) {
   "use strict";
 
   var MAX_REQUEST_BYTES = 16384;
@@ -11,6 +11,8 @@
   var MAX_USER_NAME_LEN = 256;
   var MAX_USER_ID_B64U_LEN = 128;
   var MAX_ALGORITHMS = 16;
+
+  var NATIVE_HOST = "rs.passless.sign_proxy";
 
   function parseHttpsOrigin(url) {
     if (typeof url !== "string") return null;
@@ -84,38 +86,43 @@
       return false;
     }
 
-    fetch("http://127.0.0.1:" + port + path, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": "Bearer " + bearer
-      },
+    var message = {
+      path: path,
+      bearer: bearer,
+      socket_path: socketPath,
       body: body
-    }).then(function(response) {
-      return response.json().catch(function() {
-        return { error: "invalid_daemon_response" };
-      }).then(function(payload) {
-        return { ok: response.ok, payload: payload };
-      });
-    }).then(function(result) {
-      if (!result.ok) {
-        var code = result.payload && typeof result.payload.error === "string"
-          ? result.payload.error
-          : "request_denied";
+    };
+
+    chrome.runtime.sendNativeMessage(NATIVE_HOST, message, function(response) {
+      if (chrome.runtime.lastError) {
+        sendResponse({ ok: false, type: type, error: "transport_error" });
+        return;
+      }
+      if (!response || typeof response !== "object") {
+        sendResponse({ ok: false, type: type, error: "invalid_daemon_response" });
+        return;
+      }
+      if (response.error) {
         sendResponse({
           ok: false,
           type: type,
-          error: code,
-          fallback: code === "human_interaction_required"
+          error: response.error,
+          fallback: response.error === "human_interaction_required"
         });
         return;
       }
-      if (!result.payload || typeof result.payload !== "object" || !result.payload[responseField]) {
-        throw new Error("malformed daemon response");
+      var payload;
+      try {
+        payload = typeof response.body === "string" ? JSON.parse(response.body) : response.body;
+      } catch (error) {
+        sendResponse({ ok: false, type: type, error: "invalid_daemon_response" });
+        return;
       }
-      sendResponse({ ok: true, response: result.payload[responseField], type: type });
-    }).catch(function() {
-      sendResponse({ ok: false, type: type, error: "transport_error" });
+      if (!payload || typeof payload !== "object" || !payload[responseField]) {
+        sendResponse({ ok: false, type: type, error: "invalid_daemon_response" });
+        return;
+      }
+      sendResponse({ ok: true, response: payload[responseField], type: type });
     });
     return true;
   }
@@ -179,4 +186,4 @@
     }
     return handleGetRequest(req, origins, sendResponse);
   });
-})(__PASSLESS_PORT__, __PASSLESS_BEARER__);
+})(__PASSLESS_SOCKET_PATH__, __PASSLESS_BEARER__);

--- a/cmd/passless/src/agent/audit.rs
+++ b/cmd/passless/src/agent/audit.rs
@@ -2332,7 +2332,7 @@ mod tests {
             DaemonStartBuilder::new(1234, BackendKind::Local).build(),
             ProfileCreateBuilder::new(test_profile_id()).build(),
             CredentialCreateBuilder::new(test_cred(), "example.com").build(),
-            GrantApproveBuilder::new(test_grant_id(), test_profile_id()).build(),
+            GrantApproveBuilder::new(test_grant_id(), test_profile_id(), 300).build(),
         ];
         for event in events {
             let receipt = gate.record(event).unwrap();

--- a/cmd/passless/src/agent/audit_events.rs
+++ b/cmd/passless/src/agent/audit_events.rs
@@ -623,12 +623,14 @@ pub struct IntentExpireMeta {
 pub struct GrantRequestMeta {
     request_id: String,
     profile_id: ProfileId,
+    rp_ids: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GrantApproveMeta {
     grant_id: GrantId,
     profile_id: ProfileId,
+    ttl_secs: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1445,13 +1447,15 @@ impl IntentExpireBuilder {
 pub struct GrantRequestBuilder {
     request_id: String,
     profile_id: ProfileId,
+    rp_ids: Vec<String>,
 }
 
 impl GrantRequestBuilder {
-    pub fn new(request_id: &GrantRequestId, profile_id: ProfileId) -> Self {
+    pub fn new(request_id: &GrantRequestId, profile_id: ProfileId, rp_ids: Vec<String>) -> Self {
         Self {
             request_id: request_id.as_str().to_string(),
             profile_id,
+            rp_ids,
         }
     }
 
@@ -1459,6 +1463,7 @@ impl GrantRequestBuilder {
         AuditEvent::new(AuditPayload::GrantRequest(GrantRequestMeta {
             request_id: self.request_id,
             profile_id: self.profile_id,
+            rp_ids: self.rp_ids,
         }))
     }
 }
@@ -1466,13 +1471,15 @@ impl GrantRequestBuilder {
 pub struct GrantApproveBuilder {
     grant_id: GrantId,
     profile_id: ProfileId,
+    ttl_secs: u64,
 }
 
 impl GrantApproveBuilder {
-    pub fn new(grant_id: GrantId, profile_id: ProfileId) -> Self {
+    pub fn new(grant_id: GrantId, profile_id: ProfileId, ttl_secs: u64) -> Self {
         Self {
             grant_id,
             profile_id,
+            ttl_secs,
         }
     }
 
@@ -1480,6 +1487,7 @@ impl GrantApproveBuilder {
         AuditEvent::new(AuditPayload::GrantApprove(GrantApproveMeta {
             grant_id: self.grant_id,
             profile_id: self.profile_id,
+            ttl_secs: self.ttl_secs,
         }))
     }
 }
@@ -2342,8 +2350,8 @@ mod tests {
             IntentClaimBuilder::new(iid.clone()).build(),
             IntentConsumeBuilder::new(iid.clone()).build(),
             IntentExpireBuilder::new(iid.clone()).build(),
-            GrantRequestBuilder::new(&req_id, pid.clone()).build(),
-            GrantApproveBuilder::new(gid.clone(), pid.clone()).build(),
+            GrantRequestBuilder::new(&req_id, pid.clone(), vec!["example.com".to_string()]).build(),
+            GrantApproveBuilder::new(gid.clone(), pid.clone(), 300).build(),
             GrantRevokeBuilder::new(gid.clone()).build(),
             GrantExpireBuilder::new(gid.clone()).build(),
             GrantClaimBuilder::new(gid.clone(), &cer_id).build(),

--- a/cmd/passless/src/agent/browser.rs
+++ b/cmd/passless/src/agent/browser.rs
@@ -678,9 +678,12 @@ impl BrowserProcessManager {
                     .map(|p| p.join("sign-proxy"))
                     .unwrap_or_else(|| PathBuf::from("sign-proxy"));
                 if sign_proxy.exists() {
-                    if let Err(e) =
-                        install_native_messaging_manifest(&ext_dir, &config.executable, &sign_proxy)
-                    {
+                    if let Err(e) = install_native_messaging_manifest(
+                        &ext_dir,
+                        &config.executable,
+                        &sign_proxy,
+                        Some(&profile_dir),
+                    ) {
                         log::warn!("failed to install native messaging manifest: {}", e);
                     }
                 } else {
@@ -1843,19 +1846,8 @@ pub fn install_native_messaging_manifest(
     ext_dir: &Path,
     browser_exec: &Path,
     sign_proxy_path: &Path,
+    profile_dir: Option<&Path>,
 ) -> Result<PathBuf, LaunchError> {
-    let hosts_dir = native_messaging_hosts_dir(browser_exec).ok_or_else(|| {
-        LaunchError::ExtensionSetupFailed(
-            "cannot determine native messaging hosts directory".into(),
-        )
-    })?;
-    fs::create_dir_all(&hosts_dir).map_err(|e| {
-        LaunchError::ExtensionSetupFailed(format!(
-            "create native messaging dir {}: {}",
-            hosts_dir.display(),
-            e
-        ))
-    })?;
     let ext_id = compute_extension_id(ext_dir);
     let manifest = serde_json::json!({
         "name": NATIVE_MESSAGING_HOST_NAME,
@@ -1864,6 +1856,31 @@ pub fn install_native_messaging_manifest(
         "type": "stdio",
         "allowed_origins": [format!("chrome-extension://{}/", ext_id)]
     });
+
+    let hosts_dir = if let Some(profile_dir) = profile_dir {
+        profile_dir.join("NativeMessagingHosts")
+    } else {
+        native_messaging_hosts_dir(browser_exec).ok_or_else(|| {
+            LaunchError::ExtensionSetupFailed(
+                "cannot determine native messaging hosts directory".into(),
+            )
+        })?
+    };
+
+    write_native_messaging_manifest(&hosts_dir, &manifest)
+}
+
+fn write_native_messaging_manifest(
+    hosts_dir: &Path,
+    manifest: &serde_json::Value,
+) -> Result<PathBuf, LaunchError> {
+    fs::create_dir_all(hosts_dir).map_err(|e| {
+        LaunchError::ExtensionSetupFailed(format!(
+            "create native messaging dir {}: {}",
+            hosts_dir.display(),
+            e
+        ))
+    })?;
     let manifest_path = hosts_dir.join(format!("{}.json", NATIVE_MESSAGING_HOST_NAME));
     let file = fs::OpenOptions::new()
         .write(true)
@@ -1874,7 +1891,7 @@ pub fn install_native_messaging_manifest(
         .map_err(|e| {
             LaunchError::ExtensionSetupFailed(format!("create native messaging manifest: {}", e))
         })?;
-    serde_json::to_writer_pretty(&file, &manifest).map_err(|e| {
+    serde_json::to_writer_pretty(&file, manifest).map_err(|e| {
         LaunchError::ExtensionSetupFailed(format!("write native messaging manifest: {}", e))
     })?;
     Ok(manifest_path)

--- a/cmd/passless/src/agent/browser.rs
+++ b/cmd/passless/src/agent/browser.rs
@@ -7,7 +7,7 @@ use std::io;
 use std::io::Read;
 use std::io::Write;
 use std::os::unix::ffi::OsStrExt;
-use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
@@ -188,7 +188,7 @@ pub struct BrowserManifest {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AgentEndpointMetadata {
-    pub port: u16,
+    pub socket_path: String,
     pub bearer_token: String,
 }
 
@@ -406,6 +406,7 @@ pub enum LaunchError {
     InvalidArg(String),
     EndpointFileWriteFailed(String, String),
     ExtensionSetupFailed(String),
+    InvalidCdpEndpoint(String),
 }
 
 impl fmt::Display for LaunchError {
@@ -442,6 +443,9 @@ impl fmt::Display for LaunchError {
             }
             LaunchError::ExtensionSetupFailed(msg) => {
                 write!(f, "extension setup failed: {}", msg)
+            }
+            LaunchError::InvalidCdpEndpoint(msg) => {
+                write!(f, "invalid CDP endpoint: {}", msg)
             }
         }
     }
@@ -1684,9 +1688,10 @@ fn render_channel_script(template: &str, channel: &str) -> String {
 
 fn render_worker_script(template: &str, channel: &str, metadata: &AgentEndpointMetadata) -> String {
     let bearer_literal = serde_json::to_string(&metadata.bearer_token).unwrap();
+    let socket_path_literal = serde_json::to_string(&metadata.socket_path).unwrap();
     template
         .replace("__PASSLESS_CHANNEL__", channel)
-        .replace("__PASSLESS_PORT__", &metadata.port.to_string())
+        .replace("__PASSLESS_SOCKET_PATH__", &socket_path_literal)
         .replace("__PASSLESS_BEARER__", &bearer_literal)
 }
 
@@ -1699,10 +1704,16 @@ fn write_extension_file(
     target_gid: u32,
 ) -> Result<(), LaunchError> {
     let path = dir.join(name);
-    fs::write(&path, content)
+    let file = fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(mode)
+        .open(&path)
+        .map_err(|e| LaunchError::ExtensionSetupFailed(format!("create {}: {}", name, e)))?;
+    (&file)
+        .write_all(content.as_bytes())
         .map_err(|e| LaunchError::ExtensionSetupFailed(format!("write {}: {}", name, e)))?;
-    let file = fs::File::open(&path)
-        .map_err(|e| LaunchError::ExtensionSetupFailed(format!("open {}: {}", name, e)))?;
     let ret = unsafe { libc::fchown(file.as_raw_fd(), target_uid, target_gid) };
     if ret != 0 {
         return Err(LaunchError::ExtensionSetupFailed(format!(
@@ -1711,9 +1722,6 @@ fn write_extension_file(
             io::Error::last_os_error()
         )));
     }
-    drop(file);
-    fs::set_permissions(&path, fs::Permissions::from_mode(mode))
-        .map_err(|e| LaunchError::ExtensionSetupFailed(format!("chmod {}: {}", name, e)))?;
     Ok(())
 }
 
@@ -2067,7 +2075,21 @@ pub(crate) fn discover_cdp_endpoint(
             if lines.len() >= 2 {
                 let port = lines[0].trim();
                 let ws_path = lines[1].trim();
-                return Ok(format!("ws://127.0.0.1:{}{}", port, ws_path));
+                let port_num: u16 = port.parse().map_err(|_| {
+                    LaunchError::InvalidCdpEndpoint(format!("invalid port '{}'", port))
+                })?;
+                if port_num == 0 {
+                    return Err(LaunchError::InvalidCdpEndpoint("port must not be 0".into()));
+                }
+                if !ws_path.starts_with("/devtools/browser/") {
+                    return Err(LaunchError::InvalidCdpEndpoint(format!(
+                        "invalid devtools path '{}'",
+                        ws_path
+                    )));
+                }
+                let url = format!("ws://127.0.0.1:{}{}", port, ws_path);
+                validate_loopback_ws_url(&url)?;
+                return Ok(url);
             }
         }
         if Instant::now() >= deadline {
@@ -2091,7 +2113,21 @@ fn discover_cdp_endpoint_with_child(
             if lines.len() >= 2 {
                 let port = lines[0].trim();
                 let ws_path = lines[1].trim();
-                return Ok(format!("ws://127.0.0.1:{}{}", port, ws_path));
+                let port_num: u16 = port.parse().map_err(|_| {
+                    LaunchError::InvalidCdpEndpoint(format!("invalid port '{}'", port))
+                })?;
+                if port_num == 0 {
+                    return Err(LaunchError::InvalidCdpEndpoint("port must not be 0".into()));
+                }
+                if !ws_path.starts_with("/devtools/browser/") {
+                    return Err(LaunchError::InvalidCdpEndpoint(format!(
+                        "invalid devtools path '{}'",
+                        ws_path
+                    )));
+                }
+                let url = format!("ws://127.0.0.1:{}{}", port, ws_path);
+                validate_loopback_ws_url(&url)?;
+                return Ok(url);
             }
         }
         if Instant::now() >= deadline {
@@ -2155,6 +2191,53 @@ fn wait_for_cdp_port(
     }
 }
 
+fn validate_loopback_ws_url(url: &str) -> Result<(), LaunchError> {
+    let rest = url
+        .strip_prefix("ws://")
+        .ok_or_else(|| LaunchError::InvalidCdpEndpoint("scheme must be ws://".into()))?;
+
+    let (host_port, path) = rest
+        .split_once('/')
+        .ok_or_else(|| LaunchError::InvalidCdpEndpoint("missing path after host".into()))?;
+
+    let (host, port_str) = if host_port.starts_with('[') {
+        let bracket_end = host_port
+            .find(']')
+            .ok_or_else(|| LaunchError::InvalidCdpEndpoint("malformed IPv6 address".into()))?;
+        let host = &host_port[1..bracket_end];
+        let port_str = &host_port[bracket_end + 1..];
+        let port_str = port_str.strip_prefix(':').unwrap_or(port_str);
+        (host, port_str)
+    } else {
+        host_port
+            .rsplit_once(':')
+            .ok_or_else(|| LaunchError::InvalidCdpEndpoint("missing port".into()))?
+    };
+
+    if host != "127.0.0.1" && host != "::1" && host != "localhost" {
+        return Err(LaunchError::InvalidCdpEndpoint(format!(
+            "host must be loopback, got '{}'",
+            host
+        )));
+    }
+
+    let port: u16 = port_str
+        .parse()
+        .map_err(|_| LaunchError::InvalidCdpEndpoint(format!("invalid port '{}'", port_str)))?;
+    if port == 0 {
+        return Err(LaunchError::InvalidCdpEndpoint("port must not be 0".into()));
+    }
+
+    if !path.starts_with("devtools/browser/") {
+        return Err(LaunchError::InvalidCdpEndpoint(format!(
+            "path must start with /devtools/browser/, got '/{}'",
+            path
+        )));
+    }
+
+    Ok(())
+}
+
 fn extract_web_socket_debugger_url(http_response: &str) -> Option<String> {
     let key = "webSocketDebuggerUrl";
     let key_pos = http_response.find(key)?;
@@ -2162,7 +2245,9 @@ fn extract_web_socket_debugger_url(http_response: &str) -> Option<String> {
     let ws_start = after_key.find("ws://")?;
     let value = &after_key[ws_start..];
     let end = value.find('"').unwrap_or(value.len());
-    Some(value[..end].to_string())
+    let url = &value[..end];
+    validate_loopback_ws_url(url).ok()?;
+    Some(url.to_string())
 }
 
 fn write_cdp_endpoint(
@@ -2172,14 +2257,18 @@ fn write_cdp_endpoint(
     target_gid: u32,
 ) -> Result<(), LaunchError> {
     let path = runtime_dir.join("cdp-endpoint");
-    fs::write(&path, url).map_err(|e| {
+    let file = fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(&path)
+        .map_err(|e| {
+            LaunchError::EndpointFileWriteFailed(path.display().to_string(), e.to_string())
+        })?;
+    (&file).write_all(url.as_bytes()).map_err(|e| {
         LaunchError::EndpointFileWriteFailed(path.display().to_string(), e.to_string())
     })?;
-
-    let file = fs::File::open(&path).map_err(|e| {
-        LaunchError::EndpointFileWriteFailed(path.display().to_string(), e.to_string())
-    })?;
-    use std::os::unix::io::AsRawFd;
     let ret = unsafe { libc::fchown(file.as_raw_fd(), target_uid, target_gid) };
     if ret != 0 {
         return Err(LaunchError::EndpointFileWriteFailed(
@@ -2187,10 +2276,6 @@ fn write_cdp_endpoint(
             io::Error::last_os_error().to_string(),
         ));
     }
-    let perms = fs::Permissions::from_mode(0o600);
-    fs::set_permissions(&path, perms).map_err(|e| {
-        LaunchError::EndpointFileWriteFailed(path.display().to_string(), e.to_string())
-    })?;
     Ok(())
 }
 
@@ -2425,23 +2510,32 @@ fn path_to_cstring(path: &Path) -> io::Result<CString> {
 
 fn write_manifest_atomic(dir: &Path, manifest: &BrowserManifest) -> Result<(), LaunchError> {
     let manifest_path = dir.join(MANIFEST_FILENAME);
-    let tmp_name = format!(".{}.tmp.{}", MANIFEST_FILENAME, std::process::id());
+    let tmp_name = format!(
+        ".{}.tmp.{:016x}",
+        MANIFEST_FILENAME,
+        rand::thread_rng().r#gen::<u64>()
+    );
     let tmp_path = dir.join(&tmp_name);
 
     let manifest_json = serde_json::to_string_pretty(manifest).map_err(|e| {
         LaunchError::ManifestWriteFailed(manifest_path.display().to_string(), e.to_string())
     })?;
 
-    fs::write(&tmp_path, &manifest_json).map_err(|e| {
-        LaunchError::ManifestWriteFailed(tmp_path.display().to_string(), e.to_string())
-    })?;
-
-    let tmp_file = fs::File::open(&tmp_path).map_err(|e| {
-        LaunchError::ManifestWriteFailed(tmp_path.display().to_string(), e.to_string())
-    })?;
+    let tmp_file = fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&tmp_path)
+        .map_err(|e| {
+            LaunchError::ManifestWriteFailed(tmp_path.display().to_string(), e.to_string())
+        })?;
+    (&tmp_file)
+        .write_all(manifest_json.as_bytes())
+        .map_err(|e| {
+            LaunchError::ManifestWriteFailed(tmp_path.display().to_string(), e.to_string())
+        })?;
     #[cfg(target_os = "linux")]
     {
-        use std::os::unix::io::AsRawFd;
         let ret = unsafe { libc::fsync(tmp_file.as_raw_fd()) };
         if ret != 0 {
             let _ = fs::remove_file(&tmp_path);
@@ -2624,7 +2718,7 @@ mod tests {
             daemon_uid: 0,
             daemon_gid: 0,
             cdp_expose: CdpExposeMode::default(),
-            cdp_port: 0,
+            cdp_port: 9222,
         }
     }
 
@@ -4327,7 +4421,7 @@ mod tests {
             daemon_uid: 0,
             daemon_gid: 0,
             cdp_expose: CdpExposeMode::default(),
-            cdp_port: 0,
+            cdp_port: 9222,
         };
 
         let result = mgr.launch(&config, test_endpoint_id(), test_profile_id());
@@ -4356,7 +4450,7 @@ mod tests {
             daemon_uid: 0,
             daemon_gid: 0,
             cdp_expose: CdpExposeMode::default(),
-            cdp_port: 0,
+            cdp_port: 9222,
         };
 
         let result = mgr.launch(&config, test_endpoint_id(), test_profile_id());
@@ -5632,7 +5726,7 @@ mod tests {
             daemon_uid: 0,
             daemon_gid: 0,
             cdp_expose: CdpExposeMode::Pipe,
-            cdp_port: 0,
+            cdp_port: 9222,
         };
 
         let cmd = build_browser_command(&config, dir.path()).unwrap();
@@ -5703,7 +5797,7 @@ mod tests {
             daemon_uid: 0,
             daemon_gid: 0,
             cdp_expose: CdpExposeMode::Pipe,
-            cdp_port: 0,
+            cdp_port: 9222,
         };
 
         let result = build_browser_command(&config, dir.path());
@@ -5726,7 +5820,7 @@ mod tests {
             daemon_uid: 0,
             daemon_gid: 0,
             cdp_expose: CdpExposeMode::Pipe,
-            cdp_port: 0,
+            cdp_port: 9222,
         };
 
         let result = build_browser_command(&config, dir.path());
@@ -5749,7 +5843,7 @@ mod tests {
             daemon_uid: 0,
             daemon_gid: 0,
             cdp_expose: CdpExposeMode::Pipe,
-            cdp_port: 0,
+            cdp_port: 9222,
         };
 
         let result = build_browser_command(&config, dir.path());
@@ -5770,7 +5864,7 @@ mod tests {
             daemon_uid: 0,
             daemon_gid: 0,
             cdp_expose: CdpExposeMode::Pipe,
-            cdp_port: 0,
+            cdp_port: 9222,
         }
     }
 
@@ -5873,7 +5967,7 @@ mod tests {
             daemon_uid: 0,
             daemon_gid: 0,
             cdp_expose: CdpExposeMode::Pipe,
-            cdp_port: 0,
+            cdp_port: 9222,
         };
         assert!(build_browser_command(&config, dir.path()).is_ok());
     }
@@ -5888,18 +5982,17 @@ mod tests {
 
     #[test]
     fn test_render_worker_script_replaces_all_placeholders() {
-        let template =
-            r#"(function(p,b){})("__PASSLESS_CHANNEL__",__PASSLESS_PORT__,__PASSLESS_BEARER__);"#;
+        let template = r#"(function(s,b){})("__PASSLESS_CHANNEL__",__PASSLESS_SOCKET_PATH__,__PASSLESS_BEARER__);"#;
         let metadata = AgentEndpointMetadata {
-            port: 54321,
+            socket_path: "/tmp/test/sock".to_string(),
             bearer_token: "secrettoken".to_string(),
         };
         let result = render_worker_script(template, "chan123", &metadata);
         assert!(result.contains("chan123"));
-        assert!(result.contains("54321"));
+        assert!(result.contains("/tmp/test/sock"));
         assert!(result.contains("secrettoken"));
         assert!(!result.contains("__PASSLESS_CHANNEL__"));
-        assert!(!result.contains("__PASSLESS_PORT__"));
+        assert!(!result.contains("__PASSLESS_SOCKET_PATH__"));
         assert!(!result.contains("__PASSLESS_BEARER__"));
     }
 
@@ -5909,7 +6002,7 @@ mod tests {
             include_str!("../../assets/agent-extension/main.js"),
             "testchannel",
         );
-        assert!(!rendered.contains("__PASSLESS_PORT__"));
+        assert!(!rendered.contains("__PASSLESS_SOCKET_PATH__"));
         assert!(!rendered.contains("__PASSLESS_BEARER__"));
         assert!(rendered.contains("testchannel"));
         assert!(!rendered.contains("__PASSLESS_CHANNEL__"));
@@ -5921,7 +6014,7 @@ mod tests {
             include_str!("../../assets/agent-extension/broker.js"),
             "testchannel",
         );
-        assert!(!rendered.contains("__PASSLESS_PORT__"));
+        assert!(!rendered.contains("__PASSLESS_SOCKET_PATH__"));
         assert!(!rendered.contains("__PASSLESS_BEARER__"));
         assert!(rendered.contains("testchannel"));
     }
@@ -5929,7 +6022,7 @@ mod tests {
     #[test]
     fn test_render_worker_script_contains_endpoint_secrets() {
         let metadata = AgentEndpointMetadata {
-            port: 60000,
+            socket_path: "/tmp/test/sock".to_string(),
             bearer_token: "beartoken99".to_string(),
         };
         let rendered = render_worker_script(
@@ -5937,9 +6030,9 @@ mod tests {
             "wchan",
             &metadata,
         );
-        assert!(rendered.contains("60000"));
+        assert!(rendered.contains("/tmp/test/sock"));
         assert!(rendered.contains("beartoken99"));
-        assert!(!rendered.contains("__PASSLESS_PORT__"));
+        assert!(!rendered.contains("__PASSLESS_SOCKET_PATH__"));
         assert!(!rendered.contains("__PASSLESS_BEARER__"));
     }
 
@@ -5953,7 +6046,7 @@ mod tests {
         create_lease_dir(&lease_dir, uid, gid).unwrap();
 
         let metadata = AgentEndpointMetadata {
-            port: 55555,
+            socket_path: "/tmp/test/sock".to_string(),
             bearer_token: "deadbeef".to_string(),
         };
         let ext_dir = generate_agent_extension(&lease_dir, &metadata, uid, gid).unwrap();
@@ -5976,7 +6069,7 @@ mod tests {
         create_lease_dir(&lease_dir, uid, gid).unwrap();
 
         let metadata = AgentEndpointMetadata {
-            port: 55555,
+            socket_path: "/tmp/test/sock".to_string(),
             bearer_token: "tok".to_string(),
         };
         let ext_dir = generate_agent_extension(&lease_dir, &metadata, uid, gid).unwrap();
@@ -5994,7 +6087,7 @@ mod tests {
         create_lease_dir(&lease_dir, uid, gid).unwrap();
 
         let metadata = AgentEndpointMetadata {
-            port: 55555,
+            socket_path: "/tmp/test/sock".to_string(),
             bearer_token: "tok".to_string(),
         };
         let ext_dir = generate_agent_extension(&lease_dir, &metadata, uid, gid).unwrap();
@@ -6016,7 +6109,7 @@ mod tests {
         create_lease_dir(&lease_dir, uid, gid).unwrap();
 
         let metadata = AgentEndpointMetadata {
-            port: 55555,
+            socket_path: "/tmp/test/sock".to_string(),
             bearer_token: "tok".to_string(),
         };
         let ext_dir = generate_agent_extension(&lease_dir, &metadata, uid, gid).unwrap();
@@ -6050,7 +6143,7 @@ mod tests {
         create_lease_dir(&lease_dir, uid, gid).unwrap();
 
         let metadata = AgentEndpointMetadata {
-            port: 55555,
+            socket_path: "/tmp/test/sock".to_string(),
             bearer_token: "tok".to_string(),
         };
         let ext_dir = generate_agent_extension(&lease_dir, &metadata, uid, gid).unwrap();
@@ -6084,7 +6177,7 @@ mod tests {
         create_lease_dir(&lease_dir, uid, gid).unwrap();
 
         let metadata = AgentEndpointMetadata {
-            port: 55555,
+            socket_path: "/tmp/test/sock".to_string(),
             bearer_token: "supersecretbearer".to_string(),
         };
         let ext_dir = generate_agent_extension(&lease_dir, &metadata, uid, gid).unwrap();
@@ -6106,7 +6199,7 @@ mod tests {
         create_lease_dir(&lease_dir, uid, gid).unwrap();
 
         let metadata = AgentEndpointMetadata {
-            port: 55555,
+            socket_path: "/tmp/test/sock".to_string(),
             bearer_token: "tok".to_string(),
         };
         let ext_dir = generate_agent_extension(&lease_dir, &metadata, uid, gid).unwrap();
@@ -6172,13 +6265,12 @@ mod tests {
     }
 
     #[test]
-    fn test_manifest_has_loopback_host_permission() {
+    fn test_manifest_has_no_host_permissions() {
         let manifest_str = include_str!("../../assets/agent-extension/manifest.json");
         let parsed: serde_json::Value = serde_json::from_str(manifest_str).unwrap();
-        let hosts = parsed["host_permissions"].as_array().unwrap();
         assert!(
-            hosts.iter().any(|h| h == "http://127.0.0.1/*"),
-            "host_permissions must include http://127.0.0.1/*"
+            parsed.get("host_permissions").is_none(),
+            "host_permissions must not be present (Unix socket transport)"
         );
     }
 
@@ -6231,7 +6323,7 @@ mod tests {
         create_lease_dir(&lease_dir, uid, gid).unwrap();
 
         let metadata = AgentEndpointMetadata {
-            port: 55555,
+            socket_path: "/tmp/test/sock".to_string(),
             bearer_token: "tok".to_string(),
         };
         let ext_dir = generate_agent_extension(&lease_dir, &metadata, uid, gid).unwrap();
@@ -6295,7 +6387,7 @@ mod tests {
         let config = test_config(dir.path());
 
         let metadata = AgentEndpointMetadata {
-            port: 55555,
+            socket_path: "/tmp/test/sock".to_string(),
             bearer_token: "deadbeef".to_string(),
         };
         let lease_id = mgr
@@ -6317,7 +6409,7 @@ mod tests {
         assert!(ext_dir.join("worker.js").exists());
 
         let worker_content = fs::read_to_string(ext_dir.join("worker.js")).unwrap();
-        assert!(worker_content.contains("55555"));
+        assert!(worker_content.contains("/tmp/test/sock"));
         assert!(worker_content.contains("deadbeef"));
     }
 
@@ -6329,7 +6421,7 @@ mod tests {
         let config = test_config(dir.path());
 
         let metadata = AgentEndpointMetadata {
-            port: 55555,
+            socket_path: "/tmp/test/sock".to_string(),
             bearer_token: "tok".to_string(),
         };
         let lease_id = mgr
@@ -6362,7 +6454,7 @@ mod tests {
         let config = test_config(dir.path());
 
         let metadata = AgentEndpointMetadata {
-            port: 55555,
+            socket_path: "/tmp/test/sock".to_string(),
             bearer_token: "tok".to_string(),
         };
         let lease_id = mgr
@@ -6433,7 +6525,7 @@ mod tests {
         create_lease_dir(&lease_dir, uid, gid).unwrap();
 
         let metadata = AgentEndpointMetadata {
-            port: 55555,
+            socket_path: "/tmp/test/sock".to_string(),
             bearer_token: "tok\"en\\with\nspecial\u{00e9}".to_string(),
         };
         let ext_dir = generate_agent_extension(&lease_dir, &metadata, uid, gid).unwrap();
@@ -6460,7 +6552,7 @@ mod tests {
         create_lease_dir(&lease_dir, uid, gid).unwrap();
 
         let metadata = AgentEndpointMetadata {
-            port: 55555,
+            socket_path: "/tmp/test/sock".to_string(),
             bearer_token: "supersecretbearertoken".to_string(),
         };
         let ext_dir = generate_agent_extension(&lease_dir, &metadata, uid, gid).unwrap();
@@ -6479,7 +6571,7 @@ mod tests {
         let mut config = test_config(dir.path());
 
         let metadata = AgentEndpointMetadata {
-            port: 55555,
+            socket_path: "/tmp/test/sock".to_string(),
             bearer_token: "cleanup-test-token-xyz".to_string(),
         };
         config.executable = PathBuf::from("/bin/sleep");
@@ -6516,7 +6608,7 @@ mod tests {
         config.extra_args = vec!["60".to_string()];
 
         let metadata = AgentEndpointMetadata {
-            port: 55555,
+            socket_path: "/tmp/test/sock".to_string(),
             bearer_token: "quarantine-token-abc".to_string(),
         };
         let lease_id = mgr
@@ -6582,7 +6674,7 @@ mod tests {
             daemon_uid: 0,
             daemon_gid: 0,
             cdp_expose: CdpExposeMode::Pipe,
-            cdp_port: 0,
+            cdp_port: 9222,
         };
 
         let cmd = build_browser_command(&config, &profile_dir).unwrap();
@@ -6613,7 +6705,7 @@ mod tests {
             daemon_uid: 0,
             daemon_gid: 0,
             cdp_expose: CdpExposeMode::Pipe,
-            cdp_port: 0,
+            cdp_port: 9222,
         };
 
         let cmd = build_browser_command(&config, &profile_dir).unwrap();
@@ -6628,7 +6720,7 @@ mod tests {
     #[test]
     fn test_agent_endpoint_metadata_serde_roundtrip() {
         let metadata = AgentEndpointMetadata {
-            port: 50000,
+            socket_path: "/tmp/test/sock".to_string(),
             bearer_token: "abc123".to_string(),
         };
         let json = serde_json::to_string(&metadata).unwrap();

--- a/cmd/passless/src/agent/browser.rs
+++ b/cmd/passless/src/agent/browser.rs
@@ -29,6 +29,7 @@ use super::launcher::{
 };
 
 const RUNTIME_DIR_MODE: u32 = 0o700;
+const EXTENSION_DIR_MODE: u32 = 0o755;
 const DEFAULT_SIGTERM_TIMEOUT: Duration = Duration::from_secs(5);
 const DEFAULT_SIGKILL_TIMEOUT: Duration = Duration::from_secs(3);
 const MAX_TTL_CLAMP_SECS: u64 = 86_400;
@@ -735,10 +736,22 @@ impl BrowserProcessManager {
             .join(format!("lease-{}", lease_id.as_str()));
         let profile_dir = runtime_dir.join("profile");
 
-        create_lease_dir(&runtime_dir, config.target_uid, config.target_gid).map_err(|e| {
+        create_lease_dir(
+            &runtime_dir,
+            RUNTIME_DIR_MODE,
+            config.target_uid,
+            config.target_gid,
+        )
+        .map_err(|e| {
             LaunchError::DirCreationFailed(runtime_dir.display().to_string(), e.to_string())
         })?;
-        create_lease_dir(&profile_dir, config.target_uid, config.target_gid).map_err(|e| {
+        create_lease_dir(
+            &profile_dir,
+            RUNTIME_DIR_MODE,
+            config.target_uid,
+            config.target_gid,
+        )
+        .map_err(|e| {
             LaunchError::DirCreationFailed(profile_dir.display().to_string(), e.to_string())
         })?;
 
@@ -1582,7 +1595,7 @@ fn validate_runtime_root(path: &Path, expected_uid: u32) -> io::Result<()> {
     Ok(())
 }
 
-fn create_lease_dir(path: &Path, target_uid: u32, target_gid: u32) -> io::Result<()> {
+fn create_lease_dir(path: &Path, mode: u32, target_uid: u32, target_gid: u32) -> io::Result<()> {
     let parent = path.parent().unwrap_or(Path::new("/"));
     let dir_name = path.file_name().ok_or_else(|| {
         io::Error::new(
@@ -1618,7 +1631,7 @@ fn create_lease_dir(path: &Path, target_uid: u32, target_gid: u32) -> io::Result
         ));
     }
 
-    let mkdir_ret = unsafe { libc::mkdirat(parent_fd, c_name.as_ptr(), RUNTIME_DIR_MODE) };
+    let mkdir_ret = unsafe { libc::mkdirat(parent_fd, c_name.as_ptr(), mode) };
     if mkdir_ret != 0 {
         let err = io::Error::last_os_error();
         unsafe { libc::close(parent_fd) };
@@ -1833,7 +1846,7 @@ fn generate_agent_extension(
     target_gid: u32,
 ) -> Result<PathBuf, LaunchError> {
     let ext_dir = runtime_dir.join(AGENT_EXTENSION_DIR);
-    create_lease_dir(&ext_dir, target_uid, target_gid)
+    create_lease_dir(&ext_dir, EXTENSION_DIR_MODE, target_uid, target_gid)
         .map_err(|e| LaunchError::ExtensionSetupFailed(format!("extension dir: {}", e)))?;
 
     let channel_bytes: [u8; 32] = rand::thread_rng().r#gen();
@@ -3228,13 +3241,13 @@ mod tests {
         let target = root.join("lease-test");
         let uid = unsafe { libc::getuid() };
         let gid = unsafe { libc::getgid() };
-        create_lease_dir(&target, uid, gid).unwrap();
+        create_lease_dir(&target, RUNTIME_DIR_MODE, uid, gid).unwrap();
         let meta = fs::symlink_metadata(&target).unwrap();
         assert!(meta.is_dir());
         assert_eq!(meta.permissions().mode() & 0o777, RUNTIME_DIR_MODE);
         assert_eq!(meta.uid(), uid);
         assert_eq!(meta.gid(), gid);
-        assert!(create_lease_dir(&target, uid, gid).is_err());
+        assert!(create_lease_dir(&target, RUNTIME_DIR_MODE, uid, gid).is_err());
     }
 
     #[test]
@@ -4485,7 +4498,7 @@ mod tests {
         let lease_dir = root.join("lease-test");
         let uid = unsafe { libc::getuid() };
         let gid = unsafe { libc::getgid() };
-        create_lease_dir(&lease_dir, uid, gid).unwrap();
+        create_lease_dir(&lease_dir, RUNTIME_DIR_MODE, uid, gid).unwrap();
 
         let manifest = BrowserManifest {
             lease_id: "test".to_string(),
@@ -6247,7 +6260,7 @@ mod tests {
         let lease_dir = root.join("lease-ext");
         let uid = unsafe { libc::getuid() };
         let gid = unsafe { libc::getgid() };
-        create_lease_dir(&lease_dir, uid, gid).unwrap();
+        create_lease_dir(&lease_dir, RUNTIME_DIR_MODE, uid, gid).unwrap();
 
         let metadata = AgentEndpointMetadata {
             socket_path: "/tmp/test/sock".to_string(),
@@ -6264,13 +6277,13 @@ mod tests {
     }
 
     #[test]
-    fn test_extension_dir_permissions_are_0700() {
+    fn test_extension_dir_permissions_are_0755() {
         let dir = tempfile::tempdir().unwrap();
         let root = setup_runtime_root(dir.path());
         let lease_dir = root.join("lease-perm");
         let uid = unsafe { libc::getuid() };
         let gid = unsafe { libc::getgid() };
-        create_lease_dir(&lease_dir, uid, gid).unwrap();
+        create_lease_dir(&lease_dir, RUNTIME_DIR_MODE, uid, gid).unwrap();
 
         let metadata = AgentEndpointMetadata {
             socket_path: "/tmp/test/sock".to_string(),
@@ -6278,7 +6291,7 @@ mod tests {
         };
         let ext_dir = generate_agent_extension(&lease_dir, &metadata, uid, gid).unwrap();
         let mode = fs::symlink_metadata(&ext_dir).unwrap().permissions().mode() & 0o777;
-        assert_eq!(mode, 0o700);
+        assert_eq!(mode, 0o755);
     }
 
     #[test]
@@ -6288,7 +6301,7 @@ mod tests {
         let lease_dir = root.join("lease-wperm");
         let uid = unsafe { libc::getuid() };
         let gid = unsafe { libc::getgid() };
-        create_lease_dir(&lease_dir, uid, gid).unwrap();
+        create_lease_dir(&lease_dir, RUNTIME_DIR_MODE, uid, gid).unwrap();
 
         let metadata = AgentEndpointMetadata {
             socket_path: "/tmp/test/sock".to_string(),
@@ -6310,7 +6323,7 @@ mod tests {
         let lease_dir = root.join("lease-mperm");
         let uid = unsafe { libc::getuid() };
         let gid = unsafe { libc::getgid() };
-        create_lease_dir(&lease_dir, uid, gid).unwrap();
+        create_lease_dir(&lease_dir, RUNTIME_DIR_MODE, uid, gid).unwrap();
 
         let metadata = AgentEndpointMetadata {
             socket_path: "/tmp/test/sock".to_string(),
@@ -6344,7 +6357,7 @@ mod tests {
         let lease_dir = root.join("lease-noplace");
         let uid = unsafe { libc::getuid() };
         let gid = unsafe { libc::getgid() };
-        create_lease_dir(&lease_dir, uid, gid).unwrap();
+        create_lease_dir(&lease_dir, RUNTIME_DIR_MODE, uid, gid).unwrap();
 
         let metadata = AgentEndpointMetadata {
             socket_path: "/tmp/test/sock".to_string(),
@@ -6378,7 +6391,7 @@ mod tests {
         let lease_dir = root.join("lease-nosec");
         let uid = unsafe { libc::getuid() };
         let gid = unsafe { libc::getgid() };
-        create_lease_dir(&lease_dir, uid, gid).unwrap();
+        create_lease_dir(&lease_dir, RUNTIME_DIR_MODE, uid, gid).unwrap();
 
         let metadata = AgentEndpointMetadata {
             socket_path: "/tmp/test/sock".to_string(),
@@ -6400,7 +6413,7 @@ mod tests {
         let lease_dir = root.join("lease-nometa");
         let uid = unsafe { libc::getuid() };
         let gid = unsafe { libc::getgid() };
-        create_lease_dir(&lease_dir, uid, gid).unwrap();
+        create_lease_dir(&lease_dir, RUNTIME_DIR_MODE, uid, gid).unwrap();
 
         let metadata = AgentEndpointMetadata {
             socket_path: "/tmp/test/sock".to_string(),
@@ -6530,7 +6543,7 @@ mod tests {
         let lease_dir = root.join("lease-nodecheck");
         let uid = unsafe { libc::getuid() };
         let gid = unsafe { libc::getgid() };
-        create_lease_dir(&lease_dir, uid, gid).unwrap();
+        create_lease_dir(&lease_dir, RUNTIME_DIR_MODE, uid, gid).unwrap();
 
         let metadata = AgentEndpointMetadata {
             socket_path: "/tmp/test/sock".to_string(),
@@ -6732,7 +6745,7 @@ mod tests {
         let lease_dir = root.join("lease-bearer-special");
         let uid = unsafe { libc::getuid() };
         let gid = unsafe { libc::getgid() };
-        create_lease_dir(&lease_dir, uid, gid).unwrap();
+        create_lease_dir(&lease_dir, RUNTIME_DIR_MODE, uid, gid).unwrap();
 
         let metadata = AgentEndpointMetadata {
             socket_path: "/tmp/test/sock".to_string(),
@@ -6759,7 +6772,7 @@ mod tests {
         let lease_dir = root.join("lease-bearer-iso");
         let uid = unsafe { libc::getuid() };
         let gid = unsafe { libc::getgid() };
-        create_lease_dir(&lease_dir, uid, gid).unwrap();
+        create_lease_dir(&lease_dir, RUNTIME_DIR_MODE, uid, gid).unwrap();
 
         let metadata = AgentEndpointMetadata {
             socket_path: "/tmp/test/sock".to_string(),

--- a/cmd/passless/src/agent/browser.rs
+++ b/cmd/passless/src/agent/browser.rs
@@ -20,6 +20,7 @@ use passless_core::agent::{BrowserLeaseId, EndpointId, ProfileId};
 
 use rand::Rng;
 use serde::{Deserialize, Serialize};
+use serde_json;
 
 use super::launcher::{
     DEFAULT_RLIMIT_AS, DEFAULT_RLIMIT_CORE, DEFAULT_RLIMIT_NPROC, HardenedChildSetup,
@@ -665,12 +666,30 @@ impl BrowserProcessManager {
         })?;
 
         if let Some(metadata) = agent_endpoint {
-            let _ext_dir = generate_agent_extension(
+            let ext_dir = generate_agent_extension(
                 &runtime_dir,
                 metadata,
                 config.target_uid,
                 config.target_gid,
             )?;
+            if let Ok(current_exe) = std::env::current_exe() {
+                let sign_proxy = current_exe
+                    .parent()
+                    .map(|p| p.join("sign-proxy"))
+                    .unwrap_or_else(|| PathBuf::from("sign-proxy"));
+                if sign_proxy.exists() {
+                    if let Err(e) =
+                        install_native_messaging_manifest(&ext_dir, &config.executable, &sign_proxy)
+                    {
+                        log::warn!("failed to install native messaging manifest: {}", e);
+                    }
+                } else {
+                    log::warn!(
+                        "sign-proxy not found at {}, native messaging disabled",
+                        sign_proxy.display()
+                    );
+                }
+            }
         }
 
         let profile_fp = fingerprint_path(&profile_dir).map_err(|e| {
@@ -959,6 +978,8 @@ impl BrowserProcessManager {
     }
 
     pub fn cleanup(&mut self, lease_id: &BrowserLeaseId) -> Result<CleanupSafety, TransitionError> {
+        remove_native_messaging_manifest_from_all();
+
         let entry = self.leases.get(lease_id).ok_or(TransitionError::NotFound)?;
 
         let manifest = &entry.manifest;
@@ -1782,6 +1803,87 @@ fn generate_agent_extension(
     )?;
 
     Ok(ext_dir)
+}
+
+const NATIVE_MESSAGING_HOST_NAME: &str = "rs.passless.sign_proxy";
+
+fn compute_extension_id(ext_dir: &Path) -> String {
+    use sha2::Digest;
+    let abs_path = ext_dir
+        .canonicalize()
+        .unwrap_or_else(|_| ext_dir.to_path_buf());
+    let path_str = abs_path.to_string_lossy();
+    let hash = sha2::Sha256::digest(path_str.as_bytes());
+    hash.iter()
+        .take(16)
+        .map(|b| (b'a' + (b % 16)) as char)
+        .collect()
+}
+
+fn native_messaging_hosts_dir(browser_exec: &Path) -> Option<PathBuf> {
+    let exec_name = browser_exec
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("");
+    let config_dir = if exec_name.contains("google-chrome") || exec_name == "chrome" {
+        dirs::config_dir().map(|d| d.join("google-chrome"))
+    } else if exec_name.contains("chromium") {
+        dirs::config_dir().map(|d| d.join("chromium"))
+    } else {
+        dirs::config_dir().map(|d| d.join("chromium"))
+    };
+    config_dir.map(|d| d.join("NativeMessagingHosts"))
+}
+
+fn install_native_messaging_manifest(
+    ext_dir: &Path,
+    browser_exec: &Path,
+    sign_proxy_path: &Path,
+) -> Result<PathBuf, LaunchError> {
+    let hosts_dir = native_messaging_hosts_dir(browser_exec).ok_or_else(|| {
+        LaunchError::ExtensionSetupFailed(
+            "cannot determine native messaging hosts directory".into(),
+        )
+    })?;
+    fs::create_dir_all(&hosts_dir).map_err(|e| {
+        LaunchError::ExtensionSetupFailed(format!(
+            "create native messaging dir {}: {}",
+            hosts_dir.display(),
+            e
+        ))
+    })?;
+    let ext_id = compute_extension_id(ext_dir);
+    let manifest = serde_json::json!({
+        "name": NATIVE_MESSAGING_HOST_NAME,
+        "description": "Passless agent sign proxy",
+        "path": sign_proxy_path,
+        "type": "stdio",
+        "allowed_origins": [format!("chrome-extension://{}/", ext_id)]
+    });
+    let manifest_path = hosts_dir.join(format!("{}.json", NATIVE_MESSAGING_HOST_NAME));
+    let file = fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o644)
+        .open(&manifest_path)
+        .map_err(|e| {
+            LaunchError::ExtensionSetupFailed(format!("create native messaging manifest: {}", e))
+        })?;
+    serde_json::to_writer_pretty(&file, &manifest).map_err(|e| {
+        LaunchError::ExtensionSetupFailed(format!("write native messaging manifest: {}", e))
+    })?;
+    Ok(manifest_path)
+}
+
+fn remove_native_messaging_manifest_from_all() {
+    if let Some(config_dir) = dirs::config_dir() {
+        for browser_dir in &["chromium", "google-chrome", "google-chrome-beta"] {
+            let hosts_dir = config_dir.join(browser_dir).join("NativeMessagingHosts");
+            let manifest_path = hosts_dir.join(format!("{}.json", NATIVE_MESSAGING_HOST_NAME));
+            let _ = fs::remove_file(&manifest_path);
+        }
+    }
 }
 
 pub(crate) fn build_browser_command(

--- a/cmd/passless/src/agent/browser.rs
+++ b/cmd/passless/src/agent/browser.rs
@@ -19,6 +19,8 @@ use passless_core::agent::config::{ANY_RP_ID, CdpExposeMode, validate_rp_id};
 use passless_core::agent::{BrowserLeaseId, EndpointId, ProfileId};
 
 use rand::Rng;
+use rsa::RsaPrivateKey;
+use rsa::pkcs8::{DecodePrivateKey, EncodePrivateKey, EncodePublicKey};
 use serde::{Deserialize, Serialize};
 use serde_json;
 
@@ -46,6 +48,81 @@ pub const CDP_MAX_RESPONSE_TOTAL_BYTES: usize = 64 * 1024;
 pub const CDP_MAX_TIMEOUT: Duration = Duration::from_secs(30);
 pub const CDP_MIN_TIMEOUT: Duration = Duration::from_millis(100);
 const CDP_READ_BUF_SIZE: usize = 16 * 1024;
+const EXTENSION_KEY_FILENAME: &str = "extension_key.pem";
+
+fn extension_key_path() -> Result<PathBuf, LaunchError> {
+    dirs::config_dir()
+        .map(|d| d.join("passless").join(EXTENSION_KEY_FILENAME))
+        .ok_or_else(|| {
+            LaunchError::ExtensionSetupFailed("cannot determine config directory".into())
+        })
+}
+
+fn generate_extension_key() -> Result<RsaPrivateKey, LaunchError> {
+    let mut rng = rand::thread_rng();
+    RsaPrivateKey::new(&mut rng, 2048)
+        .map_err(|e| LaunchError::ExtensionSetupFailed(format!("generate RSA key: {}", e)))
+}
+
+fn load_or_create_extension_key() -> Result<RsaPrivateKey, LaunchError> {
+    let key_path = extension_key_path()?;
+
+    if key_path.exists() {
+        let pem_data = fs::read_to_string(&key_path)
+            .map_err(|e| LaunchError::ExtensionSetupFailed(format!("read extension key: {}", e)))?;
+        RsaPrivateKey::from_pkcs8_pem(&pem_data)
+            .map_err(|e| LaunchError::ExtensionSetupFailed(format!("parse extension key: {}", e)))
+    } else {
+        let key = generate_extension_key()?;
+        let pem_data = key.to_pkcs8_pem(rsa::pkcs8::LineEnding::LF).map_err(|e| {
+            LaunchError::ExtensionSetupFailed(format!("encode extension key: {}", e))
+        })?;
+
+        if let Some(parent) = key_path.parent() {
+            fs::create_dir_all(parent).map_err(|e| {
+                LaunchError::ExtensionSetupFailed(format!("create config directory: {}", e))
+            })?;
+        }
+
+        fs::write(&key_path, pem_data.as_bytes()).map_err(|e| {
+            LaunchError::ExtensionSetupFailed(format!("write extension key: {}", e))
+        })?;
+
+        Ok(key)
+    }
+}
+
+fn compute_extension_id_from_key(key: &RsaPrivateKey) -> Result<String, LaunchError> {
+    use sha2::Digest;
+
+    let pub_key = key.to_public_key();
+    let pub_key_der = pub_key
+        .to_public_key_der()
+        .map_err(|e| LaunchError::ExtensionSetupFailed(format!("encode public key: {}", e)))?;
+
+    let hash = sha2::Sha256::digest(pub_key_der.as_bytes());
+    let ext_id: String = hash
+        .iter()
+        .take(16)
+        .flat_map(|b| {
+            let high = (b >> 4) & 0x0F;
+            let low = b & 0x0F;
+            [(b'a' + high) as char, (b'a' + low) as char]
+        })
+        .collect();
+
+    Ok(ext_id)
+}
+
+fn get_public_key_base64(key: &RsaPrivateKey) -> Result<String, LaunchError> {
+    let pub_key = key.to_public_key();
+    let pub_key_der = pub_key
+        .to_public_key_der()
+        .map_err(|e| LaunchError::ExtensionSetupFailed(format!("encode public key: {}", e)))?;
+
+    use base64::Engine;
+    Ok(base64::engine::general_purpose::STANDARD.encode(pub_key_der.as_bytes()))
+}
 
 fn process_epoch() -> &'static Instant {
     static EPOCH: OnceLock<Instant> = OnceLock::new();
@@ -1762,10 +1839,22 @@ fn generate_agent_extension(
     let channel_bytes: [u8; 32] = rand::thread_rng().r#gen();
     let channel: String = channel_bytes.iter().map(|b| format!("{:02x}", b)).collect();
 
+    let key = load_or_create_extension_key()?;
+    let pub_key_base64 = get_public_key_base64(&key)?;
+
+    let base_manifest: serde_json::Value = serde_json::from_str(include_str!(
+        "../../assets/agent-extension/manifest.json"
+    ))
+    .map_err(|e| LaunchError::ExtensionSetupFailed(format!("parse base manifest: {}", e)))?;
+    let mut manifest = base_manifest.as_object().cloned().unwrap_or_default();
+    manifest.insert("key".to_string(), serde_json::Value::String(pub_key_base64));
+    let manifest_json = serde_json::to_string_pretty(&manifest)
+        .map_err(|e| LaunchError::ExtensionSetupFailed(format!("serialize manifest: {}", e)))?;
+
     write_extension_file(
         &ext_dir,
         "manifest.json",
-        include_str!("../../assets/agent-extension/manifest.json"),
+        &manifest_json,
         0o644,
         target_uid,
         target_gid,
@@ -1810,21 +1899,13 @@ fn generate_agent_extension(
 
 pub const NATIVE_MESSAGING_HOST_NAME: &str = "rs.passless.sign_proxy";
 
-pub fn compute_extension_id(ext_dir: &Path) -> String {
-    use sha2::Digest;
-    let abs_path = ext_dir
-        .canonicalize()
-        .unwrap_or_else(|_| ext_dir.to_path_buf());
-    let path_str = abs_path.to_string_lossy();
-    let hash = sha2::Sha256::digest(path_str.as_bytes());
-    hash.iter()
-        .take(16)
-        .flat_map(|b| {
-            let high = (b >> 4) & 0x0F;
-            let low = b & 0x0F;
-            [(b'a' + high) as char, (b'a' + low) as char]
+pub fn compute_extension_id(_ext_dir: &Path) -> String {
+    load_or_create_extension_key()
+        .and_then(|key| compute_extension_id_from_key(&key))
+        .unwrap_or_else(|e| {
+            log::error!("failed to compute stable extension ID: {}", e);
+            String::new()
         })
-        .collect()
 }
 
 fn native_messaging_hosts_dir(browser_exec: &Path) -> Option<PathBuf> {

--- a/cmd/passless/src/agent/browser.rs
+++ b/cmd/passless/src/agent/browser.rs
@@ -6388,12 +6388,18 @@ mod tests {
     }
 
     #[test]
-    fn test_manifest_has_no_host_permissions() {
+    fn test_manifest_has_host_permissions() {
         let manifest_str = include_str!("../../assets/agent-extension/manifest.json");
         let parsed: serde_json::Value = serde_json::from_str(manifest_str).unwrap();
+        let host_permissions = parsed
+            .get("host_permissions")
+            .expect("host_permissions must be present for content scripts");
+        let arr = host_permissions
+            .as_array()
+            .expect("host_permissions must be an array");
         assert!(
-            parsed.get("host_permissions").is_none(),
-            "host_permissions must not be present (Unix socket transport)"
+            arr.iter().any(|v| v.as_str() == Some("https://*/*")),
+            "host_permissions must include https://*/*"
         );
     }
 

--- a/cmd/passless/src/agent/browser.rs
+++ b/cmd/passless/src/agent/browser.rs
@@ -26,6 +26,7 @@ use serde_json;
 
 use super::launcher::{
     DEFAULT_RLIMIT_AS, DEFAULT_RLIMIT_CORE, DEFAULT_RLIMIT_NPROC, HardenedChildSetup,
+    close_range_preserving,
 };
 
 const RUNTIME_DIR_MODE: u32 = 0o700;
@@ -2241,13 +2242,25 @@ fn spawn_browser_port_mode(
     unsafe {
         cmd.pre_exec(move || {
             if trusted_same_user {
-                // Do not set PR_SET_NO_NEW_PRIVS before exec in trusted
-                // same-user mode. Chromium may need its setuid sandbox helper
-                // during startup. Keep a dedicated session/process group so
-                // lifecycle cleanup can still terminate the complete browser.
+                // Close inherited FDs (sockets, audit files, UHID, etc.) but
+                // preserve stdio. Port mode uses TCP, not inherited pipes.
+                if close_range_preserving(&[0, 1, 2]).is_err() {
+                    return Err(io::Error::last_os_error());
+                }
+
+                // Dedicated session/process group for lifecycle cleanup.
                 if libc::setsid() < 0 {
                     return Err(io::Error::last_os_error());
                 }
+
+                // Reap browser if daemon dies.
+                if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM, 0, 0, 0) < 0 {
+                    return Err(io::Error::last_os_error());
+                }
+
+                // Do not set PR_SET_NO_NEW_PRIVS before exec in trusted
+                // same-user mode. Chromium may need its setuid sandbox helper
+                // during startup.
                 Ok(())
             } else {
                 setup.apply(&[0, 1, 2])

--- a/cmd/passless/src/agent/browser.rs
+++ b/cmd/passless/src/agent/browser.rs
@@ -1805,9 +1805,9 @@ fn generate_agent_extension(
     Ok(ext_dir)
 }
 
-const NATIVE_MESSAGING_HOST_NAME: &str = "rs.passless.sign_proxy";
+pub const NATIVE_MESSAGING_HOST_NAME: &str = "rs.passless.sign_proxy";
 
-fn compute_extension_id(ext_dir: &Path) -> String {
+pub fn compute_extension_id(ext_dir: &Path) -> String {
     use sha2::Digest;
     let abs_path = ext_dir
         .canonicalize()
@@ -1816,7 +1816,11 @@ fn compute_extension_id(ext_dir: &Path) -> String {
     let hash = sha2::Sha256::digest(path_str.as_bytes());
     hash.iter()
         .take(16)
-        .map(|b| (b'a' + (b % 16)) as char)
+        .flat_map(|b| {
+            let high = (b >> 4) & 0x0F;
+            let low = b & 0x0F;
+            [(b'a' + high) as char, (b'a' + low) as char]
+        })
         .collect()
 }
 
@@ -1835,7 +1839,7 @@ fn native_messaging_hosts_dir(browser_exec: &Path) -> Option<PathBuf> {
     config_dir.map(|d| d.join("NativeMessagingHosts"))
 }
 
-fn install_native_messaging_manifest(
+pub fn install_native_messaging_manifest(
     ext_dir: &Path,
     browser_exec: &Path,
     sign_proxy_path: &Path,

--- a/cmd/passless/src/agent/ceremony.rs
+++ b/cmd/passless/src/agent/ceremony.rs
@@ -4103,7 +4103,7 @@ mod tests {
             let clock = Arc::new(MockClock::new());
             let config = make_isolated_config(true);
             let runtime =
-                Arc::new(PolicyRuntime::new(&config, clock.clone(), clock.clone()).unwrap());
+                Arc::new(PolicyRuntime::new(&config, clock.clone(), clock.clone(), None).unwrap());
 
             let audit_dir = format!("/tmp/test-handler-audit-{}", suffix);
             let _ = std::fs::remove_dir_all(&audit_dir);
@@ -5065,8 +5065,9 @@ mod tests {
             ) -> (Arc<PolicyRuntime>, Arc<AuditGate>) {
                 let clock = Arc::new(MockClock::new());
                 let config = make_isolated_config();
-                let runtime =
-                    Arc::new(PolicyRuntime::new(&config, clock.clone(), clock.clone()).unwrap());
+                let runtime = Arc::new(
+                    PolicyRuntime::new(&config, clock.clone(), clock.clone(), None).unwrap(),
+                );
                 (runtime, audit)
             }
 
@@ -5290,8 +5291,9 @@ mod tests {
 
                 let clock = Arc::new(MockClock::new());
                 let config = make_isolated_config();
-                let runtime =
-                    Arc::new(PolicyRuntime::new(&config, clock.clone(), clock.clone()).unwrap());
+                let runtime = Arc::new(
+                    PolicyRuntime::new(&config, clock.clone(), clock.clone(), None).unwrap(),
+                );
                 let generation = runtime.current_generation();
                 let profile_id = ProfileId::new("test").unwrap();
                 let endpoint_id = EndpointId::new();
@@ -5370,8 +5372,9 @@ mod tests {
                 let audit = Arc::new(AuditGate::open(&audit_dir).unwrap());
                 let config = make_isolated_config();
                 let clock = Arc::new(MockClock::new());
-                let runtime =
-                    Arc::new(PolicyRuntime::new(&config, clock.clone(), clock.clone()).unwrap());
+                let runtime = Arc::new(
+                    PolicyRuntime::new(&config, clock.clone(), clock.clone(), None).unwrap(),
+                );
                 let generation = runtime.current_generation();
                 let profile_id = ProfileId::new("test").unwrap();
                 let session_id = PrincipalSessionId::new();
@@ -5461,8 +5464,9 @@ mod tests {
                 let audit = Arc::new(AuditGate::open(&audit_dir).unwrap());
                 let config = make_allow_config();
                 let clock = Arc::new(MockClock::new());
-                let runtime =
-                    Arc::new(PolicyRuntime::new(&config, clock.clone(), clock.clone()).unwrap());
+                let runtime = Arc::new(
+                    PolicyRuntime::new(&config, clock.clone(), clock.clone(), None).unwrap(),
+                );
                 let generation = runtime.current_generation();
                 let profile_id = ProfileId::new("test").unwrap();
                 let session_id = PrincipalSessionId::new();
@@ -5550,8 +5554,9 @@ mod tests {
                 let audit = Arc::new(AuditGate::open(&audit_dir).unwrap());
                 let config = make_isolated_config();
                 let clock = Arc::new(MockClock::new());
-                let runtime =
-                    Arc::new(PolicyRuntime::new(&config, clock.clone(), clock.clone()).unwrap());
+                let runtime = Arc::new(
+                    PolicyRuntime::new(&config, clock.clone(), clock.clone(), None).unwrap(),
+                );
                 let generation = runtime.current_generation();
                 let profile_id = ProfileId::new("test").unwrap();
                 let endpoint_id = EndpointId::new();
@@ -5727,8 +5732,9 @@ mod tests {
                 let audit = Arc::new(crate::agent::audit::AuditGate::open(&audit_dir).unwrap());
                 let clock = Arc::new(MockClock::new());
                 let config = make_config();
-                let runtime =
-                    Arc::new(PolicyRuntime::new(&config, clock.clone(), clock.clone()).unwrap());
+                let runtime = Arc::new(
+                    PolicyRuntime::new(&config, clock.clone(), clock.clone(), None).unwrap(),
+                );
                 let generation = runtime.current_generation();
                 let profile_id = ProfileId::new("test").unwrap();
                 let endpoint_id = EndpointId::new();
@@ -5886,8 +5892,9 @@ mod tests {
                 let audit = Arc::new(crate::agent::audit::AuditGate::open(&audit_dir).unwrap());
                 let clock = Arc::new(MockClock::new());
                 let config = make_config();
-                let runtime =
-                    Arc::new(PolicyRuntime::new(&config, clock.clone(), clock.clone()).unwrap());
+                let runtime = Arc::new(
+                    PolicyRuntime::new(&config, clock.clone(), clock.clone(), None).unwrap(),
+                );
                 let generation = runtime.current_generation();
                 let profile_id = ProfileId::new("test").unwrap();
                 let endpoint_id = EndpointId::new();
@@ -5954,8 +5961,9 @@ mod tests {
                 let audit = Arc::new(crate::agent::audit::AuditGate::open(&audit_dir).unwrap());
                 let clock = Arc::new(MockClock::new());
                 let config = make_config();
-                let runtime =
-                    Arc::new(PolicyRuntime::new(&config, clock.clone(), clock.clone()).unwrap());
+                let runtime = Arc::new(
+                    PolicyRuntime::new(&config, clock.clone(), clock.clone(), None).unwrap(),
+                );
                 let generation = runtime.current_generation();
                 let profile_id = ProfileId::new("test").unwrap();
                 let endpoint_id = EndpointId::new();

--- a/cmd/passless/src/agent/endpoint_manager.rs
+++ b/cmd/passless/src/agent/endpoint_manager.rs
@@ -1292,7 +1292,7 @@ mod tests {
         let monotonic_clock: Arc<dyn super::super::intent::MonotonicClock> =
             Arc::new(super::super::intent::SystemClock::new());
         let policy_runtime = Arc::new(
-            PolicyRuntime::new(&agent_config, clock, monotonic_clock)
+            PolicyRuntime::new(&agent_config, clock, monotonic_clock, None)
                 .expect("policy runtime creation"),
         );
 

--- a/cmd/passless/src/agent/grant.rs
+++ b/cmd/passless/src/agent/grant.rs
@@ -9,6 +9,8 @@ use passless_core::agent::{
     ProfileId, RegistrationGrantId,
 };
 
+use super::audit::AuditGate;
+use super::audit_events::{GrantApproveBuilder, GrantRequestBuilder};
 use super::browser::Clock;
 use super::intent::AdminAuthority;
 
@@ -469,6 +471,7 @@ pub struct GrantRegistry {
     allowed_actions: BTreeSet<String>,
     max_concurrent_grants: u64,
     last_seen_mono: u64,
+    audit_sink: Option<Arc<AuditGate>>,
 }
 
 impl GrantRegistry {
@@ -479,6 +482,7 @@ impl GrantRegistry {
         max_ttl_secs: u64,
         allowed_actions: BTreeSet<String>,
         max_concurrent_grants: u64,
+        audit_sink: Option<Arc<AuditGate>>,
     ) -> Self {
         Self {
             grants: HashMap::new(),
@@ -491,6 +495,7 @@ impl GrantRegistry {
             allowed_actions,
             max_concurrent_grants,
             last_seen_mono: 0,
+            audit_sink,
         }
     }
 
@@ -544,6 +549,8 @@ impl GrantRegistry {
         }
 
         let request_id = GrantRequestId::new();
+        let audit_profile_id = params.profile_id.clone();
+        let audit_rp_ids = params.rp_ids.clone();
         let request = GrantRequest {
             profile_id: params.profile_id,
             session_id: params.session_id,
@@ -558,6 +565,13 @@ impl GrantRegistry {
         };
 
         self.pending_requests.insert(request_id.clone(), request);
+
+        if let Some(ref sink) = self.audit_sink {
+            let event =
+                GrantRequestBuilder::new(&request_id, audit_profile_id, audit_rp_ids).build();
+            let _ = sink.record(event);
+        }
+
         Ok(request_id)
     }
 
@@ -596,11 +610,12 @@ impl GrantRegistry {
         };
         let ttl = clamp_ttl(request.requested_ttl_secs, self.max_ttl_secs);
         let now = self.clock.monotonic_secs();
+        let profile_id = request.profile_id.clone();
 
         let grant_id = GrantId::new();
         let grant = Grant {
             id: grant_id.clone(),
-            profile_id: request.profile_id.clone(),
+            profile_id: profile_id.clone(),
             session_id: request.session_id.clone(),
             endpoint_id: request.endpoint_id.clone(),
             principal_digest: request.principal_digest,
@@ -618,6 +633,11 @@ impl GrantRegistry {
         if let Some(req) = self.pending_requests.get_mut(request_id) {
             req.resolved = true;
             req.resolved_grant_id = Some(grant_id.clone());
+        }
+
+        if let Some(ref sink) = self.audit_sink {
+            let event = GrantApproveBuilder::new(grant_id.clone(), profile_id, ttl).build();
+            let _ = sink.record(event);
         }
 
         Ok(grant_id)
@@ -1321,6 +1341,7 @@ mod tests {
             300,
             test_actions(),
             10,
+            None,
         )
     }
 
@@ -1834,6 +1855,7 @@ mod tests {
             300,
             test_actions(),
             10,
+            None,
         );
 
         let authority = super::super::intent::admin_authority();
@@ -2875,5 +2897,49 @@ mod tests {
 
         let snapshots = registry.list_all_snapshots();
         assert_eq!(snapshots.len(), 2);
+    }
+
+    #[test]
+    fn test_grant_request_and_approve_emit_audit_records() {
+        use super::super::audit::AuditGate;
+        use tempfile::TempDir;
+
+        let temp = TempDir::new().unwrap();
+        let audit_dir = temp.path().join("audit");
+        let gate = Arc::new(AuditGate::open(&audit_dir).unwrap());
+
+        let clock = test_clock();
+        let mut registry = GrantRegistry::new(
+            clock.clone(),
+            test_policy_gen(),
+            test_policy_digest(),
+            300,
+            test_actions(),
+            10,
+            Some(gate.clone()),
+        );
+
+        let session = test_session_id();
+        let authority = super::super::intent::admin_authority();
+
+        let req_id = registry
+            .request_dynamic_grant(GrantRequestParams {
+                profile_id: test_profile_id(),
+                session_id: session.clone(),
+                endpoint_id: test_endpoint_id(),
+                principal_digest: test_digest(1000),
+                rp_ids: vec!["example.com".to_string()],
+                credentials: vec![],
+                requested_ttl_secs: 60,
+            })
+            .unwrap();
+
+        let _gid = registry.approve_grant(&req_id, &authority).unwrap();
+
+        let entry_count = gate.verify_all().unwrap();
+        assert_eq!(
+            entry_count, 2,
+            "expected 2 audit records (request + approve)"
+        );
     }
 }

--- a/cmd/passless/src/agent/launcher.rs
+++ b/cmd/passless/src/agent/launcher.rs
@@ -756,7 +756,7 @@ impl HardenedChildSetup {
     }
 }
 
-unsafe fn close_range_preserving(preserved: &[RawFd]) -> Result<(), io::Error> {
+pub(crate) unsafe fn close_range_preserving(preserved: &[RawFd]) -> Result<(), io::Error> {
     let mut sorted: Vec<RawFd> = preserved.to_vec();
     sorted.sort_unstable();
     sorted.dedup();

--- a/cmd/passless/src/agent/policy_engine.rs
+++ b/cmd/passless/src/agent/policy_engine.rs
@@ -11,6 +11,7 @@ use passless_core::agent::{
     PolicyDigest, PolicyGenerationId, PolicyParams, PrincipalSessionId, ProfileId,
 };
 
+use super::audit::AuditGate;
 use super::browser::Clock;
 use super::grant::{
     CeremonyId, ClaimIntent, GrantError, GrantRegistry, GrantRequestId, GrantRequestParams,
@@ -630,6 +631,7 @@ pub struct PolicyRuntime {
     pending: Mutex<HashMap<String, PendingAuthorization>>,
     pending_requests: Mutex<HashMap<String, PendingPrincipalRequest>>,
     clock: Arc<dyn Clock>,
+    audit_gate: Option<Arc<AuditGate>>,
 }
 
 impl PolicyRuntime {
@@ -637,6 +639,7 @@ impl PolicyRuntime {
         config: &AgentConfig,
         clock: Arc<dyn Clock>,
         monotonic_clock: Arc<dyn MonotonicClock>,
+        audit_gate: Option<Arc<AuditGate>>,
     ) -> Result<Self, PolicyRuntimeError> {
         let generation = Self::compile_generation(config, clock.monotonic_secs())?;
         let gen_arc = Arc::new(generation);
@@ -654,6 +657,7 @@ impl PolicyRuntime {
                 snapshot.max_grant_ttl_secs,
                 snapshot.allowed_actions.clone(),
                 snapshot.max_concurrent_grants,
+                audit_gate.clone(),
             );
             grant_registries.insert(snapshot.profile_id.as_str().to_string(), registry);
         }
@@ -666,6 +670,7 @@ impl PolicyRuntime {
             pending: Mutex::new(HashMap::new()),
             pending_requests: Mutex::new(HashMap::new()),
             clock,
+            audit_gate,
         })
     }
 
@@ -1052,6 +1057,7 @@ impl PolicyRuntime {
                 snapshot.max_grant_ttl_secs,
                 snapshot.allowed_actions.clone(),
                 snapshot.max_concurrent_grants,
+                self.audit_gate.clone(),
             );
             new_registries.insert(snapshot.profile_id.as_str().to_string(), registry);
         }
@@ -2399,7 +2405,7 @@ mod tests {
 
     fn make_runtime(config: &AgentConfig) -> (PolicyRuntime, Arc<MockClock>) {
         let clock = test_clock();
-        let runtime = PolicyRuntime::new(config, clock.clone(), clock.clone()).unwrap();
+        let runtime = PolicyRuntime::new(config, clock.clone(), clock.clone(), None).unwrap();
         (runtime, clock)
     }
 

--- a/cmd/passless/src/agent/prompt.rs
+++ b/cmd/passless/src/agent/prompt.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use log::{debug, info, warn};
@@ -7,6 +6,12 @@ use notify_rust::{Notification, Timeout, Urgency};
 use serde::{Deserialize, Serialize};
 
 use passless_core::agent::{CredentialRef, ProfileId};
+
+#[cfg(test)]
+use std::sync::Mutex;
+
+const NOTIFICATIONS_WELL_KNOWN_NAME: &str = "org.freedesktop.Notifications";
+const NOTIFICATIONS_IFACE: &str = "org.freedesktop.Notifications";
 
 const MAX_UNTRUSTED_LEN: usize = 256;
 const MAX_RP_ID_LEN: usize = 253;
@@ -498,6 +503,157 @@ pub fn query_server_capabilities() -> ServerCapability {
     }
 }
 
+fn resolve_notification_server_unique_name() -> Result<String, PromptError> {
+    let conn = zbus::blocking::Connection::session().map_err(|e| {
+        warn!(
+            "Prompt: failed to connect to session bus for sender validation: {}",
+            e
+        );
+        PromptError {
+            kind: PromptErrorKind::NotificationUnsupported,
+        }
+    })?;
+
+    let reply = conn
+        .call_method(
+            Some("org.freedesktop.DBus"),
+            "/org/freedesktop/DBus",
+            Some("org.freedesktop.DBus"),
+            "GetNameOwner",
+            &NOTIFICATIONS_WELL_KNOWN_NAME,
+        )
+        .map_err(|e| {
+            warn!(
+                "Prompt: failed to resolve notification server unique name: {}",
+                e
+            );
+            PromptError {
+                kind: PromptErrorKind::NotificationUnsupported,
+            }
+        })?;
+
+    let unique_name: String = reply.body().deserialize().map_err(|e| {
+        warn!("Prompt: failed to deserialize GetNameOwner reply: {}", e);
+        PromptError {
+            kind: PromptErrorKind::InternalError,
+        }
+    })?;
+
+    debug!("Prompt: notification server unique name: {}", unique_name);
+    Ok(unique_name)
+}
+
+enum ValidatedAction {
+    Action(String),
+    Closed,
+}
+
+fn wait_for_validated_action(
+    server_unique_name: &str,
+    notification_id: u32,
+    timeout: Duration,
+) -> ValidatedAction {
+    let conn = match zbus::blocking::Connection::session() {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(
+                "Prompt: failed to connect to session bus for signal subscription: {}",
+                e
+            );
+            return ValidatedAction::Closed;
+        }
+    };
+
+    let rule = match zbus::MatchRule::builder()
+        .msg_type(zbus::message::Type::Signal)
+        .sender(server_unique_name)
+        .and_then(|b| b.interface(NOTIFICATIONS_IFACE))
+    {
+        Ok(builder) => builder.build(),
+        Err(e) => {
+            warn!("Prompt: failed to build match rule: {}", e);
+            return ValidatedAction::Closed;
+        }
+    };
+
+    let mut iter = match zbus::blocking::MessageIterator::for_match_rule(rule, &conn, Some(16)) {
+        Ok(iter) => iter,
+        Err(e) => {
+            warn!("Prompt: failed to subscribe to signals: {}", e);
+            return ValidatedAction::Closed;
+        }
+    };
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    let deadline = Instant::now() + timeout;
+
+    let server_unique_name_owned = server_unique_name.to_string();
+    let thread = std::thread::spawn(move || {
+        for msg in &mut iter {
+            let msg = match msg {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            let header = msg.header();
+            let sender = match header.sender() {
+                Some(s) => s.to_string(),
+                None => continue,
+            };
+            if sender != server_unique_name_owned {
+                debug!(
+                    "Prompt: rejecting signal from unexpected sender: {}",
+                    sender
+                );
+                continue;
+            }
+            let member = match header.member() {
+                Some(m) => m.to_string(),
+                None => continue,
+            };
+            match member.as_str() {
+                "ActionInvoked" => {
+                    let body: Result<(u32, String), _> = msg.body().deserialize();
+                    if let Ok((id, action_key)) = body
+                        && id == notification_id
+                    {
+                        let _ = tx.send(ValidatedAction::Action(action_key));
+                        return;
+                    }
+                }
+                "NotificationClosed" => {
+                    let body: Result<(u32, u32), _> = msg.body().deserialize();
+                    if let Ok((id, _reason)) = body
+                        && id == notification_id
+                    {
+                        let _ = tx.send(ValidatedAction::Closed);
+                        return;
+                    }
+                }
+                _ => {}
+            }
+        }
+    });
+
+    let now = Instant::now();
+    let remaining = if now < deadline {
+        deadline - now
+    } else {
+        Duration::from_millis(0)
+    };
+
+    let result = rx.recv_timeout(remaining);
+
+    drop(rx);
+    drop(conn);
+    let _ = thread.join();
+
+    match result {
+        Ok(action) => action,
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => ValidatedAction::Closed,
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => ValidatedAction::Closed,
+    }
+}
+
 pub trait PromptHandle: Send + Sync {
     fn prompt(&self, request: &PromptRequest) -> PromptResult;
 }
@@ -596,11 +752,20 @@ impl PromptHandle for DesktopPromptHandle {
             ServerCapability::FullActions => {}
         }
 
+        let server_unique_name = match resolve_notification_server_unique_name() {
+            Ok(name) => name,
+            Err(e) => {
+                warn!(
+                    "Prompt: failed to resolve notification server unique name: {}",
+                    e
+                );
+                return PromptResult::error(e.kind, start.elapsed().as_millis() as u64);
+            }
+        };
+
         let title = build_security_title(request.action());
         let body = build_security_body(request);
 
-        let action_result = Arc::new(Mutex::new(None));
-        let action_result_clone = Arc::clone(&action_result);
         let show_start = Instant::now();
 
         let mut notification = Notification::new();
@@ -624,20 +789,17 @@ impl PromptHandle for DesktopPromptHandle {
             }
         };
 
-        handle.wait_for_action(|action| {
-            debug!("Prompt: user action received: {}", action);
-            let mut result = action_result_clone
-                .lock()
-                .expect("prompt action result lock poisoned");
-            *result = Some(action.to_string());
-        });
+        let notification_id = handle.id();
+        let timeout_duration = Duration::from_secs(self.timeout_secs);
+
+        let validated_action =
+            wait_for_validated_action(&server_unique_name, notification_id, timeout_duration);
 
         let elapsed_since_show = show_start.elapsed();
-        let action = action_result
-            .lock()
-            .expect("prompt action result lock poisoned")
-            .clone()
-            .unwrap_or_else(|| "__closed".to_string());
+        let action = match validated_action {
+            ValidatedAction::Action(a) => a,
+            ValidatedAction::Closed => "__closed".to_string(),
+        };
 
         let decision = match action.as_str() {
             "approve" => {

--- a/cmd/passless/src/agent/register.rs
+++ b/cmd/passless/src/agent/register.rs
@@ -708,7 +708,7 @@ mod tests {
             let mono_clock = Arc::new(MockMonoClock::new());
 
             let policy_runtime = Arc::new(
-                PolicyRuntime::new(&agent_config, clock.clone(), mono_clock.clone()).unwrap(),
+                PolicyRuntime::new(&agent_config, clock.clone(), mono_clock.clone(), None).unwrap(),
             );
 
             let mut registration_grants = HashMap::new();
@@ -847,8 +847,9 @@ mod tests {
         let clock = Arc::new(MockClock::new());
         let mono_clock = Arc::new(MockMonoClock::new());
 
-        let policy_runtime =
-            Arc::new(PolicyRuntime::new(&agent_config, clock.clone(), mono_clock.clone()).unwrap());
+        let policy_runtime = Arc::new(
+            PolicyRuntime::new(&agent_config, clock.clone(), mono_clock.clone(), None).unwrap(),
+        );
 
         let mut registration_grants = HashMap::new();
         registration_grants.insert(

--- a/cmd/passless/src/agent/runtime.rs
+++ b/cmd/passless/src/agent/runtime.rs
@@ -535,7 +535,7 @@ pub struct AgentRuntime {
     sign_server_shutdown: Arc<AtomicBool>,
     sign_server_handle: Mutex<Option<JoinHandle<()>>>,
     #[allow(dead_code)]
-    sign_port: u16,
+    sign_socket_path: std::path::PathBuf,
 }
 
 impl AgentRuntime {
@@ -973,11 +973,21 @@ impl AgentRuntime {
 
         let sign_registry = Arc::new(SignContextRegistry::new());
         let sign_server_shutdown = Arc::new(AtomicBool::new(false));
-        let sign_server = SignHttpServer::bind(sign_server_shutdown.clone()).map_err(|e| {
-            RuntimeError::Service(format!("failed to bind sign HTTP server: {}", e))
-        })?;
-        let sign_port = sign_server.port();
-        info!("Sign HTTP server listening on 127.0.0.1:{}", sign_port);
+        let sign_socket_base = dirs::runtime_dir()
+            .or_else(|| {
+                let uid = unsafe { libc::getuid() };
+                Some(PathBuf::from(format!("/tmp/passless-agent-{}", uid)))
+            })
+            .ok_or_else(|| RuntimeError::Config("cannot resolve runtime directory".into()))?;
+        let sign_socket_path = sign_socket_base.join("agent").join("sign").join("sock");
+        let sign_server =
+            SignHttpServer::bind(sign_socket_path.clone(), sign_server_shutdown.clone()).map_err(
+                |e| RuntimeError::Service(format!("failed to bind sign HTTP server: {}", e)),
+            )?;
+        info!(
+            "Sign HTTP server listening on {}",
+            sign_socket_path.display()
+        );
         let sign_server_handle = sign_server.serve(sign_registry.clone());
 
         let endpoint_manager = Mutex::new(EndpointManager::new(
@@ -1213,7 +1223,7 @@ impl AgentRuntime {
             sign_registry,
             sign_server_shutdown,
             sign_server_handle: Mutex::new(Some(sign_server_handle)),
-            sign_port,
+            sign_socket_path,
         });
 
         let runtime_for_loop = Arc::clone(&runtime);
@@ -5032,7 +5042,7 @@ impl AgentRuntime {
             })?;
 
         let metadata = super::browser::AgentEndpointMetadata {
-            port: self.sign_port,
+            socket_path: self.sign_socket_path.to_string_lossy().into_owned(),
             bearer_token: bearer_token.clone(),
         };
 
@@ -6333,9 +6343,13 @@ mod tests {
 
         let sign_registry = Arc::new(SignContextRegistry::new());
         let sign_server_shutdown = Arc::new(AtomicBool::new(false));
+        let sign_socket_path = std::env::temp_dir()
+            .join("passless-test")
+            .join(format!("sign-{}", std::process::id()))
+            .join("sock");
         let sign_server =
-            SignHttpServer::bind(sign_server_shutdown.clone()).expect("bind sign server");
-        let sign_port = sign_server.port();
+            SignHttpServer::bind(sign_socket_path.clone(), sign_server_shutdown.clone())
+                .expect("bind sign server");
         let sign_server_handle = sign_server.serve(sign_registry.clone());
 
         let runtime = Arc::new(AgentRuntime {
@@ -6364,7 +6378,7 @@ mod tests {
             sign_registry,
             sign_server_shutdown,
             sign_server_handle: Mutex::new(Some(sign_server_handle)),
-            sign_port,
+            sign_socket_path,
         });
 
         let profile = runtime.profiles.get(&profile_id).unwrap();

--- a/cmd/passless/src/agent/runtime.rs
+++ b/cmd/passless/src/agent/runtime.rs
@@ -601,9 +601,13 @@ impl AgentRuntime {
         let _ = audit_gate.record(start_event);
 
         let policy_runtime = Arc::new(
-            PolicyRuntime::new(agent_config, clock.clone(), monotonic_clock.clone()).map_err(
-                |e| RuntimeError::Policy(format!("failed to create policy runtime: {}", e)),
-            )?,
+            PolicyRuntime::new(
+                agent_config,
+                clock.clone(),
+                monotonic_clock.clone(),
+                Some(audit_gate.clone()),
+            )
+            .map_err(|e| RuntimeError::Policy(format!("failed to create policy runtime: {}", e)))?,
         );
 
         let browser_manager =
@@ -6015,6 +6019,7 @@ mod tests {
                         &config,
                         clock,
                         monotonic_clock,
+                        None,
                     )
                     .unwrap(),
                 )
@@ -6254,6 +6259,7 @@ mod tests {
                 &agent_config,
                 clock.clone(),
                 monotonic_clock.clone(),
+                None,
             )
             .unwrap(),
         );

--- a/cmd/passless/src/agent/runtime/browser_ensure.rs
+++ b/cmd/passless/src/agent/runtime/browser_ensure.rs
@@ -281,7 +281,7 @@ impl AgentRuntime {
             })?;
 
         let metadata = crate::agent::browser::AgentEndpointMetadata {
-            port: self.sign_port,
+            socket_path: self.sign_socket_path.to_string_lossy().into_owned(),
             bearer_token: bearer_token.clone(),
         };
         let lease_id = match browser_manager.launch_pending_with_agent_endpoint(

--- a/cmd/passless/src/agent/sign.rs
+++ b/cmd/passless/src/agent/sign.rs
@@ -2202,7 +2202,7 @@ mod tests {
             panic!("expected WaitFor");
         };
         {
-            let mut guard = InFlightGuard::new(budget.clone(), digest);
+            let guard = InFlightGuard::new(budget.clone(), digest);
             drop(guard);
         }
         let outcome = entry
@@ -3138,7 +3138,8 @@ mod tests {
                 let mono_clock = Arc::new(MockMonoClock::new());
 
                 let policy_runtime = Arc::new(
-                    PolicyRuntime::new(&agent_config, clock.clone(), mono_clock.clone()).unwrap(),
+                    PolicyRuntime::new(&agent_config, clock.clone(), mono_clock.clone(), None)
+                        .unwrap(),
                 );
 
                 let session_id = passless_core::agent::PrincipalSessionId::new();
@@ -3563,7 +3564,7 @@ mod tests {
         };
 
         use std::collections::BTreeMap;
-        use std::sync::{Arc, Condvar, Mutex};
+        use std::sync::{Arc, Mutex};
         use std::time::Duration;
 
         const FRAME_MAGIC: u32 = 0x41554449;
@@ -3730,7 +3731,8 @@ mod tests {
                 let mono_clock = Arc::new(MockMonoClock::new());
 
                 let policy_runtime = Arc::new(
-                    PolicyRuntime::new(&agent_config, clock.clone(), mono_clock.clone()).unwrap(),
+                    PolicyRuntime::new(&agent_config, clock.clone(), mono_clock.clone(), None)
+                        .unwrap(),
                 );
 
                 let session_id = passless_core::agent::PrincipalSessionId::new();

--- a/cmd/passless/src/agent/sign.rs
+++ b/cmd/passless/src/agent/sign.rs
@@ -4,9 +4,9 @@ use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use log::{debug, warn};
 use sha2::{Digest, Sha256};
@@ -240,15 +240,195 @@ pub fn generate_bearer_token() -> Result<String, String> {
     Ok(b64u_encode(&bytes))
 }
 
+#[derive(Debug, Clone)]
+struct InFlightOutcome {
+    status: &'static str,
+    body: Vec<u8>,
+}
+
+#[derive(Debug)]
+enum InFlightState {
+    Pending,
+    Resolved(InFlightOutcome),
+}
+
+#[derive(Debug)]
+struct InFlightEntry {
+    state: Mutex<InFlightState>,
+    done: Condvar,
+}
+
+impl InFlightEntry {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(InFlightState::Pending),
+            done: Condvar::new(),
+        }
+    }
+
+    fn resolve(&self, outcome: InFlightOutcome) {
+        let mut s = match self.state.lock() {
+            Ok(g) => g,
+            Err(_) => return,
+        };
+        *s = InFlightState::Resolved(outcome);
+        self.done.notify_all();
+    }
+
+    fn wait(&self, timeout: Duration) -> Option<InFlightOutcome> {
+        let guard = match self.state.lock() {
+            Ok(g) => g,
+            Err(_) => return None,
+        };
+        let (guard, timed_out) = match self
+            .done
+            .wait_timeout_while(guard, timeout, |s| matches!(s, InFlightState::Pending))
+        {
+            Ok(pair) => pair,
+            Err(_) => return None,
+        };
+        if timed_out.timed_out() {
+            return None;
+        }
+        match &*guard {
+            InFlightState::Resolved(o) => Some(o.clone()),
+            InFlightState::Pending => None,
+        }
+    }
+}
+
+// Completed-outcome cache: some relying parties (e.g. Kanidm) submit the same
+// WebAuthn request body more than once for a single user gesture. The first
+// request is signed; an identical follow-up must receive the SAME outcome rather
+// than a `replayed_operation` rejection, otherwise the user-facing ceremony fails.
+//
+// Safety: a cached outcome is returned without re-signing, so the sign counter is
+// incremented exactly once and no new signature is produced. The real replay
+// defence remains the relying party's one-time challenge. After the TTL elapses an
+// identical body is rejected as `Replayed` as before.
+const COMPLETED_OUTCOME_TTL: Duration = Duration::from_secs(120);
+const MAX_COMPLETED_OUTCOMES: usize = 256;
+
+struct CompletedOutcome {
+    outcome: InFlightOutcome,
+    at: Instant,
+}
+
+struct RequestBudgetInner {
+    used: HashSet<[u8; 32]>,
+    in_flight: HashMap<[u8; 32], Arc<InFlightEntry>>,
+    completed: HashMap<[u8; 32], CompletedOutcome>,
+}
+
 #[derive(Clone)]
 struct RequestBudget {
-    used_requests: Arc<Mutex<HashSet<[u8; 32]>>>,
+    inner: Arc<Mutex<RequestBudgetInner>>,
     max_requests: usize,
 }
 
 impl RequestBudget {
     fn claim(&self, body: &[u8]) -> RequestClaim {
-        claim_request_digest(&self.used_requests, self.max_requests, body)
+        let hash = Sha256::digest(body);
+        let mut digest = [0u8; 32];
+        digest.copy_from_slice(&hash);
+
+        let mut inner = match self.inner.lock() {
+            Ok(g) => g,
+            Err(_) => return RequestClaim::Unavailable,
+        };
+
+        if inner.used.contains(&digest) {
+            if let Some(entry) = inner.in_flight.get(&digest) {
+                return RequestClaim::WaitFor(entry.clone());
+            }
+            let now = Instant::now();
+            if let Some(completed) = inner.completed.get(&digest)
+                && now.duration_since(completed.at) <= COMPLETED_OUTCOME_TTL
+            {
+                return RequestClaim::Cached {
+                    outcome: completed.outcome.clone(),
+                };
+            }
+            return RequestClaim::Replayed;
+        }
+
+        if inner.used.len() >= self.max_requests {
+            return RequestClaim::Exhausted;
+        }
+
+        inner.used.insert(digest);
+        let entry = Arc::new(InFlightEntry::new());
+        inner.in_flight.insert(digest, entry);
+        RequestClaim::Claimed { digest }
+    }
+
+    fn resolve(&self, digest: [u8; 32], outcome: InFlightOutcome) {
+        let entry = {
+            let mut inner = match self.inner.lock() {
+                Ok(g) => g,
+                Err(_) => return,
+            };
+            let entry = inner.in_flight.remove(&digest);
+            let now = Instant::now();
+            inner
+                .completed
+                .retain(|_, completed| now.duration_since(completed.at) <= COMPLETED_OUTCOME_TTL);
+            if inner.completed.len() >= MAX_COMPLETED_OUTCOMES
+                && let Some(oldest) = inner
+                    .completed
+                    .iter()
+                    .min_by_key(|(_, completed)| completed.at)
+                    .map(|(digest, _)| *digest)
+            {
+                inner.completed.remove(&oldest);
+            }
+            inner.completed.insert(
+                digest,
+                CompletedOutcome {
+                    outcome: outcome.clone(),
+                    at: now,
+                },
+            );
+            entry
+        };
+        if let Some(entry) = entry {
+            entry.resolve(outcome);
+        }
+    }
+}
+
+struct InFlightGuard {
+    budget: RequestBudget,
+    digest: [u8; 32],
+    resolved: bool,
+}
+
+impl InFlightGuard {
+    fn new(budget: RequestBudget, digest: [u8; 32]) -> Self {
+        Self {
+            budget,
+            digest,
+            resolved: false,
+        }
+    }
+
+    fn resolve(&mut self, outcome: InFlightOutcome) {
+        self.budget.resolve(self.digest, outcome);
+        self.resolved = true;
+    }
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        if !self.resolved {
+            self.budget.resolve(
+                self.digest,
+                InFlightOutcome {
+                    status: "500 Internal Server Error",
+                    body: b"{\"error\":\"internal_error\"}".to_vec(),
+                },
+            );
+        }
     }
 }
 
@@ -285,33 +465,14 @@ impl RegistrationLeaseEntry {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 enum RequestClaim {
-    Claimed,
+    Claimed { digest: [u8; 32] },
     Replayed,
     Exhausted,
     Unavailable,
-}
-
-fn claim_request_digest(
-    registry: &Mutex<HashSet<[u8; 32]>>,
-    max_requests: usize,
-    body: &[u8],
-) -> RequestClaim {
-    let hash = Sha256::digest(body);
-    let mut digest = [0u8; 32];
-    digest.copy_from_slice(&hash);
-    let Ok(mut used) = registry.lock() else {
-        return RequestClaim::Unavailable;
-    };
-    if used.contains(&digest) {
-        return RequestClaim::Replayed;
-    }
-    if used.len() >= max_requests {
-        return RequestClaim::Exhausted;
-    }
-    used.insert(digest);
-    RequestClaim::Claimed
+    WaitFor(Arc<InFlightEntry>),
+    Cached { outcome: InFlightOutcome },
 }
 
 impl SignContextRegistry {
@@ -335,7 +496,11 @@ impl SignContextRegistry {
             return Ok(existing.clone());
         }
         let budget = RequestBudget {
-            used_requests: Arc::new(Mutex::new(HashSet::new())),
+            inner: Arc::new(Mutex::new(RequestBudgetInner {
+                used: HashSet::new(),
+                in_flight: HashMap::new(),
+                completed: HashMap::new(),
+            })),
             max_requests,
         };
         budgets.insert(token.to_string(), budget.clone());
@@ -525,7 +690,7 @@ impl SignContextRegistry {
                 .find(|entry| entry.lease_id.as_deref() == Some(lease_id))?;
             entry.request_budget.clone()
         };
-        let used = budget.used_requests.lock().ok()?.len();
+        let used = budget.inner.lock().ok()?.used.len();
         Some((used, budget.max_requests))
     }
 
@@ -806,7 +971,35 @@ fn handle_http_connection(
                     return Ok(());
                 }
                 match reg_entry.claim_request(&body) {
-                    RequestClaim::Claimed => {}
+                    RequestClaim::Claimed { digest } => {
+                        let mut guard =
+                            InFlightGuard::new(reg_entry.request_budget.clone(), digest);
+                        let outcome = handle_register_body(&mut stream, &reg_entry, &body)?;
+                        guard.resolve(outcome);
+                    }
+                    RequestClaim::WaitFor(in_flight) => {
+                        match in_flight.wait(Duration::from_secs(30)) {
+                            Some(outcome) => {
+                                send_sign_response(
+                                    &mut stream,
+                                    outcome.status,
+                                    Some(&outcome.body),
+                                );
+                            }
+                            None => {
+                                send_sign_error(
+                                    &mut stream,
+                                    "500 Internal Server Error",
+                                    "operation_timeout",
+                                );
+                            }
+                        }
+                        return Ok(());
+                    }
+                    RequestClaim::Cached { outcome } => {
+                        send_sign_response(&mut stream, outcome.status, Some(&outcome.body));
+                        return Ok(());
+                    }
                     RequestClaim::Replayed => {
                         send_sign_error(&mut stream, "409 Conflict", "replayed_operation");
                         return Ok(());
@@ -826,34 +1019,6 @@ fn handle_http_connection(
                             "operation_registry_unavailable",
                         );
                         return Ok(());
-                    }
-                }
-                let req: RegisterCredentialRequest = match serde_json::from_slice(&body) {
-                    Ok(r) => r,
-                    Err(_) => {
-                        send_sign_error(&mut stream, "400 Bad Request", "invalid_json");
-                        return Ok(());
-                    }
-                };
-                match reg_entry.handler.register(&reg_entry.context, &req) {
-                    Ok(resp) => {
-                        let resp_body = serde_json::to_vec(&resp)
-                            .map_err(|e| format!("json serialize: {}", e))?;
-                        send_sign_response(&mut stream, "200 OK", Some(&resp_body));
-                    }
-                    Err(e) => {
-                        let (status, code) = match e.code {
-                            ErrorCode::BadRequest => ("400 Bad Request", "bad_request"),
-                            ErrorCode::Unauthorized => ("401 Unauthorized", "unauthorized"),
-                            ErrorCode::Forbidden => ("403 Forbidden", "forbidden"),
-                            ErrorCode::NotFound => ("404 Not Found", "not_found"),
-                            ErrorCode::Conflict => ("409 Conflict", "conflict"),
-                            ErrorCode::InteractionRequired => {
-                                ("409 Conflict", "human_interaction_required")
-                            }
-                            _ => ("500 Internal Server Error", "internal_error"),
-                        };
-                        send_sign_error(&mut stream, status, code);
                     }
                 }
                 return Ok(());
@@ -913,7 +1078,30 @@ fn handle_http_connection(
         return Ok(());
     }
     match entry.claim_request(&body) {
-        RequestClaim::Claimed => {}
+        RequestClaim::Claimed { digest } => {
+            let mut guard = InFlightGuard::new(entry.request_budget.clone(), digest);
+            let outcome = handle_sign_body(&mut stream, &entry, &body)?;
+            guard.resolve(outcome);
+        }
+        RequestClaim::WaitFor(in_flight) => {
+            match in_flight.wait(Duration::from_secs(30)) {
+                Some(outcome) => {
+                    send_sign_response(&mut stream, outcome.status, Some(&outcome.body));
+                }
+                None => {
+                    send_sign_error(
+                        &mut stream,
+                        "500 Internal Server Error",
+                        "operation_timeout",
+                    );
+                }
+            }
+            return Ok(());
+        }
+        RequestClaim::Cached { outcome } => {
+            send_sign_response(&mut stream, outcome.status, Some(&outcome.body));
+            return Ok(());
+        }
         RequestClaim::Replayed => {
             send_sign_error(&mut stream, "409 Conflict", "replayed_operation");
             return Ok(());
@@ -935,33 +1123,97 @@ fn handle_http_connection(
             return Ok(());
         }
     }
-    let req: SignAssertionRequest = match serde_json::from_slice(&body) {
+    Ok(())
+}
+
+fn handle_sign_body(
+    stream: &mut UnixStream,
+    entry: &LeaseEntry,
+    body: &[u8],
+) -> Result<InFlightOutcome, String> {
+    let req: SignAssertionRequest = match serde_json::from_slice(body) {
         Ok(r) => r,
         Err(_) => {
-            send_sign_error(&mut stream, "400 Bad Request", "invalid_json");
-            return Ok(());
+            let outcome = InFlightOutcome {
+                status: "400 Bad Request",
+                body: b"{\"error\":\"invalid_json\"}".to_vec(),
+            };
+            send_sign_response(stream, outcome.status, Some(&outcome.body));
+            return Ok(outcome);
         }
     };
-    match entry.handler.sign(&entry.context, &req) {
+    let outcome = match entry.handler.sign(&entry.context, &req) {
         Ok(resp) => {
             let resp_body =
                 serde_json::to_vec(&resp).map_err(|e| format!("json serialize: {}", e))?;
-            send_sign_response(&mut stream, "200 OK", Some(&resp_body));
+            send_sign_response(stream, "200 OK", Some(&resp_body));
+            InFlightOutcome {
+                status: "200 OK",
+                body: resp_body,
+            }
         }
         Err(e) => {
-            let (status, code) = match e.code {
-                ErrorCode::BadRequest => ("400 Bad Request", "bad_request"),
-                ErrorCode::Unauthorized => ("401 Unauthorized", "unauthorized"),
-                ErrorCode::Forbidden => ("403 Forbidden", "forbidden"),
-                ErrorCode::NotFound => ("404 Not Found", "not_found"),
-                ErrorCode::Conflict => ("409 Conflict", "conflict"),
-                ErrorCode::InteractionRequired => ("409 Conflict", "human_interaction_required"),
-                _ => ("500 Internal Server Error", "internal_error"),
-            };
-            send_sign_error(&mut stream, status, code);
+            let (status, code) = error_status_code(e.code);
+            let err_body = format!("{{\"error\":\"{}\"}}", code).into_bytes();
+            send_sign_response(stream, status, Some(&err_body));
+            InFlightOutcome {
+                status,
+                body: err_body,
+            }
         }
+    };
+    Ok(outcome)
+}
+
+fn handle_register_body(
+    stream: &mut UnixStream,
+    reg_entry: &RegistrationLeaseEntry,
+    body: &[u8],
+) -> Result<InFlightOutcome, String> {
+    let req: RegisterCredentialRequest = match serde_json::from_slice(body) {
+        Ok(r) => r,
+        Err(_) => {
+            let outcome = InFlightOutcome {
+                status: "400 Bad Request",
+                body: b"{\"error\":\"invalid_json\"}".to_vec(),
+            };
+            send_sign_response(stream, outcome.status, Some(&outcome.body));
+            return Ok(outcome);
+        }
+    };
+    let outcome = match reg_entry.handler.register(&reg_entry.context, &req) {
+        Ok(resp) => {
+            let resp_body =
+                serde_json::to_vec(&resp).map_err(|e| format!("json serialize: {}", e))?;
+            send_sign_response(stream, "200 OK", Some(&resp_body));
+            InFlightOutcome {
+                status: "200 OK",
+                body: resp_body,
+            }
+        }
+        Err(e) => {
+            let (status, code) = error_status_code(e.code);
+            let err_body = format!("{{\"error\":\"{}\"}}", code).into_bytes();
+            send_sign_response(stream, status, Some(&err_body));
+            InFlightOutcome {
+                status,
+                body: err_body,
+            }
+        }
+    };
+    Ok(outcome)
+}
+
+fn error_status_code(code: ErrorCode) -> (&'static str, &'static str) {
+    match code {
+        ErrorCode::BadRequest => ("400 Bad Request", "bad_request"),
+        ErrorCode::Unauthorized => ("401 Unauthorized", "unauthorized"),
+        ErrorCode::Forbidden => ("403 Forbidden", "forbidden"),
+        ErrorCode::NotFound => ("404 Not Found", "not_found"),
+        ErrorCode::Conflict => ("409 Conflict", "conflict"),
+        ErrorCode::InteractionRequired => ("409 Conflict", "human_interaction_required"),
+        _ => ("500 Internal Server Error", "internal_error"),
     }
-    Ok(())
 }
 
 #[derive(Clone)]
@@ -1805,11 +2057,221 @@ mod tests {
         let first = registry.request_budget(&token, 2).unwrap();
         let second = registry.request_budget(&token, 2).unwrap();
 
-        assert_eq!(first.claim(b"register-operation"), RequestClaim::Claimed);
-        assert_eq!(second.claim(b"register-operation"), RequestClaim::Replayed);
-        assert_eq!(second.claim(b"sign-operation"), RequestClaim::Claimed);
-        assert_eq!(first.claim(b"third-operation"), RequestClaim::Exhausted);
+        assert!(matches!(
+            first.claim(b"register-operation"),
+            RequestClaim::Claimed { .. }
+        ));
+        assert!(matches!(
+            second.claim(b"register-operation"),
+            RequestClaim::WaitFor(_)
+        ));
+        assert!(matches!(
+            second.claim(b"sign-operation"),
+            RequestClaim::Claimed { .. }
+        ));
+        assert!(matches!(
+            first.claim(b"third-operation"),
+            RequestClaim::Exhausted
+        ));
         assert!(registry.request_budget(&token, 3).is_err());
+    }
+
+    fn make_budget(max_requests: usize) -> RequestBudget {
+        RequestBudget {
+            inner: Arc::new(Mutex::new(RequestBudgetInner {
+                used: HashSet::new(),
+                in_flight: HashMap::new(),
+                completed: HashMap::new(),
+            })),
+            max_requests,
+        }
+    }
+
+    #[test]
+    fn test_claim_duplicate_in_flight_returns_wait_for() {
+        let budget = make_budget(5);
+        let body = b"identical-request-body";
+        let first = budget.claim(body);
+        assert!(matches!(first, RequestClaim::Claimed { .. }));
+        let second = budget.claim(body);
+        assert!(matches!(second, RequestClaim::WaitFor(_)));
+
+        let RequestClaim::Claimed { digest } = first else {
+            panic!("expected Claimed");
+        };
+        budget.resolve(
+            digest,
+            InFlightOutcome {
+                status: "200 OK",
+                body: b"result".to_vec(),
+            },
+        );
+
+        let third = budget.claim(body);
+        assert!(matches!(third, RequestClaim::Cached { .. }));
+    }
+
+    #[test]
+    fn test_completed_expired_returns_replayed() {
+        let budget = make_budget(5);
+        let body = b"expired-body";
+        let RequestClaim::Claimed { digest } = budget.claim(body) else {
+            panic!("expected Claimed");
+        };
+        budget.resolve(
+            digest,
+            InFlightOutcome {
+                status: "200 OK",
+                body: b"ok".to_vec(),
+            },
+        );
+        {
+            let mut inner = budget.inner.lock().unwrap();
+            if let Some(completed) = inner.completed.get_mut(&digest) {
+                completed.at = Instant::now() - COMPLETED_OUTCOME_TTL - Duration::from_secs(1);
+            }
+        }
+        assert!(matches!(budget.claim(body), RequestClaim::Replayed));
+    }
+
+    #[test]
+    fn test_claim_different_bodies_both_claimed() {
+        let budget = make_budget(5);
+        assert!(matches!(
+            budget.claim(b"body-a"),
+            RequestClaim::Claimed { .. }
+        ));
+        assert!(matches!(
+            budget.claim(b"body-b"),
+            RequestClaim::Claimed { .. }
+        ));
+    }
+
+    #[test]
+    fn test_claim_budget_exhausted() {
+        let budget = make_budget(2);
+        assert!(matches!(budget.claim(b"one"), RequestClaim::Claimed { .. }));
+        assert!(matches!(budget.claim(b"two"), RequestClaim::Claimed { .. }));
+        assert!(matches!(budget.claim(b"three"), RequestClaim::Exhausted));
+    }
+
+    #[test]
+    fn test_in_flight_waiter_receives_resolved_outcome() {
+        let budget = make_budget(5);
+        let body = b"shared-body";
+        let RequestClaim::Claimed { digest } = budget.claim(body) else {
+            panic!("expected Claimed");
+        };
+        let RequestClaim::WaitFor(entry) = budget.claim(body) else {
+            panic!("expected WaitFor");
+        };
+
+        let waiter = std::thread::spawn(move || entry.wait(Duration::from_secs(5)));
+        std::thread::sleep(Duration::from_millis(50));
+        budget.resolve(
+            digest,
+            InFlightOutcome {
+                status: "403 Forbidden",
+                body: b"{\"error\":\"forbidden\"}".to_vec(),
+            },
+        );
+        let outcome = waiter.join().unwrap().expect("waiter should resolve");
+        assert_eq!(outcome.status, "403 Forbidden");
+        assert_eq!(outcome.body, b"{\"error\":\"forbidden\"}");
+    }
+
+    #[test]
+    fn test_in_flight_waiter_timeout_returns_none() {
+        let budget = make_budget(5);
+        let body = b"timeout-body";
+        assert!(matches!(budget.claim(body), RequestClaim::Claimed { .. }));
+        let RequestClaim::WaitFor(entry) = budget.claim(body) else {
+            panic!("expected WaitFor");
+        };
+        assert!(entry.wait(Duration::from_millis(50)).is_none());
+    }
+
+    #[test]
+    fn test_in_flight_guard_drop_resolves_waiters() {
+        let budget = make_budget(5);
+        let body = b"guard-body";
+        let RequestClaim::Claimed { digest } = budget.claim(body) else {
+            panic!("expected Claimed");
+        };
+        let RequestClaim::WaitFor(entry) = budget.claim(body) else {
+            panic!("expected WaitFor");
+        };
+        {
+            let mut guard = InFlightGuard::new(budget.clone(), digest);
+            drop(guard);
+        }
+        let outcome = entry
+            .wait(Duration::from_secs(5))
+            .expect("resolved by drop");
+        assert_eq!(outcome.status, "500 Internal Server Error");
+    }
+
+    #[test]
+    fn test_completed_duplicate_within_ttl_returns_cached() {
+        let budget = make_budget(5);
+        let body = b"cached-body";
+        let RequestClaim::Claimed { digest } = budget.claim(body) else {
+            panic!("expected Claimed");
+        };
+        budget.resolve(
+            digest,
+            InFlightOutcome {
+                status: "200 OK",
+                body: b"cached-result".to_vec(),
+            },
+        );
+        let RequestClaim::Cached { outcome } = budget.claim(body) else {
+            panic!("expected Cached");
+        };
+        assert_eq!(outcome.status, "200 OK");
+        assert_eq!(outcome.body, b"cached-result");
+    }
+
+    #[test]
+    fn test_completed_cache_does_not_consume_extra_budget() {
+        let budget = make_budget(2);
+        let body = b"budget-body";
+        let RequestClaim::Claimed { digest } = budget.claim(body) else {
+            panic!("expected Claimed");
+        };
+        budget.resolve(
+            digest,
+            InFlightOutcome {
+                status: "200 OK",
+                body: b"ok".to_vec(),
+            },
+        );
+        assert!(matches!(budget.claim(body), RequestClaim::Cached { .. }));
+        assert!(matches!(
+            budget.claim(b"other"),
+            RequestClaim::Claimed { .. }
+        ));
+        assert!(matches!(budget.claim(b"third"), RequestClaim::Exhausted));
+    }
+
+    #[test]
+    fn test_completed_cache_bounded_size() {
+        let budget = make_budget(MAX_COMPLETED_OUTCOMES + 8);
+        for i in 0..MAX_COMPLETED_OUTCOMES + 4 {
+            let body = format!("body-{}", i);
+            let RequestClaim::Claimed { digest } = budget.claim(body.as_bytes()) else {
+                panic!("expected Claimed");
+            };
+            budget.resolve(
+                digest,
+                InFlightOutcome {
+                    status: "200 OK",
+                    body: b"ok".to_vec(),
+                },
+            );
+        }
+        let used = budget.inner.lock().unwrap().completed.len();
+        assert!(used <= MAX_COMPLETED_OUTCOMES);
     }
 
     #[test]
@@ -3101,7 +3563,7 @@ mod tests {
         };
 
         use std::collections::BTreeMap;
-        use std::sync::{Arc, Mutex};
+        use std::sync::{Arc, Condvar, Mutex};
         use std::time::Duration;
 
         const FRAME_MAGIC: u32 = 0x41554449;
@@ -3975,7 +4437,7 @@ mod tests {
         }
 
         #[test]
-        fn http_replay_attack_same_challenge_is_rejected() {
+        fn http_duplicate_request_within_ttl_returns_cached_assertion() {
             let (shutdown, _dir, sock_path, _registry, token, _f, handle) = setup_bound(false);
             let body = sign_request_body(
                 "https://example.com",
@@ -3994,12 +4456,25 @@ mod tests {
                 .get("authenticator_data_b64u")
                 .unwrap()
                 .as_str()
-                .unwrap();
-            assert_eq!(extract_counter(auth1), 1);
+                .unwrap()
+                .to_string();
+            assert_eq!(extract_counter(&auth1), 1);
 
+            // An identical request within the completed-outcome TTL returns the
+            // same cached assertion instead of being re-signed. The counter is not
+            // incremented again, so no new signature is produced (idempotent).
             let resp2 = http_request(&sock_path, &req, &body);
-            assert!(resp2.contains("409 Conflict"));
-            assert!(http_body(&resp2).contains("replayed_operation"));
+            assert!(resp2.contains("200 OK"));
+            let parsed2: serde_json::Value = serde_json::from_str(http_body(&resp2)).unwrap();
+            let auth2 = parsed2
+                .get("sign_assertion_result")
+                .unwrap()
+                .get("authenticator_data_b64u")
+                .unwrap()
+                .as_str()
+                .unwrap();
+            assert_eq!(auth2, auth1);
+            assert_eq!(extract_counter(auth2), 1);
 
             shutdown.store(true, Ordering::Release);
             handle.join().unwrap();

--- a/cmd/passless/src/agent/sign.rs
+++ b/cmd/passless/src/agent/sign.rs
@@ -1,6 +1,8 @@
 use std::collections::{HashMap, HashSet};
 use std::io::{Read, Write};
-use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -544,8 +546,8 @@ impl Default for SignContextRegistry {
 }
 
 pub struct SignHttpServer {
-    listener: TcpListener,
-    addr: SocketAddr,
+    listener: Option<UnixListener>,
+    socket_path: PathBuf,
     shutdown: Arc<AtomicBool>,
 }
 
@@ -554,37 +556,37 @@ const MAX_HTTP_HEADER_SIZE: usize = 8192;
 const MAX_CONNECTIONS: usize = 8;
 
 impl SignHttpServer {
-    pub fn bind(shutdown: Arc<AtomicBool>) -> Result<Self, String> {
+    pub fn bind(socket_path: PathBuf, shutdown: Arc<AtomicBool>) -> Result<Self, String> {
+        if let Some(parent) = socket_path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("create socket directory: {}", e))?;
+            std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))
+                .map_err(|e| format!("set socket dir permissions: {}", e))?;
+        }
+        let _ = std::fs::remove_file(&socket_path);
         let listener =
-            TcpListener::bind("127.0.0.1:0").map_err(|e| format!("bind failed: {}", e))?;
-        listener
-            .set_nonblocking(false)
-            .map_err(|e| format!("set_nonblocking failed: {}", e))?;
-        let addr = listener
-            .local_addr()
-            .map_err(|e| format!("local_addr failed: {}", e))?;
+            UnixListener::bind(&socket_path).map_err(|e| format!("bind failed: {}", e))?;
+        std::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o600))
+            .map_err(|e| format!("set socket permissions: {}", e))?;
         Ok(Self {
-            listener,
-            addr,
+            listener: Some(listener),
+            socket_path,
             shutdown,
         })
     }
 
-    pub fn addr(&self) -> SocketAddr {
-        self.addr
-    }
-
-    pub fn port(&self) -> u16 {
-        self.addr.port()
+    pub fn socket_path(&self) -> &Path {
+        &self.socket_path
     }
 
     pub fn shutdown(&self) {
         self.shutdown.store(true, Ordering::Release);
     }
 
-    pub fn serve(self, registry: Arc<SignContextRegistry>) -> thread::JoinHandle<()> {
+    pub fn serve(mut self, registry: Arc<SignContextRegistry>) -> thread::JoinHandle<()> {
         let shutdown = self.shutdown.clone();
-        let listener = self.listener;
+        let listener = self.listener.take().expect("listener already taken");
+        let socket_path = self.socket_path.clone();
         thread::spawn(move || {
             listener.set_nonblocking(true).expect("set_nonblocking");
             let active_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -617,11 +619,20 @@ impl SignHttpServer {
                     }
                 }
             }
+            let _ = std::fs::remove_file(&socket_path);
         })
     }
 }
 
-fn send_http_response(stream: &mut TcpStream, status: &str, body: Option<&[u8]>) {
+impl Drop for SignHttpServer {
+    fn drop(&mut self) {
+        if self.listener.is_some() {
+            let _ = std::fs::remove_file(&self.socket_path);
+        }
+    }
+}
+
+fn send_http_response(stream: &mut UnixStream, status: &str, body: Option<&[u8]>) {
     let content_length = body.map(|b| b.len()).unwrap_or(0);
     let header = format!(
         "HTTP/1.1 {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n",
@@ -633,18 +644,16 @@ fn send_http_response(stream: &mut TcpStream, status: &str, body: Option<&[u8]>)
     }
 }
 
-fn send_http_error(stream: &mut TcpStream, status: &str, code: &str) {
+fn send_http_error(stream: &mut UnixStream, status: &str, code: &str) {
     let body = format!("{{\"error\":\"{}\"}}", code);
     send_http_response(stream, status, Some(body.as_bytes()));
 }
 
-const CORS_HEADERS: &str = "Access-Control-Allow-Origin: *\r\nAccess-Control-Allow-Methods: POST\r\nAccess-Control-Allow-Headers: Authorization, Content-Type\r\n";
-
-fn send_sign_response(stream: &mut TcpStream, status: &str, body: Option<&[u8]>) {
+fn send_sign_response(stream: &mut UnixStream, status: &str, body: Option<&[u8]>) {
     let content_length = body.map(|b| b.len()).unwrap_or(0);
     let header = format!(
-        "HTTP/1.1 {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n{}\r\n",
-        status, content_length, CORS_HEADERS
+        "HTTP/1.1 {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n",
+        status, content_length
     );
     let _ = stream.write_all(header.as_bytes());
     if let Some(body) = body {
@@ -652,21 +661,13 @@ fn send_sign_response(stream: &mut TcpStream, status: &str, body: Option<&[u8]>)
     }
 }
 
-fn send_sign_error(stream: &mut TcpStream, status: &str, code: &str) {
+fn send_sign_error(stream: &mut UnixStream, status: &str, code: &str) {
     let body = format!("{{\"error\":\"{}\"}}", code);
     send_sign_response(stream, status, Some(body.as_bytes()));
 }
 
-fn send_preflight_response(stream: &mut TcpStream) {
-    let response = format!(
-        "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n{}\r\n",
-        CORS_HEADERS
-    );
-    let _ = stream.write_all(response.as_bytes());
-}
-
 fn handle_http_connection(
-    mut stream: TcpStream,
+    mut stream: UnixStream,
     registry: &SignContextRegistry,
 ) -> Result<(), String> {
     let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
@@ -699,10 +700,6 @@ fn handle_http_connection(
     let mut parts = request_line.split_whitespace();
     let method = parts.next().ok_or("no method")?;
     let path = parts.next().ok_or("no path")?;
-    if method == "OPTIONS" && (path == "/sign" || path == "/register") {
-        send_preflight_response(&mut stream);
-        return Ok(());
-    }
     if method != "POST" || (path != "/sign" && path != "/register") {
         send_http_error(&mut stream, "404 Not Found", "not_found");
         return Ok(());
@@ -1684,10 +1681,16 @@ mod tests {
     }
 
     #[test]
-    fn test_http_server_binds_loopback() {
+    fn test_http_server_binds_unix_socket() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("sock");
         let shutdown = Arc::new(AtomicBool::new(false));
-        let server = SignHttpServer::bind(shutdown.clone()).unwrap();
-        assert!(server.addr().ip().is_loopback());
+        let server = SignHttpServer::bind(sock_path.clone(), shutdown.clone()).unwrap();
+        assert!(server.socket_path().exists());
+        let meta = std::fs::metadata(server.socket_path()).unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        assert_eq!(meta.permissions().mode() & 0o777, 0o600);
+        drop(server);
         shutdown.store(true, Ordering::Release);
     }
 
@@ -1902,14 +1905,14 @@ mod tests {
     }
 
     #[test]
-    fn test_agent_endpoint_metadata_contains_sign_port_and_bearer() {
+    fn test_agent_endpoint_metadata_contains_sign_socket_path_and_bearer() {
         use crate::agent::browser::AgentEndpointMetadata;
         let token = generate_bearer_token().unwrap();
         let metadata = AgentEndpointMetadata {
-            port: 12345,
+            socket_path: "/tmp/test/sock".to_string(),
             bearer_token: token.clone(),
         };
-        assert_eq!(metadata.port, 12345);
+        assert_eq!(metadata.socket_path, "/tmp/test/sock");
         assert_eq!(metadata.bearer_token, token);
     }
 
@@ -1951,9 +1954,10 @@ mod tests {
 
     #[test]
     fn test_http_valid_bound_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("sock");
         let shutdown = Arc::new(AtomicBool::new(false));
-        let server = SignHttpServer::bind(shutdown.clone()).unwrap();
-        let addr = server.addr();
+        let server = SignHttpServer::bind(sock_path.clone(), shutdown.clone()).unwrap();
         let registry = Arc::new(SignContextRegistry::new());
         let token = generate_bearer_token().unwrap();
         let f = sign_handler_tests::TestFixture::new(true);
@@ -1979,7 +1983,7 @@ mod tests {
             token,
             body.len()
         );
-        let mut stream = TcpStream::connect(addr).unwrap();
+        let mut stream = UnixStream::connect(&sock_path).unwrap();
         stream
             .set_read_timeout(Some(Duration::from_secs(5)))
             .unwrap();
@@ -1995,9 +1999,10 @@ mod tests {
 
     #[test]
     fn test_http_unknown_bearer_401() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("sock");
         let shutdown = Arc::new(AtomicBool::new(false));
-        let server = SignHttpServer::bind(shutdown.clone()).unwrap();
-        let addr = server.addr();
+        let server = SignHttpServer::bind(sock_path.clone(), shutdown.clone()).unwrap();
         let registry = Arc::new(SignContextRegistry::new());
         let handle = server.serve(registry);
         let body = b"{}";
@@ -2005,7 +2010,7 @@ mod tests {
             "POST /sign HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer unknown_token\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n",
             body.len()
         );
-        let mut stream = TcpStream::connect(addr).unwrap();
+        let mut stream = UnixStream::connect(&sock_path).unwrap();
         stream
             .set_read_timeout(Some(Duration::from_secs(5)))
             .unwrap();
@@ -2021,9 +2026,10 @@ mod tests {
 
     #[test]
     fn test_http_unbound_bearer_401() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("sock");
         let shutdown = Arc::new(AtomicBool::new(false));
-        let server = SignHttpServer::bind(shutdown.clone()).unwrap();
-        let addr = server.addr();
+        let server = SignHttpServer::bind(sock_path.clone(), shutdown.clone()).unwrap();
         let registry = Arc::new(SignContextRegistry::new());
         let token = generate_bearer_token().unwrap();
         let f = sign_handler_tests::TestFixture::new(true);
@@ -2039,7 +2045,7 @@ mod tests {
             token,
             body.len()
         );
-        let mut stream = TcpStream::connect(addr).unwrap();
+        let mut stream = UnixStream::connect(&sock_path).unwrap();
         stream
             .set_read_timeout(Some(Duration::from_secs(5)))
             .unwrap();
@@ -2055,9 +2061,10 @@ mod tests {
 
     #[test]
     fn test_http_revoked_bearer_401() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("sock");
         let shutdown = Arc::new(AtomicBool::new(false));
-        let server = SignHttpServer::bind(shutdown.clone()).unwrap();
-        let addr = server.addr();
+        let server = SignHttpServer::bind(sock_path.clone(), shutdown.clone()).unwrap();
         let registry = Arc::new(SignContextRegistry::new());
         let token = generate_bearer_token().unwrap();
         let f = sign_handler_tests::TestFixture::new(true);
@@ -2077,7 +2084,7 @@ mod tests {
             token,
             body.len()
         );
-        let mut stream = TcpStream::connect(addr).unwrap();
+        let mut stream = UnixStream::connect(&sock_path).unwrap();
         stream
             .set_read_timeout(Some(Duration::from_secs(5)))
             .unwrap();
@@ -2093,9 +2100,10 @@ mod tests {
 
     #[test]
     fn test_http_missing_bearer() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("sock");
         let shutdown = Arc::new(AtomicBool::new(false));
-        let server = SignHttpServer::bind(shutdown.clone()).unwrap();
-        let addr = server.addr();
+        let server = SignHttpServer::bind(sock_path.clone(), shutdown.clone()).unwrap();
         let registry = Arc::new(SignContextRegistry::new());
         let handle = server.serve(registry);
         let body = b"{}";
@@ -2103,7 +2111,7 @@ mod tests {
             "POST /sign HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n",
             body.len()
         );
-        let mut stream = TcpStream::connect(addr).unwrap();
+        let mut stream = UnixStream::connect(&sock_path).unwrap();
         stream
             .set_read_timeout(Some(Duration::from_secs(5)))
             .unwrap();
@@ -2119,9 +2127,10 @@ mod tests {
 
     #[test]
     fn test_http_wrong_method() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("sock");
         let shutdown = Arc::new(AtomicBool::new(false));
-        let server = SignHttpServer::bind(shutdown.clone()).unwrap();
-        let addr = server.addr();
+        let server = SignHttpServer::bind(sock_path.clone(), shutdown.clone()).unwrap();
         let registry = Arc::new(SignContextRegistry::new());
         let token = generate_bearer_token().unwrap();
         let f = sign_handler_tests::TestFixture::new(true);
@@ -2136,7 +2145,7 @@ mod tests {
             "GET /sign HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer {}\r\n\r\n",
             token
         );
-        let mut stream = TcpStream::connect(addr).unwrap();
+        let mut stream = UnixStream::connect(&sock_path).unwrap();
         stream
             .set_read_timeout(Some(Duration::from_secs(5)))
             .unwrap();
@@ -2151,9 +2160,10 @@ mod tests {
 
     #[test]
     fn test_http_wrong_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("sock");
         let shutdown = Arc::new(AtomicBool::new(false));
-        let server = SignHttpServer::bind(shutdown.clone()).unwrap();
-        let addr = server.addr();
+        let server = SignHttpServer::bind(sock_path.clone(), shutdown.clone()).unwrap();
         let registry = Arc::new(SignContextRegistry::new());
         let token = generate_bearer_token().unwrap();
         let f = sign_handler_tests::TestFixture::new(true);
@@ -2168,7 +2178,7 @@ mod tests {
             "POST /other HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer {}\r\nContent-Length: 0\r\n\r\n",
             token
         );
-        let mut stream = TcpStream::connect(addr).unwrap();
+        let mut stream = UnixStream::connect(&sock_path).unwrap();
         stream
             .set_read_timeout(Some(Duration::from_secs(5)))
             .unwrap();
@@ -2183,16 +2193,20 @@ mod tests {
 
     #[test]
     fn test_listener_loopback_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("sock");
         let shutdown = Arc::new(AtomicBool::new(false));
-        let server = SignHttpServer::bind(shutdown.clone()).unwrap();
-        assert!(server.addr().ip().is_loopback());
+        let server = SignHttpServer::bind(sock_path.clone(), shutdown.clone()).unwrap();
+        assert!(server.socket_path().starts_with(dir.path()));
         shutdown.store(true, Ordering::Release);
     }
 
     #[test]
     fn test_shutdown_join() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("sock");
         let shutdown = Arc::new(AtomicBool::new(false));
-        let server = SignHttpServer::bind(shutdown.clone()).unwrap();
+        let server = SignHttpServer::bind(sock_path, shutdown.clone()).unwrap();
         let registry = Arc::new(SignContextRegistry::new());
         let handle = server.serve(registry);
         shutdown.store(true, Ordering::Release);
@@ -2209,40 +2223,15 @@ mod tests {
     }
 
     #[test]
-    fn test_http_options_sign_preflight() {
+    fn test_http_options_returns_404() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("sock");
         let shutdown = Arc::new(AtomicBool::new(false));
-        let server = SignHttpServer::bind(shutdown.clone()).unwrap();
-        let addr = server.addr();
+        let server = SignHttpServer::bind(sock_path.clone(), shutdown.clone()).unwrap();
         let registry = Arc::new(SignContextRegistry::new());
         let handle = server.serve(registry);
         let request = "OPTIONS /sign HTTP/1.1\r\nHost: localhost\r\nOrigin: https://evil.example.com\r\nAccess-Control-Request-Method: POST\r\nAccess-Control-Request-Headers: Authorization\r\n\r\n";
-        let mut stream = TcpStream::connect(addr).unwrap();
-        stream
-            .set_read_timeout(Some(Duration::from_secs(5)))
-            .unwrap();
-        stream.write_all(request.as_bytes()).unwrap();
-        let mut resp_buf = vec![0u8; 4096];
-        let n = stream.read(&mut resp_buf).unwrap();
-        let resp_str = std::str::from_utf8(&resp_buf[..n]).unwrap();
-        assert!(resp_str.contains("204 No Content"));
-        assert!(resp_str.contains("Access-Control-Allow-Origin: *"));
-        assert!(resp_str.contains("Access-Control-Allow-Methods: POST"));
-        assert!(resp_str.contains("Access-Control-Allow-Headers: Authorization, Content-Type"));
-        assert!(!resp_str.contains("Access-Control-Allow-Credentials"));
-        assert!(!resp_str.contains("evil.example.com"));
-        shutdown.store(true, Ordering::Release);
-        handle.join().unwrap();
-    }
-
-    #[test]
-    fn test_http_options_wrong_path_404() {
-        let shutdown = Arc::new(AtomicBool::new(false));
-        let server = SignHttpServer::bind(shutdown.clone()).unwrap();
-        let addr = server.addr();
-        let registry = Arc::new(SignContextRegistry::new());
-        let handle = server.serve(registry);
-        let request = "OPTIONS /other HTTP/1.1\r\nHost: localhost\r\n\r\n";
-        let mut stream = TcpStream::connect(addr).unwrap();
+        let mut stream = UnixStream::connect(&sock_path).unwrap();
         stream
             .set_read_timeout(Some(Duration::from_secs(5)))
             .unwrap();
@@ -2251,16 +2240,16 @@ mod tests {
         let n = stream.read(&mut resp_buf).unwrap();
         let resp_str = std::str::from_utf8(&resp_buf[..n]).unwrap();
         assert!(resp_str.contains("404"));
-        assert!(!resp_str.contains("Access-Control"));
         shutdown.store(true, Ordering::Release);
         handle.join().unwrap();
     }
 
     #[test]
-    fn test_http_post_error_has_cors_no_reflected_origin() {
+    fn test_http_post_error_no_cors_headers() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("sock");
         let shutdown = Arc::new(AtomicBool::new(false));
-        let server = SignHttpServer::bind(shutdown.clone()).unwrap();
-        let addr = server.addr();
+        let server = SignHttpServer::bind(sock_path.clone(), shutdown.clone()).unwrap();
         let registry = Arc::new(SignContextRegistry::new());
         let handle = server.serve(registry);
         let body = b"{}";
@@ -2268,7 +2257,7 @@ mod tests {
             "POST /sign HTTP/1.1\r\nHost: localhost\r\nOrigin: https://attacker.example.com\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n",
             body.len()
         );
-        let mut stream = TcpStream::connect(addr).unwrap();
+        let mut stream = UnixStream::connect(&sock_path).unwrap();
         stream
             .set_read_timeout(Some(Duration::from_secs(5)))
             .unwrap();
@@ -2278,17 +2267,17 @@ mod tests {
         let n = stream.read(&mut resp_buf).unwrap();
         let resp_str = std::str::from_utf8(&resp_buf[..n]).unwrap();
         assert!(resp_str.contains("401"));
-        assert!(resp_str.contains("Access-Control-Allow-Origin: *"));
-        assert!(!resp_str.contains("attacker.example.com"));
+        assert!(!resp_str.contains("Access-Control"));
         shutdown.store(true, Ordering::Release);
         handle.join().unwrap();
     }
 
     #[test]
-    fn test_http_success_has_cors() {
+    fn test_http_success_no_cors_headers() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("sock");
         let shutdown = Arc::new(AtomicBool::new(false));
-        let server = SignHttpServer::bind(shutdown.clone()).unwrap();
-        let addr = server.addr();
+        let server = SignHttpServer::bind(sock_path.clone(), shutdown.clone()).unwrap();
         let registry = Arc::new(SignContextRegistry::new());
         let token = generate_bearer_token().unwrap();
         let f = sign_handler_tests::TestFixture::new(true);
@@ -2316,7 +2305,7 @@ mod tests {
             token,
             body.len()
         );
-        let mut stream = TcpStream::connect(addr).unwrap();
+        let mut stream = UnixStream::connect(&sock_path).unwrap();
         stream
             .set_read_timeout(Some(Duration::from_secs(5)))
             .unwrap();
@@ -2326,18 +2315,17 @@ mod tests {
         let n = stream.read(&mut resp_buf).unwrap();
         let resp_str = std::str::from_utf8(&resp_buf[..n]).unwrap();
         assert!(resp_str.contains("200 OK"));
-        assert!(resp_str.contains("Access-Control-Allow-Origin: *"));
-        assert!(resp_str.contains("Access-Control-Allow-Methods: POST"));
-        assert!(resp_str.contains("Access-Control-Allow-Headers: Authorization, Content-Type"));
+        assert!(!resp_str.contains("Access-Control"));
         shutdown.store(true, Ordering::Release);
         handle.join().unwrap();
     }
 
     #[test]
     fn test_http_unbound_bearer_same_401_as_unknown() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("sock");
         let shutdown = Arc::new(AtomicBool::new(false));
-        let server = SignHttpServer::bind(shutdown.clone()).unwrap();
-        let addr = server.addr();
+        let server = SignHttpServer::bind(sock_path.clone(), shutdown.clone()).unwrap();
         let registry = Arc::new(SignContextRegistry::new());
         let token = generate_bearer_token().unwrap();
         let f = sign_handler_tests::TestFixture::new(true);
@@ -2353,7 +2341,7 @@ mod tests {
             token,
             body.len()
         );
-        let mut stream = TcpStream::connect(addr).unwrap();
+        let mut stream = UnixStream::connect(&sock_path).unwrap();
         stream
             .set_read_timeout(Some(Duration::from_secs(5)))
             .unwrap();
@@ -3688,13 +3676,12 @@ mod tests {
         use super::*;
 
         use std::io::{Read, Write};
-        use std::net::{SocketAddr, TcpStream};
         use std::sync::Arc;
         use std::sync::atomic::{AtomicBool, Ordering};
         use std::time::Duration;
 
-        fn http_request(addr: SocketAddr, request: &str, body: &[u8]) -> String {
-            let mut stream = TcpStream::connect(addr).unwrap();
+        fn http_request(sock_path: &Path, request: &str, body: &[u8]) -> String {
+            let mut stream = UnixStream::connect(sock_path).unwrap();
             stream
                 .set_read_timeout(Some(Duration::from_secs(5)))
                 .unwrap();
@@ -3720,15 +3707,17 @@ mod tests {
             constant_counter: bool,
         ) -> (
             Arc<AtomicBool>,
-            SocketAddr,
+            tempfile::TempDir,
+            std::path::PathBuf,
             Arc<SignContextRegistry>,
             String,
             TestFixture,
             thread::JoinHandle<()>,
         ) {
+            let dir = tempfile::tempdir().unwrap();
+            let sock_path = dir.path().join("sock");
             let shutdown = Arc::new(AtomicBool::new(false));
-            let server = SignHttpServer::bind(shutdown.clone()).unwrap();
-            let addr = server.addr();
+            let server = SignHttpServer::bind(sock_path.clone(), shutdown.clone()).unwrap();
             let registry = Arc::new(SignContextRegistry::new());
             let token = generate_bearer_token().unwrap();
             let f = TestFixture::new(constant_counter);
@@ -3741,7 +3730,7 @@ mod tests {
                 .bind_lease(&token, "lease-integ".to_string())
                 .unwrap();
             let handle = server.serve(registry.clone());
-            (shutdown, addr, registry, token, f, handle)
+            (shutdown, dir, sock_path, registry, token, f, handle)
         }
 
         fn sign_request_body(
@@ -3779,7 +3768,7 @@ mod tests {
 
         #[test]
         fn http_sign_full_response_structure() {
-            let (shutdown, addr, _registry, token, _f, handle) = setup_bound(true);
+            let (shutdown, _dir, sock_path, _registry, token, _f, handle) = setup_bound(true);
             let body = sign_request_body(
                 "https://example.com",
                 "example.com",
@@ -3788,7 +3777,7 @@ mod tests {
                 false,
             );
             let req = format_sign_request(&token, &body);
-            let resp = http_request(addr, &req, &body);
+            let resp = http_request(&sock_path, &req, &body);
             assert!(resp.contains("200 OK"));
             let body_str = http_body(&resp);
             let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
@@ -3804,16 +3793,7 @@ mod tests {
 
         #[test]
         fn http_auth_preflight_then_sign() {
-            let (shutdown, addr, _registry, token, _f, handle) = setup_bound(true);
-            let preflight = "OPTIONS /sign HTTP/1.1\r\nHost: localhost\r\nOrigin: https://example.com\r\nAccess-Control-Request-Method: POST\r\nAccess-Control-Request-Headers: Authorization\r\n\r\n";
-            let preflight_resp = http_request(addr, preflight, b"");
-            assert!(preflight_resp.contains("204 No Content"));
-            assert!(preflight_resp.contains("Access-Control-Allow-Origin: *"));
-            assert!(preflight_resp.contains("Access-Control-Allow-Methods: POST"));
-            assert!(
-                preflight_resp
-                    .contains("Access-Control-Allow-Headers: Authorization, Content-Type")
-            );
+            let (shutdown, _dir, sock_path, _registry, token, _f, handle) = setup_bound(true);
             let body = sign_request_body(
                 "https://example.com",
                 "example.com",
@@ -3822,23 +3802,19 @@ mod tests {
                 false,
             );
             let req = format_sign_request(&token, &body);
-            let sign_resp = http_request(addr, &req, &body);
+            let sign_resp = http_request(&sock_path, &req, &body);
             assert!(sign_resp.contains("200 OK"));
-            assert!(sign_resp.contains("Access-Control-Allow-Origin: *"));
-            assert!(sign_resp.contains("Access-Control-Allow-Methods: POST"));
-            assert!(
-                sign_resp.contains("Access-Control-Allow-Headers: Authorization, Content-Type")
-            );
+            assert!(!sign_resp.contains("Access-Control"));
             shutdown.store(true, Ordering::Release);
             handle.join().unwrap();
         }
 
         #[test]
         fn http_policy_deny_returns_403() {
-            let (shutdown, addr, _registry, token, _f, handle) = setup_bound(true);
+            let (shutdown, _dir, sock_path, _registry, token, _f, handle) = setup_bound(true);
             let body = sign_request_body("https://other.com", "other.com", "dGVzdA", vec![], false);
             let req = format_sign_request(&token, &body);
-            let resp = http_request(addr, &req, &body);
+            let resp = http_request(&sock_path, &req, &body);
             assert!(resp.contains("403"));
             let body_str = http_body(&resp);
             assert!(body_str.contains("forbidden"));
@@ -3848,7 +3824,7 @@ mod tests {
 
         #[test]
         fn http_grant_ttl_enforced() {
-            let (shutdown, addr, _registry, token, f, handle) = setup_bound(true);
+            let (shutdown, _dir, sock_path, _registry, token, f, handle) = setup_bound(true);
             f.clock.advance(Duration::from_secs(301));
             let body = sign_request_body(
                 "https://example.com",
@@ -3858,7 +3834,7 @@ mod tests {
                 false,
             );
             let req = format_sign_request(&token, &body);
-            let resp = http_request(addr, &req, &body);
+            let resp = http_request(&sock_path, &req, &body);
             assert!(resp.contains("403"));
             let body_str = http_body(&resp);
             assert!(body_str.contains("forbidden"));
@@ -3868,7 +3844,7 @@ mod tests {
 
         #[test]
         fn http_credential_ref_enforced() {
-            let (shutdown, addr, _registry, token, _f, handle) = setup_bound(true);
+            let (shutdown, _dir, sock_path, _registry, token, _f, handle) = setup_bound(true);
             let body = sign_request_body(
                 "https://example.com",
                 "example.com",
@@ -3877,7 +3853,7 @@ mod tests {
                 false,
             );
             let req = format_sign_request(&token, &body);
-            let resp = http_request(addr, &req, &body);
+            let resp = http_request(&sock_path, &req, &body);
             assert!(resp.contains("200 OK"));
             let body_str = http_body(&resp);
             let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
@@ -3891,7 +3867,7 @@ mod tests {
 
         #[test]
         fn http_counter_increment_monotonic() {
-            let (shutdown, addr, _registry, token, _f, handle) = setup_bound(false);
+            let (shutdown, _dir, sock_path, _registry, token, _f, handle) = setup_bound(false);
             let body1 = sign_request_body(
                 "https://example.com",
                 "example.com",
@@ -3900,7 +3876,7 @@ mod tests {
                 false,
             );
             let req1 = format_sign_request(&token, &body1);
-            let resp1 = http_request(addr, &req1, &body1);
+            let resp1 = http_request(&sock_path, &req1, &body1);
             assert!(resp1.contains("200 OK"));
             let parsed1: serde_json::Value = serde_json::from_str(http_body(&resp1)).unwrap();
             let inner1 = parsed1.get("sign_assertion_result").unwrap();
@@ -3918,7 +3894,7 @@ mod tests {
                 false,
             );
             let req2 = format_sign_request(&token, &body2);
-            let resp2 = http_request(addr, &req2, &body2);
+            let resp2 = http_request(&sock_path, &req2, &body2);
             assert!(resp2.contains("200 OK"));
             let parsed2: serde_json::Value = serde_json::from_str(http_body(&resp2)).unwrap();
             let inner2 = parsed2.get("sign_assertion_result").unwrap();
@@ -3936,14 +3912,14 @@ mod tests {
 
         #[test]
         fn http_content_type_validation() {
-            let (shutdown, addr, _registry, token, _f, handle) = setup_bound(true);
+            let (shutdown, _dir, sock_path, _registry, token, _f, handle) = setup_bound(true);
             let body = b"{}";
             let req = format!(
                 "POST /sign HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer {}\r\nContent-Type: text/plain\r\nContent-Length: {}\r\n\r\n",
                 token,
                 body.len()
             );
-            let resp = http_request(addr, &req, body);
+            let resp = http_request(&sock_path, &req, body);
             assert!(resp.contains("415"));
             let body_str = http_body(&resp);
             assert!(body_str.contains("unsupported_content_type"));
@@ -3953,11 +3929,11 @@ mod tests {
 
         #[test]
         fn http_origin_mismatch_denied() {
-            let (shutdown, addr, _registry, token, _f, handle) = setup_bound(true);
+            let (shutdown, _dir, sock_path, _registry, token, _f, handle) = setup_bound(true);
             let body =
                 sign_request_body("https://evil.com", "example.com", "dGVzdA", vec![], false);
             let req = format_sign_request(&token, &body);
-            let resp = http_request(addr, &req, &body);
+            let resp = http_request(&sock_path, &req, &body);
             assert!(resp.contains("403"));
             let body_str = http_body(&resp);
             assert!(body_str.contains("forbidden"));
@@ -3967,10 +3943,10 @@ mod tests {
 
         #[test]
         fn http_wrong_rp_id_denied() {
-            let (shutdown, addr, _registry, token, _f, handle) = setup_bound(true);
+            let (shutdown, _dir, sock_path, _registry, token, _f, handle) = setup_bound(true);
             let body = sign_request_body("https://other.com", "other.com", "dGVzdA", vec![], false);
             let req = format_sign_request(&token, &body);
-            let resp = http_request(addr, &req, &body);
+            let resp = http_request(&sock_path, &req, &body);
             assert!(resp.contains("403"));
             let body_str = http_body(&resp);
             assert!(body_str.contains("forbidden"));
@@ -3980,7 +3956,7 @@ mod tests {
 
         #[test]
         fn http_unauthorized_credential_denied() {
-            let (shutdown, addr, _registry, token, _f, handle) = setup_bound(true);
+            let (shutdown, _dir, sock_path, _registry, token, _f, handle) = setup_bound(true);
             let wrong_cred = b64u_encode(b"wrong_credential_id_bytes_1234567");
             let body = sign_request_body(
                 "https://example.com",
@@ -3990,7 +3966,7 @@ mod tests {
                 false,
             );
             let req = format_sign_request(&token, &body);
-            let resp = http_request(addr, &req, &body);
+            let resp = http_request(&sock_path, &req, &body);
             assert!(resp.contains("403"));
             let body_str = http_body(&resp);
             assert!(body_str.contains("forbidden"));
@@ -4000,7 +3976,7 @@ mod tests {
 
         #[test]
         fn http_replay_attack_same_challenge_is_rejected() {
-            let (shutdown, addr, _registry, token, _f, handle) = setup_bound(false);
+            let (shutdown, _dir, sock_path, _registry, token, _f, handle) = setup_bound(false);
             let body = sign_request_body(
                 "https://example.com",
                 "example.com",
@@ -4009,7 +3985,7 @@ mod tests {
                 false,
             );
             let req = format_sign_request(&token, &body);
-            let resp1 = http_request(addr, &req, &body);
+            let resp1 = http_request(&sock_path, &req, &body);
             assert!(resp1.contains("200 OK"));
             let parsed1: serde_json::Value = serde_json::from_str(http_body(&resp1)).unwrap();
             let auth1 = parsed1
@@ -4021,7 +3997,7 @@ mod tests {
                 .unwrap();
             assert_eq!(extract_counter(auth1), 1);
 
-            let resp2 = http_request(addr, &req, &body);
+            let resp2 = http_request(&sock_path, &req, &body);
             assert!(resp2.contains("409 Conflict"));
             assert!(http_body(&resp2).contains("replayed_operation"));
 
@@ -4031,10 +4007,10 @@ mod tests {
 
         #[test]
         fn http_invalid_json_body() {
-            let (shutdown, addr, _registry, token, _f, handle) = setup_bound(true);
+            let (shutdown, _dir, sock_path, _registry, token, _f, handle) = setup_bound(true);
             let body = b"{invalid json!!";
             let req = format_sign_request(&token, body);
-            let resp = http_request(addr, &req, body);
+            let resp = http_request(&sock_path, &req, body);
             assert!(resp.contains("400"));
             let body_str = http_body(&resp);
             assert!(body_str.contains("invalid_json"));
@@ -4044,12 +4020,12 @@ mod tests {
 
         #[test]
         fn http_body_too_large() {
-            let (shutdown, addr, _registry, token, _f, handle) = setup_bound(true);
+            let (shutdown, _dir, sock_path, _registry, token, _f, handle) = setup_bound(true);
             let req = format!(
                 "POST /sign HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer {}\r\nContent-Type: application/json\r\nContent-Length: 99999\r\n\r\n",
                 token
             );
-            let resp = http_request(addr, &req, b"");
+            let resp = http_request(&sock_path, &req, b"");
             assert!(resp.contains("413"));
             let body_str = http_body(&resp);
             assert!(body_str.contains("body_too_large"));
@@ -4059,7 +4035,7 @@ mod tests {
 
         #[test]
         fn http_bearer_not_prefix_match() {
-            let (shutdown, addr, _registry, token, _f, handle) = setup_bound(true);
+            let (shutdown, _dir, sock_path, _registry, token, _f, handle) = setup_bound(true);
             let prefix = &token[..10];
             let body = sign_request_body(
                 "https://example.com",
@@ -4069,7 +4045,7 @@ mod tests {
                 false,
             );
             let req = format_sign_request(prefix, &body);
-            let resp = http_request(addr, &req, &body);
+            let resp = http_request(&sock_path, &req, &body);
             assert!(resp.contains("401"));
             let body_str = http_body(&resp);
             assert!(body_str.contains("invalid_bearer"));
@@ -4079,7 +4055,7 @@ mod tests {
 
         #[test]
         fn http_wrong_auth_scheme() {
-            let (shutdown, addr, _registry, token, _f, handle) = setup_bound(true);
+            let (shutdown, _dir, sock_path, _registry, token, _f, handle) = setup_bound(true);
             let body = sign_request_body(
                 "https://example.com",
                 "example.com",
@@ -4092,7 +4068,7 @@ mod tests {
                 token,
                 body.len()
             );
-            let resp = http_request(addr, &req, &body);
+            let resp = http_request(&sock_path, &req, &body);
             assert!(resp.contains("401"));
             let body_str = http_body(&resp);
             assert!(body_str.contains("invalid_authorization_scheme"));
@@ -4102,7 +4078,7 @@ mod tests {
 
         #[test]
         fn http_cross_origin_theft_attempt() {
-            let (shutdown, addr, _registry, token, _f, handle) = setup_bound(true);
+            let (shutdown, _dir, sock_path, _registry, token, _f, handle) = setup_bound(true);
             let body = sign_request_body(
                 "https://attacker.com",
                 "example.com",
@@ -4111,7 +4087,7 @@ mod tests {
                 true,
             );
             let req = format_sign_request(&token, &body);
-            let resp = http_request(addr, &req, &body);
+            let resp = http_request(&sock_path, &req, &body);
             assert!(resp.contains("403"));
             let body_str = http_body(&resp);
             assert!(body_str.contains("forbidden"));

--- a/cmd/passless/src/bin/sign-proxy.rs
+++ b/cmd/passless/src/bin/sign-proxy.rs
@@ -1,0 +1,156 @@
+use std::io::{Read, Write};
+use std::os::unix::net::UnixStream;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+struct NativeRequest {
+    path: String,
+    bearer: String,
+    #[allow(dead_code)]
+    socket_path: String,
+    body: String,
+}
+
+#[derive(Serialize)]
+struct NativeResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    body: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+fn read_native_message() -> Option<NativeRequest> {
+    let mut len_buf = [0u8; 4];
+    std::io::stdin().read_exact(&mut len_buf).ok()?;
+    let len = u32::from_le_bytes(len_buf) as usize;
+    if len > 1024 * 1024 {
+        return None;
+    }
+    let mut msg_buf = vec![0u8; len];
+    std::io::stdin().read_exact(&mut msg_buf).ok()?;
+    serde_json::from_slice(&msg_buf).ok()
+}
+
+fn write_native_response(resp: &NativeResponse) {
+    let json = serde_json::to_vec(resp).unwrap_or_default();
+    let len = (json.len() as u32).to_le_bytes();
+    let mut stdout = std::io::stdout().lock();
+    let _ = stdout.write_all(&len);
+    let _ = stdout.write_all(&json);
+    let _ = stdout.flush();
+}
+
+fn forward_to_sign_server(req: &NativeRequest) -> NativeResponse {
+    let socket_path =
+        std::env::var("PASSLESS_SIGN_SOCKET").unwrap_or_else(|_| req.socket_path.clone());
+
+    let mut stream = match UnixStream::connect(&socket_path) {
+        Ok(s) => s,
+        Err(e) => {
+            return NativeResponse {
+                body: None,
+                error: Some(format!("connect: {}", e)),
+            };
+        }
+    };
+
+    let _ = stream.set_read_timeout(Some(Duration::from_secs(10)));
+    let _ = stream.set_write_timeout(Some(Duration::from_secs(10)));
+
+    let http_req = format!(
+        "POST {} HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+        req.path,
+        req.bearer,
+        req.body.len(),
+        req.body
+    );
+
+    if stream.write_all(http_req.as_bytes()).is_err() {
+        return NativeResponse {
+            body: None,
+            error: Some("write".to_string()),
+        };
+    }
+
+    let mut resp_buf = vec![0u8; 65536];
+    let mut total = 0;
+    loop {
+        match stream.read(&mut resp_buf[total..]) {
+            Ok(0) => break,
+            Ok(n) => {
+                total += n;
+                if total >= resp_buf.len() {
+                    break;
+                }
+                if let Some(pos) = resp_buf[..total].windows(4).position(|w| w == b"\r\n\r\n") {
+                    let header_end = pos + 4;
+                    let header_str = match std::str::from_utf8(&resp_buf[..pos]) {
+                        Ok(s) => s,
+                        Err(_) => {
+                            return NativeResponse {
+                                body: None,
+                                error: Some("invalid_utf8".to_string()),
+                            };
+                        }
+                    };
+                    let content_length: usize = header_str
+                        .lines()
+                        .find_map(|l| {
+                            let lower = l.to_ascii_lowercase();
+                            lower
+                                .strip_prefix("content-length:")
+                                .and_then(|v| v.trim().parse().ok())
+                        })
+                        .unwrap_or(0);
+                    let body_start = header_end;
+                    let body_received = total.saturating_sub(body_start);
+                    if body_received >= content_length {
+                        break;
+                    }
+                }
+            }
+            Err(_) => break,
+        }
+    }
+
+    let resp_str = match std::str::from_utf8(&resp_buf[..total]) {
+        Ok(s) => s,
+        Err(_) => {
+            return NativeResponse {
+                body: None,
+                error: Some("invalid_response".to_string()),
+            };
+        }
+    };
+
+    let body = resp_str
+        .find("\r\n\r\n")
+        .map(|pos| &resp_str[pos + 4..])
+        .unwrap_or("");
+
+    let status_ok = resp_str.starts_with("HTTP/1.1 200");
+    if status_ok {
+        NativeResponse {
+            body: Some(body.to_string()),
+            error: None,
+        }
+    } else {
+        let error = serde_json::from_str::<serde_json::Value>(body)
+            .ok()
+            .and_then(|v| v.get("error").and_then(|e| e.as_str()).map(String::from))
+            .unwrap_or_else(|| "request_denied".to_string());
+        NativeResponse {
+            body: None,
+            error: Some(error),
+        }
+    }
+}
+
+fn main() {
+    while let Some(req) = read_native_message() {
+        let resp = forward_to_sign_server(&req);
+        write_native_response(&resp);
+    }
+}

--- a/cmd/passless/src/commands/agent_admin.rs
+++ b/cmd/passless/src/commands/agent_admin.rs
@@ -120,7 +120,7 @@ pub fn install_native_messaging(browser: &str, ext_dir: &Path, sign_proxy: &Path
     };
 
     let browser_exec = PathBuf::from(browser);
-    let manifest_path = install_native_messaging_manifest(ext_dir, &browser_exec, sign_proxy)
+    let manifest_path = install_native_messaging_manifest(ext_dir, &browser_exec, sign_proxy, None)
         .map_err(|e| Error::Other(e.to_string()))?;
 
     let ext_id = compute_extension_id(ext_dir);

--- a/cmd/passless/src/commands/agent_admin.rs
+++ b/cmd/passless/src/commands/agent_admin.rs
@@ -114,6 +114,31 @@ pub fn install(target: AgentSkillTarget, scope: AgentSkillScope, force: bool) ->
     Ok(())
 }
 
+pub fn install_native_messaging(browser: &str, ext_dir: &Path, sign_proxy: &Path) -> Result<()> {
+    use crate::agent::browser::{
+        NATIVE_MESSAGING_HOST_NAME, compute_extension_id, install_native_messaging_manifest,
+    };
+
+    let browser_exec = PathBuf::from(browser);
+    let manifest_path = install_native_messaging_manifest(ext_dir, &browser_exec, sign_proxy)
+        .map_err(|e| Error::Other(e.to_string()))?;
+
+    let ext_id = compute_extension_id(ext_dir);
+    println!(
+        "Installed native messaging manifest at {}",
+        manifest_path.display()
+    );
+    println!("  Host name: {}", NATIVE_MESSAGING_HOST_NAME);
+    println!("  Extension ID: {}", ext_id);
+    println!("  Sign proxy: {}", sign_proxy.display());
+    println!(
+        "\nNote: Ensure the extension is loaded with --load-extension={}",
+        ext_dir.display()
+    );
+
+    Ok(())
+}
+
 #[derive(Serialize)]
 struct AdminEnvelope<T: Serialize> {
     version: &'static str,
@@ -164,6 +189,11 @@ pub fn dispatch_admin(output: OutputFormat, action: &AgentAdminAction) -> Result
             scope,
             force,
         } => install(*target, *scope, *force),
+        AgentAdminAction::InstallNativeMessaging {
+            browser,
+            ext_dir,
+            sign_proxy,
+        } => install_native_messaging(browser, ext_dir, sign_proxy),
         AgentAdminAction::Profile { action } => dispatch_profile(output, action),
         AgentAdminAction::Policy { action } => dispatch_policy(output, action),
         AgentAdminAction::Credential { action } => dispatch_admin_credential(output, action),

--- a/cmd/passless/tests/agent_extension_behavioral.js
+++ b/cmd/passless/tests/agent_extension_behavioral.js
@@ -19,10 +19,11 @@ function renderBroker(channel) {
   return readTemplate("broker.js").replace(/__PASSLESS_CHANNEL__/g, channel);
 }
 
-function renderWorker(port, bearer) {
+function renderWorker(socketPath, bearer) {
   const bearerLiteral = JSON.stringify(bearer);
+  const socketPathLiteral = JSON.stringify(socketPath);
   return readTemplate("worker.js")
-    .replace(/__PASSLESS_PORT__/g, String(port))
+    .replace(/__PASSLESS_SOCKET_PATH__/g, socketPathLiteral)
     .replace(/__PASSLESS_BEARER__/g, bearerLiteral);
 }
 
@@ -200,32 +201,32 @@ function runBrokerTest(channel, setupFn) {
   return sandbox;
 }
 
-function runWorkerTest(port, bearer, setupFn) {
+function runWorkerTest(socketPath, bearer, setupFn) {
   const sandbox = {
     _listeners: [],
     _sendResponses: [],
-    _fetchCalls: [],
+    _nativeMessageCalls: [],
   };
 
   const chromeObj = {
     runtime: {
       id: "test-extension-id",
+      lastError: null,
       onMessage: {
         addListener: function(fn) {
           sandbox._listeners.push(fn);
         },
       },
+      sendNativeMessage: function(host, message, callback) {
+        sandbox._nativeMessageCalls.push({ host, message, callback });
+        if (sandbox._nativeMessageResponse) {
+          callback(sandbox._nativeMessageResponse);
+        }
+      },
     },
   };
 
   sandbox.chrome = chromeObj;
-  sandbox.fetch = function(url, opts) {
-    sandbox._fetchCalls.push({ url, opts });
-    if (sandbox._fetchResponse) {
-      return Promise.resolve(sandbox._fetchResponse);
-    }
-    return new Promise(function() {});
-  };
   sandbox.URL = URL;
   sandbox.Array = Array;
   sandbox.Object = Object;
@@ -238,7 +239,7 @@ function runWorkerTest(port, bearer, setupFn) {
   sandbox.Promise = Promise;
 
   const ctx = vm.createContext(sandbox);
-  const code = renderWorker(port, bearer);
+  const code = renderWorker(socketPath || "/tmp/test/sock", bearer);
   vm.runInContext(code, ctx);
 
   if (setupFn) setupFn(sandbox);
@@ -1136,7 +1137,7 @@ test("broker: rejects credential id that is not a string", async function() {
 // ======================== WORKER.JS BEHAVIORAL TESTS ========================
 
 test("worker: validates sender.url must be valid URL", async function() {
-  const sandbox = runWorkerTest(12345, "testtoken", function(sandbox) {
+  const sandbox = runWorkerTest("/tmp/test/sock", "testtoken", function(sandbox) {
     const listener = sandbox._listeners[0];
     assert.ok(listener);
 
@@ -1162,7 +1163,7 @@ test("worker: validates sender.url must be valid URL", async function() {
 });
 
 test("worker: validates sender.url must be https:", async function() {
-  const sandbox = runWorkerTest(12345, "testtoken", function(sandbox) {
+  const sandbox = runWorkerTest("/tmp/test/sock", "testtoken", function(sandbox) {
     const listener = sandbox._listeners[0];
 
     let response = null;
@@ -1186,7 +1187,7 @@ test("worker: validates sender.url must be https:", async function() {
 });
 
 test("worker: validates sender.id against chrome.runtime.id", async function() {
-  const sandbox = runWorkerTest(12345, "testtoken", function(sandbox) {
+  const sandbox = runWorkerTest("/tmp/test/sock", "testtoken", function(sandbox) {
     const listener = sandbox._listeners[0];
 
     let response = null;
@@ -1210,8 +1211,8 @@ test("worker: validates sender.id against chrome.runtime.id", async function() {
 });
 
 test("worker: accepts matching sender.id", async function() {
-  const sandbox = runWorkerTest(12345, "testtoken", function(sandbox) {
-    sandbox._fetchResponse = {
+  const sandbox = runWorkerTest("/tmp/test/sock", "testtoken", function(sandbox) {
+    sandbox._nativeMessageResponse = {
       ok: true,
       json: function() { return Promise.resolve({ sign_assertion_result: { credential_id_b64u: "abc" } }); },
     };
@@ -1234,12 +1235,12 @@ test("worker: accepts matching sender.id", async function() {
   });
 
   await flushPromises();
-  assert.strictEqual(sandbox._fetchCalls.length, 1);
+  assert.strictEqual(sandbox._nativeMessageCalls.length, 1);
 });
 
 test("worker: derives origin and cross_origin from sender.url", async function() {
-  const sandbox = runWorkerTest(12345, "testtoken", function(sandbox) {
-    sandbox._fetchResponse = {
+  const sandbox = runWorkerTest("/tmp/test/sock", "testtoken", function(sandbox) {
+    sandbox._nativeMessageResponse = {
       ok: true,
       json: function() { return Promise.resolve({}); },
     };
@@ -1266,16 +1267,16 @@ test("worker: derives origin and cross_origin from sender.url", async function()
   });
 
   await flushPromises();
-  assert.strictEqual(sandbox._fetchCalls.length, 1);
-  const body = JSON.parse(sandbox._fetchCalls[0].opts.body);
+  assert.strictEqual(sandbox._nativeMessageCalls.length, 1);
+  const body = JSON.parse(sandbox._nativeMessageCalls[0].message.body);
   assert.strictEqual(body.origin, "https://sub.example.com");
   assert.strictEqual(body.top_origin, "https://sub.example.com");
   assert.strictEqual(body.cross_origin, false);
 });
 
 test("worker: computes cross_origin=true for a cross-origin subframe", async function() {
-  const sandbox = runWorkerTest(12345, "testtoken", function(sandbox) {
-    sandbox._fetchResponse = {
+  const sandbox = runWorkerTest("/tmp/test/sock", "testtoken", function(sandbox) {
+    sandbox._nativeMessageResponse = {
       ok: true,
       json: function() { return Promise.resolve({}); },
     };
@@ -1302,15 +1303,15 @@ test("worker: computes cross_origin=true for a cross-origin subframe", async fun
   });
 
   await flushPromises();
-  const body = JSON.parse(sandbox._fetchCalls[0].opts.body);
+  const body = JSON.parse(sandbox._nativeMessageCalls[0].message.body);
   assert.strictEqual(body.origin, "https://evil.com");
   assert.strictEqual(body.top_origin, "https://example.com");
   assert.strictEqual(body.cross_origin, true);
 });
 
 test("worker: constructs fresh request object (not passthrough)", async function() {
-  const sandbox = runWorkerTest(12345, "testtoken", function(sandbox) {
-    sandbox._fetchResponse = {
+  const sandbox = runWorkerTest("/tmp/test/sock", "testtoken", function(sandbox) {
+    sandbox._nativeMessageResponse = {
       ok: true,
       json: function() { return Promise.resolve({}); },
     };
@@ -1332,19 +1333,16 @@ test("worker: constructs fresh request object (not passthrough)", async function
   });
 
   await flushPromises();
-  const body = JSON.parse(sandbox._fetchCalls[0].opts.body);
+  const body = JSON.parse(sandbox._nativeMessageCalls[0].message.body);
   assert.strictEqual(body.extra_field, undefined);
   assert.ok(body.origin);
   assert.ok(typeof body.cross_origin === "boolean");
 });
 
-test("worker: sends bearer token in Authorization header", async function() {
+test("worker: sends bearer token in native message", async function() {
   const bearerToken = "my-secret-bearer-token";
-  const sandbox = runWorkerTest(12345, bearerToken, function(sandbox) {
-    sandbox._fetchResponse = {
-      ok: true,
-      json: function() { return Promise.resolve({}); },
-    };
+  const sandbox = runWorkerTest("/tmp/test/sock", bearerToken, function(sandbox) {
+    sandbox._nativeMessageResponse = { body: "{}" };
 
     const listener = sandbox._listeners[0];
     const sender = { url: "https://example.com/page" };
@@ -1364,18 +1362,14 @@ test("worker: sends bearer token in Authorization header", async function() {
   });
 
   await flushPromises();
-  assert.strictEqual(sandbox._fetchCalls.length, 1);
-  const headers = sandbox._fetchCalls[0].opts.headers;
-  assert.strictEqual(headers["Authorization"], "Bearer " + bearerToken);
+  assert.strictEqual(sandbox._nativeMessageCalls.length, 1);
+  assert.strictEqual(sandbox._nativeMessageCalls[0].message.bearer, bearerToken);
 });
 
 test("worker: bearer token with special characters is safely injected", async function() {
   const bearerToken = 'tok"en\\with\nspecial\u00e9';
-  const sandbox = runWorkerTest(12345, bearerToken, function(sandbox) {
-    sandbox._fetchResponse = {
-      ok: true,
-      json: function() { return Promise.resolve({}); },
-    };
+  const sandbox = runWorkerTest("/tmp/test/sock", bearerToken, function(sandbox) {
+    sandbox._nativeMessageResponse = { body: "{}" };
 
     const listener = sandbox._listeners[0];
     const sender = { url: "https://example.com/page" };
@@ -1395,17 +1389,13 @@ test("worker: bearer token with special characters is safely injected", async fu
   });
 
   await flushPromises();
-  assert.strictEqual(sandbox._fetchCalls.length, 1);
-  const headers = sandbox._fetchCalls[0].opts.headers;
-  assert.strictEqual(headers["Authorization"], "Bearer " + bearerToken);
+  assert.strictEqual(sandbox._nativeMessageCalls.length, 1);
+  assert.strictEqual(sandbox._nativeMessageCalls[0].message.bearer, bearerToken);
 });
 
-test("worker: fetches correct URL with port", async function() {
-  const sandbox = runWorkerTest(54321, "tok", function(sandbox) {
-    sandbox._fetchResponse = {
-      ok: true,
-      json: function() { return Promise.resolve({}); },
-    };
+test("worker: sends correct socket path in native message", async function() {
+  const sandbox = runWorkerTest("/var/run/passless/sign/sock", "tok", function(sandbox) {
+    sandbox._nativeMessageResponse = { body: "{}" };
 
     const listener = sandbox._listeners[0];
     const sender = { url: "https://example.com/page" };
@@ -1425,11 +1415,12 @@ test("worker: fetches correct URL with port", async function() {
   });
 
   await flushPromises();
-  assert.strictEqual(sandbox._fetchCalls[0].url, "http://127.0.0.1:54321/sign");
+  assert.strictEqual(sandbox._nativeMessageCalls[0].message.socket_path, "/var/run/passless/sign/sock");
+  assert.strictEqual(sandbox._nativeMessageCalls[0].message.path, "/sign");
 });
 
 test("worker: rejects rp_id exceeding MAX_RP_ID_LEN", async function() {
-  const sandbox = runWorkerTest(12345, "tok", function(sandbox) {
+  const sandbox = runWorkerTest("/tmp/test/sock", "tok", function(sandbox) {
     const listener = sandbox._listeners[0];
     let response = null;
     const sender = { url: "https://example.com/page" };
@@ -1452,7 +1443,7 @@ test("worker: rejects rp_id exceeding MAX_RP_ID_LEN", async function() {
 });
 
 test("worker: rejects challenge_b64u exceeding MAX_CHALLENGE_B64U_LEN", async function() {
-  const sandbox = runWorkerTest(12345, "tok", function(sandbox) {
+  const sandbox = runWorkerTest("/tmp/test/sock", "tok", function(sandbox) {
     const listener = sandbox._listeners[0];
     let response = null;
     const sender = { url: "https://example.com/page" };
@@ -1475,7 +1466,7 @@ test("worker: rejects challenge_b64u exceeding MAX_CHALLENGE_B64U_LEN", async fu
 });
 
 test("worker: rejects allow_credentials exceeding MAX_ALLOW_CREDENTIALS", async function() {
-  const sandbox = runWorkerTest(12345, "tok", function(sandbox) {
+  const sandbox = runWorkerTest("/tmp/test/sock", "tok", function(sandbox) {
     const listener = sandbox._listeners[0];
     let response = null;
     const creds = [];
@@ -1502,7 +1493,7 @@ test("worker: rejects allow_credentials exceeding MAX_ALLOW_CREDENTIALS", async 
 });
 
 test("worker: rejects invalid user_verification", async function() {
-  const sandbox = runWorkerTest(12345, "tok", function(sandbox) {
+  const sandbox = runWorkerTest("/tmp/test/sock", "tok", function(sandbox) {
     const listener = sandbox._listeners[0];
     let response = null;
     const sender = { url: "https://example.com/page" };
@@ -1526,8 +1517,8 @@ test("worker: rejects invalid user_verification", async function() {
 
 test("worker: accepts all valid user_verification values", async function() {
   for (const uv of ["required", "preferred", "discouraged"]) {
-    const sandbox = runWorkerTest(12345, "tok", function(sandbox) {
-      sandbox._fetchResponse = {
+    const sandbox = runWorkerTest("/tmp/test/sock", "tok", function(sandbox) {
+      sandbox._nativeMessageResponse = {
         ok: true,
         json: function() { return Promise.resolve({}); },
       };
@@ -1550,17 +1541,17 @@ test("worker: accepts all valid user_verification values", async function() {
     });
 
     await flushPromises();
-    assert.strictEqual(sandbox._fetchCalls.length, 1, "should fetch for uv=" + uv);
-    const body = JSON.parse(sandbox._fetchCalls[0].opts.body);
+    assert.strictEqual(sandbox._nativeMessageCalls.length, 1, "should send native message for uv=" + uv);
+    const body = JSON.parse(sandbox._nativeMessageCalls[0].message.body);
     assert.strictEqual(body.user_verification, uv === "required");
   }
 });
 
 test("worker: malformed daemon response results in ok:false", async function() {
   let asyncResponse = null;
-  const sandbox = runWorkerTest(12345, "tok", function(sandbox) {
-    sandbox._fetchResponse = {
-      ok: false,
+  const sandbox = runWorkerTest("/tmp/test/sock", "tok", function(sandbox) {
+    sandbox._nativeMessageResponse = {
+      error: "invalid_daemon_response",
     };
 
     const listener = sandbox._listeners[0];
@@ -1585,11 +1576,13 @@ test("worker: malformed daemon response results in ok:false", async function() {
   assert.strictEqual(asyncResponse.ok, false);
 });
 
-test("worker: fetch error results in ok:false", async function() {
+test("worker: native messaging error results in ok:false", async function() {
   let asyncResponse = null;
-  const sandbox = runWorkerTest(12345, "tok", function(sandbox) {
-    sandbox.fetch = function() {
-      return Promise.reject(new Error("network error"));
+  const sandbox = runWorkerTest("/tmp/test/sock", "tok", function(sandbox) {
+    sandbox.chrome.runtime.sendNativeMessage = function(host, message, callback) {
+      sandbox.chrome.runtime.lastError = { message: "host not found" };
+      callback(null);
+      sandbox.chrome.runtime.lastError = null;
     };
 
     const listener = sandbox._listeners[0];
@@ -1617,7 +1610,7 @@ test("worker: fetch error results in ok:false", async function() {
 });
 
 test("worker: rejects request body exceeding MAX_REQUEST_BYTES", async function() {
-  const sandbox = runWorkerTest(12345, "tok", function(sandbox) {
+  const sandbox = runWorkerTest("/tmp/test/sock", "tok", function(sandbox) {
     const listener = sandbox._listeners[0];
     let response = null;
     const bigCreds = [];
@@ -1644,7 +1637,7 @@ test("worker: rejects request body exceeding MAX_REQUEST_BYTES", async function(
 });
 
 test("worker: rejects message from wrong source", async function() {
-  const sandbox = runWorkerTest(12345, "tok", function(sandbox) {
+  const sandbox = runWorkerTest("/tmp/test/sock", "tok", function(sandbox) {
     const listener = sandbox._listeners[0];
     let called = false;
     const sender = { url: "https://example.com/page" };
@@ -1667,7 +1660,7 @@ test("worker: rejects message from wrong source", async function() {
 });
 
 test("worker: rejects message without request", async function() {
-  const sandbox = runWorkerTest(12345, "tok", function(sandbox) {
+  const sandbox = runWorkerTest("/tmp/test/sock", "tok", function(sandbox) {
     const listener = sandbox._listeners[0];
     let called = false;
     const sender = { url: "https://example.com/page" };
@@ -1682,7 +1675,7 @@ test("worker: rejects message without request", async function() {
 });
 
 test("worker: rejects credential id exceeding MAX_CREDENTIAL_ID_B64U_LEN", async function() {
-  const sandbox = runWorkerTest(12345, "tok", function(sandbox) {
+  const sandbox = runWorkerTest("/tmp/test/sock", "tok", function(sandbox) {
     const listener = sandbox._listeners[0];
     let response = null;
     const sender = { url: "https://example.com/page" };
@@ -1705,7 +1698,7 @@ test("worker: rejects credential id exceeding MAX_CREDENTIAL_ID_B64U_LEN", async
 });
 
 test("worker: rejects credential id that is not a string", async function() {
-  const sandbox = runWorkerTest(12345, "tok", function(sandbox) {
+  const sandbox = runWorkerTest("/tmp/test/sock", "tok", function(sandbox) {
     const listener = sandbox._listeners[0];
     let response = null;
     const sender = { url: "https://example.com/page" };
@@ -1731,7 +1724,7 @@ test("worker: rejects credential id that is not a string", async function() {
 
 test("bearer: generated worker JS parses with special-character token", async function() {
   const token = 'tok"with\\special\nchars\u00e9';
-  const rendered = renderWorker(12345, token);
+  const rendered = renderWorker("/tmp/test/sock", token);
   const sandbox = { chrome: { runtime: { id: "x", onMessage: { addListener: function() {} } } } };
   const ctx = vm.createContext(sandbox);
   vm.runInContext(rendered, ctx);

--- a/cmd/passless/tests/agent_extension_behavioral.js
+++ b/cmd/passless/tests/agent_extension_behavioral.js
@@ -150,6 +150,12 @@ function runMainTest(channel, setupFn) {
   return sandbox;
 }
 
+function runBrokerCode(sandbox, channel) {
+  const ctx = vm.createContext(sandbox);
+  const code = renderBroker(channel);
+  vm.runInContext(code, ctx);
+}
+
 function runBrokerTest(channel, setupFn) {
   const sandbox = {
     _chromeSendResponse: null,
@@ -181,10 +187,18 @@ function runBrokerTest(channel, setupFn) {
     },
   };
 
+  const documentElement = {
+    _attributes: new Set(),
+    hasAttribute: function(name) { return this._attributes.has(name); },
+    setAttribute: function(name) { this._attributes.add(name); },
+  };
+  sandbox._windowListeners = windowListeners;
   sandbox.window = windowObj;
+  sandbox.document = { documentElement: documentElement };
   sandbox.chrome = chromeObj;
   sandbox.location = { origin: "https://example.com" };
   sandbox.Array = Array;
+  sandbox.Set = Set;
   sandbox.Object = Object;
   sandbox.String = String;
   sandbox.Boolean = Boolean;
@@ -192,9 +206,7 @@ function runBrokerTest(channel, setupFn) {
   sandbox.JSON = JSON;
   sandbox.TypeError = TypeError;
 
-  const ctx = vm.createContext(sandbox);
-  const code = renderBroker(channel);
-  vm.runInContext(code, ctx);
+  runBrokerCode(sandbox, channel);
 
   if (setupFn) setupFn(sandbox, windowListeners);
 
@@ -529,6 +541,7 @@ test("main: constructs Gitea-compatible credential from daemon response", async 
       messageHandler,
       {
         source: "passless-agent-broker",
+        request_id: "request-1",
         channel: ch,
         id: requestId,
         ok: true,
@@ -572,6 +585,7 @@ test("main: malformed daemon response becomes NotAllowedError", async function()
       messageHandler,
       {
         source: "passless-agent-broker",
+        request_id: "request-1",
         channel: ch,
         id: requestId,
         ok: true,
@@ -608,6 +622,7 @@ test("main: broker ok=false becomes NotAllowedError", async function() {
       messageHandler,
       {
         source: "passless-agent-broker",
+        request_id: "request-1",
         channel: ch,
         id: requestId,
         ok: false,
@@ -643,6 +658,7 @@ test("main: ignores messages from wrong source", async function() {
       messageHandler,
       {
         source: "passless-agent-broker",
+        request_id: "request-1",
         channel: ch,
         id: requestId,
         ok: true,
@@ -682,6 +698,7 @@ test("main: ignores messages with wrong channel", async function() {
       messageHandler,
       {
         source: "passless-agent-broker",
+        request_id: "request-1",
         channel: "wrong-channel",
         id: requestId,
         ok: true,
@@ -724,6 +741,7 @@ test("main: fresh object construction for each credential response", async funct
         messageHandler,
         {
           source: "passless-agent-broker",
+        request_id: "request-1",
           channel: ch,
           id: requestId,
           ok: true,
@@ -867,6 +885,37 @@ test("broker: forwards valid request to chrome.runtime.sendMessage", async funct
   assert.strictEqual(sandbox._chromeSendMessage.request.rp_id, "example.com");
 });
 
+test("broker: ignores duplicate injection for the same channel", async function() {
+  const ch = "broker-duplicate";
+  let sendCount = 0;
+  const sandbox = runBrokerTest(ch, function(sandbox) {
+    sandbox.chrome.runtime.sendMessage = function(message, callback) {
+      sendCount++;
+      callback({ ok: true, response: { data: "test" } });
+    };
+  });
+
+  runBrokerCode(sandbox, ch);
+
+  simulateMessage(
+    sandbox._windowListeners.message,
+    {
+      source: "passless-agent-main",
+      channel: ch,
+      id: "req-1",
+      request: {
+        rp_id: "example.com",
+        challenge_b64u: b64url(makeChallenge(32)),
+        allow_credentials: [],
+        user_verification: false,
+      },
+    },
+    sandbox.window,
+    "https://example.com"
+  );
+
+  assert.strictEqual(sendCount, 1);
+});
 test("broker: rejects message from wrong source", async function() {
   const ch = "broker-ch2";
   const sandbox = runBrokerTest(ch, function(sandbox, listeners) {
@@ -1146,6 +1195,7 @@ test("worker: validates sender.url must be valid URL", async function() {
     listener(
       {
         source: "passless-agent-broker",
+        request_id: "request-1",
         request: {
           rp_id: "example.com",
           challenge_b64u: "aaa",
@@ -1171,6 +1221,7 @@ test("worker: validates sender.url must be https:", async function() {
     listener(
       {
         source: "passless-agent-broker",
+        request_id: "request-1",
         request: {
           rp_id: "example.com",
           challenge_b64u: "aaa",
@@ -1195,6 +1246,7 @@ test("worker: validates sender.id against chrome.runtime.id", async function() {
     listener(
       {
         source: "passless-agent-broker",
+        request_id: "request-1",
         request: {
           rp_id: "example.com",
           challenge_b64u: "aaa",
@@ -1222,6 +1274,7 @@ test("worker: accepts matching sender.id", async function() {
     listener(
       {
         source: "passless-agent-broker",
+        request_id: "request-1",
         request: {
           rp_id: "example.com",
           challenge_b64u: "aaa",
@@ -1238,6 +1291,33 @@ test("worker: accepts matching sender.id", async function() {
   assert.strictEqual(sandbox._nativeMessageCalls.length, 1);
 });
 
+test("worker: coalesces duplicate request IDs", async function() {
+  const sandbox = runWorkerTest("/tmp/test/sock", "testtoken");
+  const listener = sandbox._listeners[0];
+  const sender = { url: "https://example.com/page", id: "test-extension-id" };
+  const message = {
+    source: "passless-agent-broker",
+    request_id: "duplicate-request",
+    request: {
+      rp_id: "example.com",
+      challenge_b64u: "aaa",
+      allow_credentials: [],
+      user_verification: false,
+    },
+  };
+  const responses = [];
+
+  assert.strictEqual(listener(message, sender, function(response) { responses.push(response); }), true);
+  assert.strictEqual(listener(message, sender, function(response) { responses.push(response); }), true);
+  assert.strictEqual(sandbox._nativeMessageCalls.length, 1);
+
+  sandbox._nativeMessageCalls[0].callback({
+    body: JSON.stringify({ sign_assertion_result: { credential_id_b64u: "abc" } }),
+  });
+
+  assert.strictEqual(responses.length, 2);
+  assert.deepStrictEqual(responses[0], responses[1]);
+});
 test("worker: derives origin and cross_origin from sender.url", async function() {
   const sandbox = runWorkerTest("/tmp/test/sock", "testtoken", function(sandbox) {
     sandbox._nativeMessageResponse = {
@@ -1254,6 +1334,7 @@ test("worker: derives origin and cross_origin from sender.url", async function()
     listener(
       {
         source: "passless-agent-broker",
+        request_id: "request-1",
         request: {
           rp_id: "example.com",
           challenge_b64u: "aaa",
@@ -1290,6 +1371,7 @@ test("worker: computes cross_origin=true for a cross-origin subframe", async fun
     listener(
       {
         source: "passless-agent-broker",
+        request_id: "request-1",
         request: {
           rp_id: "example.com",
           challenge_b64u: "aaa",
@@ -1326,7 +1408,8 @@ test("worker: constructs fresh request object (not passthrough)", async function
     };
     const sender = { url: "https://example.com/page" };
     listener(
-      { source: "passless-agent-broker", request: originalRequest },
+      { source: "passless-agent-broker",
+        request_id: "request-1", request: originalRequest },
       sender,
       function() {}
     );
@@ -1349,6 +1432,7 @@ test("worker: sends bearer token in native message", async function() {
     listener(
       {
         source: "passless-agent-broker",
+        request_id: "request-1",
         request: {
           rp_id: "example.com",
           challenge_b64u: "aaa",
@@ -1376,6 +1460,7 @@ test("worker: bearer token with special characters is safely injected", async fu
     listener(
       {
         source: "passless-agent-broker",
+        request_id: "request-1",
         request: {
           rp_id: "example.com",
           challenge_b64u: "aaa",
@@ -1402,6 +1487,7 @@ test("worker: sends correct socket path in native message", async function() {
     listener(
       {
         source: "passless-agent-broker",
+        request_id: "request-1",
         request: {
           rp_id: "example.com",
           challenge_b64u: "aaa",
@@ -1427,6 +1513,7 @@ test("worker: rejects rp_id exceeding MAX_RP_ID_LEN", async function() {
     listener(
       {
         source: "passless-agent-broker",
+        request_id: "request-1",
         request: {
           rp_id: "x".repeat(254),
           challenge_b64u: "aaa",
@@ -1450,6 +1537,7 @@ test("worker: rejects challenge_b64u exceeding MAX_CHALLENGE_B64U_LEN", async fu
     listener(
       {
         source: "passless-agent-broker",
+        request_id: "request-1",
         request: {
           rp_id: "example.com",
           challenge_b64u: "x".repeat(2049),
@@ -1477,6 +1565,7 @@ test("worker: rejects allow_credentials exceeding MAX_ALLOW_CREDENTIALS", async 
     listener(
       {
         source: "passless-agent-broker",
+        request_id: "request-1",
         request: {
           rp_id: "example.com",
           challenge_b64u: "aaa",
@@ -1500,6 +1589,7 @@ test("worker: rejects invalid user_verification", async function() {
     listener(
       {
         source: "passless-agent-broker",
+        request_id: "request-1",
         request: {
           rp_id: "example.com",
           challenge_b64u: "aaa",
@@ -1528,6 +1618,7 @@ test("worker: accepts all valid user_verification values", async function() {
       listener(
         {
           source: "passless-agent-broker",
+        request_id: "request-1",
           request: {
             rp_id: "example.com",
             challenge_b64u: "aaa",
@@ -1559,6 +1650,7 @@ test("worker: malformed daemon response results in ok:false", async function() {
     listener(
       {
         source: "passless-agent-broker",
+        request_id: "request-1",
         request: {
           rp_id: "example.com",
           challenge_b64u: "aaa",
@@ -1590,6 +1682,7 @@ test("worker: native messaging error results in ok:false", async function() {
     const result = listener(
       {
         source: "passless-agent-broker",
+        request_id: "request-1",
         request: {
           rp_id: "example.com",
           challenge_b64u: "aaa",
@@ -1621,6 +1714,7 @@ test("worker: rejects request body exceeding MAX_REQUEST_BYTES", async function(
     listener(
       {
         source: "passless-agent-broker",
+        request_id: "request-1",
         request: {
           rp_id: "example.com",
           challenge_b64u: "x".repeat(2048),
@@ -1682,6 +1776,7 @@ test("worker: rejects credential id exceeding MAX_CREDENTIAL_ID_B64U_LEN", async
     listener(
       {
         source: "passless-agent-broker",
+        request_id: "request-1",
         request: {
           rp_id: "example.com",
           challenge_b64u: "aaa",
@@ -1705,6 +1800,7 @@ test("worker: rejects credential id that is not a string", async function() {
     listener(
       {
         source: "passless-agent-broker",
+        request_id: "request-1",
         request: {
           rp_id: "example.com",
           challenge_b64u: "aaa",

--- a/docs/decisions/0008-same-user-trust-boundary.md
+++ b/docs/decisions/0008-same-user-trust-boundary.md
@@ -1,0 +1,75 @@
+# ADR 0008: Same-user agent trust boundary and browser hardening scope
+
+- **Status:** Accepted
+- **Date:** 2026-08-27
+- **Decision owners:** Passless maintainers
+- **Related decisions:** [ADR 0007](0007-unified-agent-identity-modes.md), [ADR 0005](0005-delegated-autonomous-authentication-redesign.md)
+- **Supersedes:** the framing of C-1 as an open security gap in [FURTHER_ANALYSIS.md](../security/FURTHER_ANALYSIS.md)
+
+## Context
+
+The `same-user` agent mode is intended to be a low-security but practical way to give an
+agent (e.g. an LLM-driven automation process) access to the user's existing passkeys. Per
+ADR 0007, a same-user profile is explicitly trusted as the authenticator user; its RP
+rules, short session TTLs, credential selectors, operation binding, and audit limit
+authority — they do not attempt to isolate the agent from the user.
+
+In this mode the daemon is unprivileged (`daemon_uid != 0`) and the browser is spawned
+with the same UID/GID as the daemon (`is_trusted_same_user_port_launch`). Security
+analysis item C-1 flagged that the port-mode spawn path applies no process hardening and
+framed this as a high-severity gap, listing `close_range`, `setuid`, rlimits, and
+`PR_SET_NO_NEW_PRIVS` as skipped.
+
+Review of the actual code shows this framing is inaccurate:
+
+- `HardenedChildSetup::apply()` is already same-user-aware. `close_range`,
+  `setgroups`/`setgid`/`setuid`, and all rlimits are gated behind `!same_user` there.
+  They would not be applied in same-user mode even if `apply()` were called.
+- The only controls the trusted port path skips are `PR_SET_PDEATHSIG` and
+  `PR_SET_NO_NEW_PRIVS`.
+
+More fundamentally, under Linux there is no kernel-enforced boundary between
+same-UID processes, independent of what `pre_exec` does: a same-UID browser can
+`ptrace` the daemon, read `/proc/<daemon>/mem` and `/proc/<daemon>/fd/*`, connect to the
+user-owned sign socket, and read the bearer token from the user's environment or memory.
+The headline C-1 scenario ("browser exploit → daemon compromise") is already true of any
+same-UID process and cannot be prevented by spawn-time hardening.
+
+## Decision
+
+1. **Same-user mode does not attempt OS-level process isolation between the browser and
+   the daemon.** The security boundary for same-user agent operation lives in the policy
+   layer: exact RP rules, grant scoping, short session TTLs, credential selectors,
+   operation binding, and complete audit. Same-UID local compromise is inside the trust
+   boundary, as ADR 0007 already states.
+
+2. **Omitting `PR_SET_NO_NEW_PRIVS` in same-user port mode is intentional.**
+   Chromium requires either its setuid `chrome-sandbox` helper or an unprivileged user
+   namespace during startup; NNP would break the helper path and provides negligible
+   protection against an attacker who already runs as the same UID.
+
+3. **Residual work is resilience/hygiene only, not security:**
+   - Close unintended inherited daemon FDs in the same-user port-mode spawn (robustness:
+     stale `/dev/uhid`, listen sockets, and pipe ends can interfere with lease cleanup).
+   - Set `PR_SET_PDEATHSIG` (or verify equivalent orphan reaping) so a browser is not
+     orphaned when the daemon dies.
+   - Optionally apply rlimits for resource robustness (limit session starvation), framed
+     as reliability, not sandboxing.
+
+## Consequences
+
+- C-1 is closed as "accepted — by design" and no longer tracked as an open security gap.
+- `FURTHER_ANALYSIS.md` keeps a pointer here; its severity framing of C-1 is superseded.
+- Effort previously allocated to same-user spawn hardening is redirected to the
+  cross-attack-surface items where a real boundary exists (C-2 daemon privileges,
+  H-1 D-Bus notification integrity, C-3 grant approval model).
+- Trade-off accepted: any process running as the user can drive the sign socket subject
+  to policy. This is the deliberate price of the mode's practicality and matches
+  ssh-agent / gpg-agent session trust models.
+
+## References
+
+- `cmd/passless/src/agent/browser.rs` `is_trusted_same_user_port_launch`, `spawn_browser_port_mode`
+- `cmd/passless/src/agent/launcher.rs` `HardenedChildSetup::apply`
+- [ADR 0007](0007-unified-agent-identity-modes.md) threat table: same-user trust boundary
+- [FURTHER_ANALYSIS.md](../security/FURTHER_ANALYSIS.md) C-1 (superseded framing)

--- a/docs/decisions/0009-daemon-hardening-scope.md
+++ b/docs/decisions/0009-daemon-hardening-scope.md
@@ -1,0 +1,72 @@
+# ADR 0009: Daemon hardening scope — root multi-principal deployments only
+
+- **Status:** Accepted
+- **Date:** 2026-08-27
+- **Decision owners:** Passless maintainers
+- **Related decisions:** [ADR 0008](0008-same-user-trust-boundary.md), [ADR 0007](0007-unified-agent-identity-modes.md)
+- **Affects:** security analysis item C-2 in [FURTHER_ANALYSIS.md](../security/FURTHER_ANALYSIS.md)
+
+## Context
+
+C-2 documents that the root system unit (`passless-agent.service`) runs with
+`NoNewPrivileges=false`, `PrivateDevices=false`, and lacks ~11 systemd hardening
+directives. Ground-truth review (2026-08) clarified the deployment reality:
+
+- Two units exist. The system unit (`passless-agent.service`) runs as root for
+  cross-user principal/browser spawning; the user unit (`passless.service`) runs
+  unprivileged as the logged-in user.
+- Root is needed **continuously**, not only at startup: every cross-user spawn
+  performs `setuid`/`setgid` in the child (`launcher.rs` `HardenedChildSetup::apply`),
+  which is precisely why `NoNewPrivileges=false`. No capability-dropping code exists.
+- `PrivateDevices=false` is required: Chromium enumerates dynamically-created hidraw
+  nodes, so a static device namespace cannot work.
+
+The meaningful question is therefore not "should the daemon be less privileged" in the
+abstract, but **which deployment mode C-2 applies to**. In same-user mode (ADR 0008), the
+daemon is unprivileged and the browser shares the user's UID — no OS boundary exists or
+is attempted, and the user unit's weak systemd hardening score is a non-issue.
+
+## Decision
+
+1. **C-2 is in-scope only for the root multi-principal (cross-user isolation)
+   deployment mode.** This mode provides real isolation between the agent and the user
+   and therefore warrants maximal defense-in-depth for the root daemon.
+
+2. **For same-user deployments**, C-2 does not apply (covered by ADR 0008). The user
+   unit's `systemd-analyze security` score (9.4 UNSAFE) is accepted as the mode's intent
+   — the daemon has no more privilege than the session it serves.
+
+3. **Hardening work is deferred for later implementation**, recorded here as the
+   roadmap for the root deployment:
+
+   - **C-2a — freely additive directives** (no code risk, implement when the root mode
+     is deployed): `ProtectHostname=true`, `ProtectClock=true`,
+     `ProtectKernelLogs=true`, `LockPersonality=true`, `RestrictRealtime=true`,
+     `RestrictAddressFamilies=AF_UNIX` (+ `AF_INET AF_INET6` only if networking is
+     needed by the deployment).
+   - **C-2b — evaluated directives**: `RestrictNamespaces` and `MemoryDenyWriteExecute`
+     (must be tested against browser spawn / JIT), and the high-value pair
+     `CapabilityBoundingSet` (bound to the minimal set the daemon needs, e.g.
+     CAP_SETUID/CAP_SETGID + device access) and `SystemCallFilter` (requires syscall
+     profiling first).
+
+4. **Open design problem deferred:** whether the daemon can operate with a bounded
+   capability set instead of full root (capability dropping post-startup, or a small
+   privileged helper for setuid spawn and UHID creation). Deferred because it requires
+   an isolation-mode redesign, not a unit-file change.
+
+## Consequences
+
+- C-2 stays open in FURTHER_ANALYSIS.md but is re-scoped: it tracks hardening of the
+  **root multi-principal** deployment only.
+- No code or unit-file changes now; the additive list (C-2a) and evaluation list (C-2b)
+  are the implementation backlog for when the isolated mode is productionized.
+- Same-user deployments have no C-2 action items.
+
+## References
+
+- `contrib/systemd/passless-agent.service` (system/root unit)
+- `contrib/systemd/passless.service` (user unit)
+- `cmd/passless/src/agent/launcher.rs` `HardenedChildSetup::apply` (setuid in child)
+- [ADR 0008](0008-same-user-trust-boundary.md) — same-user trust boundary
+- [FURTHER_ANALYSIS.md](../security/FURTHER_ANALYSIS.md) C-2

--- a/docs/decisions/0010-namespace-isolation-scope.md
+++ b/docs/decisions/0010-namespace-isolation-scope.md
@@ -1,0 +1,65 @@
+# ADR 0010: OS namespace isolation scope — isolated mode only, mount-first, pipe-mode preferred
+
+- **Status:** Accepted
+- **Date:** 2026-08-27
+- **Decision owners:** Passless maintainers
+- **Related decisions:** [ADR 0008](0008-same-user-trust-boundary.md), [ADR 0009](0009-daemon-hardening-scope.md), [ADR 0007](0007-unified-agent-identity-modes.md)
+- **Affects:** security analysis item H-2 in [FURTHER_ANALYSIS.md](../security/FURTHER_ANALYSIS.md)
+
+## Context
+
+H-2 documents that no Linux namespace isolation is applied to browser or principal
+processes. Ground-truth review (2026-08) confirmed:
+
+- No `unshare()` / `clone(CLONE_NEW*)` / `setns()` call exists anywhere. All spawn paths
+  (`spawn_browser_hardened`, `spawn_browser_port_mode`, `spawn_principal`) share the
+  daemon's mount, PID, network, user, and IPC namespaces.
+- `read_namespace_inodes()` only observes namespace inodes to detect a peer migrating
+  namespaces mid-session; it enforces nothing.
+- The browser inherits the daemon environment wholesale (`DISPLAY`, `WAYLAND_DISPLAY`,
+  X11/Wayland sockets, D-Bus); no scrubbing or bind-mount awareness exists.
+- Two CDP exposure modes exist: pipe mode (CDP over fds 3/4, no network) and port mode
+  (CDP over `127.0.0.1:<port>`, requires shared loopback).
+- A naming ambiguity exists: `AgentMode::Isolated` means **credential** isolation
+  (separate storage backend), not OS namespace isolation.
+
+## Decision
+
+1. **H-2 is out of scope for same-user mode.** Per ADR 0008, the browser runs in the
+   user's session trust boundary. Mount/user namespace games against a same-UID,
+   ptrace-capable peer offer no commensurate security for the usability cost
+   (fonts/themes/D-Bus/Wayland fragmentation).
+
+2. **H-2 is in scope for the isolated (cross-user) deployment mode only**, deferred
+   together with C-2 (ADR 0009) until that mode is productionized. Order of work when
+   picked up:
+   - **Mount namespace first** — hide other principals' storage and daemon-only paths
+     from the browser/principal, with a configurable bind-mount allowlist
+     (profile dir, runtime dir, X11/Wayland socket, fonts, themes).
+   - **PID namespace** as a stretch goal.
+   - **Network namespace only in pipe mode.** Port mode is documented as incompatible
+     with network isolation (CDP discovery requires shared loopback).
+
+3. **Terminology disambiguation:** `AgentMode::Isolated` continues to mean
+   credential/storage isolation. Any future OS namespace hardening is a separate layer
+   and must not be implied by the mode name. Documentation should avoid conflating the
+   two.
+
+4. **Implementation notes for later:** `nix` is already a dependency but needs the
+   `sched` (unshare, CloneFlags) and `mount` features enabled; no bubblewrap/landlock
+   crates are vendored.
+
+## Consequences
+
+- H-2 remains open but re-scoped: an implementation backlog item for isolated mode only.
+- Same-user mode has no namespace action items (closed by ADR 0008).
+- Doc/terminology hygiene: future docs must not conflate credential `Isolated` with OS
+  namespace isolation.
+
+## References
+
+- `cmd/passless/src/agent/browser.rs` spawn paths; `launcher.rs` `HardenedChildSetup::apply`
+- `cmd/passless/src/agent/launcher.rs` `read_namespace_inodes` (verification-only)
+- `passless-core/src/agent/config.rs` `AgentMode::Isolated`, `CdpExposeMode::{Pipe,Port}`
+- [ADR 0008](0008-same-user-trust-boundary.md), [ADR 0009](0009-daemon-hardening-scope.md)
+- [FURTHER_ANALYSIS.md](../security/FURTHER_ANALYSIS.md) H-2

--- a/docs/decisions/0011-seccomp-scope.md
+++ b/docs/decisions/0011-seccomp-scope.md
@@ -1,0 +1,53 @@
+# ADR 0011: seccomp-BPF scope — isolated mode only, principal-first, browser deferred
+
+- **Status:** Accepted
+- **Date:** 2026-08-27
+- **Decision owners:** Passless maintainers
+- **Related decisions:** [ADR 0008](0008-same-user-trust-boundary.md), [ADR 0009](0009-daemon-hardening-scope.md), [ADR 0010](0010-namespace-isolation-scope.md)
+- **Affects:** security analysis item H-3 in [FURTHER_ANALYSIS.md](../security/FURTHER_ANALYSIS.md)
+
+## Context
+
+H-3 documents that no seccomp-BPF filter is applied to any spawned process. Ground-truth
+review (2026-08) confirmed:
+
+- No seccomp setup exists anywhere; `PR_SET_NO_NEW_PRIVS` is the only syscall-adjacent
+  restriction on children. No seccomp/libseccomp crate is vendored; all hardening uses
+  raw `libc`.
+- The agent passes no sandbox-related flags to Chromium. Chromium applies its own
+  internal seccomp sandbox to renderer/GPU processes; the gap concerns the browser
+  *chrome* process and our *principal* process.
+- No syscall profiling has ever been performed; the required syscall surface for either
+  child type is undocumented.
+
+## Decision
+
+1. **H-3 is out of scope for same-user mode.** Per ADR 0008 the browser is inside the
+   user's trust boundary; a same-UID peer can ptrace the daemon, so restricting the
+   child's syscall set does not raise the boundary — and wrapper setup risks breaking
+   Chromium.
+
+2. **Isolated (cross-user) mode only**, split by risk into two backlog items:
+   - **H-3a — principal process seccomp (early, feasible).** The principal is our own
+     binary with a controlled syscall surface. Blacklist-first (e.g. ptrace, mount,
+     bpf, init_module, kexec_load, perf_event_open) is maintainable and low-risk.
+     Implement alongside the isolated-mode hardening work (ADRs 0009/0010).
+   - **H-3b — browser chrome process seccomp (deferred).** Chromium sandbox
+     initialization is version-dependent; even a blacklist can break startup on some
+     versions. Deferred to the same wave as the mount-namespace work (ADR 0010) and
+     requires syscall profiling first per Chromium version.
+
+## Consequences
+
+- H-3 remains open but re-scoped: isolated-mode only, principal-first.
+- Same-user mode has no seccomp action items (closed by ADR 0008).
+- Chromium renderer/GPU seccomp remains Chromium's responsibility (already present); no
+  change needed there.
+
+## References
+
+- `cmd/passless/src/agent/launcher.rs` `HardenedChildSetup::apply`
+- `cmd/passless/src/agent/browser.rs` `build_browser_command` (no sandbox flags passed)
+- [FURTHER_ANALYSIS.md](../security/FURTHER_ANALYSIS.md) H-3 and risks section
+- [ADR 0009](0009-daemon-hardening-scope.md) — companion backlog for the daemon unit
+- [ADR 0010](0010-namespace-isolation-scope.md) — companion namespace backlog

--- a/docs/decisions/0012-grant-audit-and-notification-approval-integrity.md
+++ b/docs/decisions/0012-grant-audit-and-notification-approval-integrity.md
@@ -1,0 +1,92 @@
+# ADR 0012: Grant audit emission and D-Bus notification approval integrity
+
+- **Status:** Accepted (deferred implementation)
+- **Date:** 2026-08-27
+- **Decision owners:** Passless maintainers
+- **Related decisions:** [ADR 0001](0001-agent-authentication-security-model.md), [ADR 0007](0007-unified-agent-identity-modes.md), [ADR 0008](0008-same-user-trust-boundary.md)
+- **Affects:** security analysis items C-3 and H-1 in [FURTHER_ANALYSIS.md](../security/FURTHER_ANALYSIS.md)
+
+## Context
+
+### C-3 — Self-approval of grants
+
+FURTHER_ANALYSIS frames the agent requesting and approving its own grants as a
+high-severity gap. Ground-truth review (2026-08):
+
+- `AdminAuthority` is an empty seal. `admin_authority()` increments
+  `ADMIN_AUTHORITY_TOKEN`, which is **never read anywhere**. `approve_grant` and
+  `revoke_grant` take it as an unused `_authority` parameter. It provides no checking.
+- However, autonomy without human approval is the **designed behavior**: ADR 0001
+  accepts unattended operation, and ADR 0007 declares `authorization="allow"` profiles
+  trusted to authorize within their RP rules. The self-approval flow is not a bypass of
+  an intended check; it is the `allow` policy itself.
+- Real defenses around grants already exist: 32-byte session capability with
+  constant-time verification, TTL clamping, RP re-validation, max concurrent grants,
+  peer UID checks.
+- **The genuine defect the review missed:** grant requests and approvals emit **zero
+  audit records in production**. `GrantRequestBuilder` and `GrantApproveBuilder` exist
+  in `audit_events.rs` but are used only in tests. Only revocations are audited. The
+  complete-audit guarantee that ADRs 0001/0007 rely on for autonomous same-user
+  operation is therefore partially absent.
+
+### H-1 — D-Bus notification action injection
+
+Ground-truth review (2026-08):
+
+- notify-rust 4.18's `wait_for_action` exposes only the action string to the callback.
+  The D-Bus sender of `ActionInvoked` is not available through that API.
+- Existing mitigations: `min_review_delay_ms` (default 1000ms), notification-server
+  capability gate (fail-closed on unknown servers), action-string validation. None of
+  these authenticate the signal — a same-session process can synthesize
+  `ActionInvoked("approve")`.
+
+Unlike C-1/H-2/H-3, H-1 is **in scope for same-user mode**: the same-user trust model
+still distinguishes the *agent* from the *human*. `authorization="confirm"` exists
+precisely so a human approves. Synthetic signal injection collapses that human/agent
+distinction even within an uncompromised UID — the agent (or any same-session process)
+could self-confirm a ceremony intended for human approval. ADR 0008's "same-UID
+compromise is inside the boundary" does not neutralize this, because the boundary here
+is human-vs-agent, not UID-vs-UID.
+
+## Decision
+
+### C-3
+
+1. **Self-approval of grants is accepted as designed** for profiles whose RP rules
+   authorize it. The `AdminAuthority` token is cosmetic and its cosmetics are recorded
+   here as known-and-accepted; a later cleanup may simplify or remove the dead counter.
+2. **Backlogged action item (C-3a): emit production audit records for grant request and
+   grant approval** using the existing `GrantRequestBuilder`/`GrantApproveBuilder`,
+   recording at minimum: request ID, profile, principal identity, RP IDs, credential
+   scope, TTL, and decision. This closes the observability gap without changing the
+   approval model.
+
+### H-1
+
+1. **H-1 remains an open gap and is in scope for same-user mode.**
+2. **Backlogged action item (H-1a): verify the D-Bus sender of `ActionInvoked`.** The
+   fix requires bypassing notify-rust's `wait_for_action` and subscribing to
+   `org.freedesktop.Notifications.ActionInvoked` via zbus directly, then validating the
+   signal's sender matches the notification server's well-known-name owner (resolved at
+   prompt time). Reject actions from any other sender. Medium effort.
+3. `min_review_delay_ms` is kept as a timing heuristic only, documented as
+   non-authenticating.
+
+## Consequences
+
+- C-3: approval model unchanged; one backlog item (C-3a audit emission).
+- H-1: one backlog item (H-1a sender validation), scoped and specified for the next
+  same-user hardening round.
+- Both items are deferred for later implementation, to be picked up alongside the
+  same-user improvements batch.
+
+## References
+
+- `cmd/passless/src/agent/intent.rs` `AdminAuthority`, `admin_authority`, dead counter
+- `cmd/passless/src/agent/grant.rs` `approve_grant` / `revoke_grant` (unused `_authority`)
+- `cmd/passless/src/agent/runtime/browser_ensure.rs` self-approval flow
+- `cmd/passless/src/agent/audit_events.rs` `GrantRequestBuilder`/`GrantApproveBuilder`
+  (test-only usage)
+- `cmd/passless/src/agent/prompt.rs` `wait_for_action`, server capability gate,
+  `min_review_delay_ms`
+- [FURTHER_ANALYSIS.md](../security/FURTHER_ANALYSIS.md) C-3, H-1

--- a/docs/plans/same-user-hardening-batch.md
+++ b/docs/plans/same-user-hardening-batch.md
@@ -1,0 +1,245 @@
+# Same-User Hardening Batch — Implementation Plan
+
+- **Status:** Approved for execution
+- **Date:** 2026-08-27
+- **Scope:** The three same-user-relevant backlog items from the FURTHER_ANALYSIS review
+  round: C-3a (grant audit), C-1 residuals (spawn hygiene), H-1a (D-Bus sender
+  validation). Isolated-cross-user items (C-2, H-2, H-3) are out of scope.
+- **Decision basis:** [ADR 0008](../decisions/0008-same-user-trust-boundary.md),
+  [ADR 0012](../decisions/0012-grant-audit-and-notification-approval-integrity.md)
+- **Execution model:** the orchestrator does not write code. Each item is implemented by
+  a `general` subagent, verified, and committed as **one commit per item**, in the
+  order listed below. Docs commit first.
+
+---
+
+## Phase 0 — Commit the decision documents
+
+Uncommitted from the review round: ADRs 0008–0012 and the six status notes in
+`docs/security/FURTHER_ANALYSIS.md`.
+
+- **Files:** `docs/decisions/0008-*.md` … `0012-*.md`, `docs/security/FURTHER_ANALYSIS.md`
+- **Verify:** `git status` shows only these doc files; nothing else staged.
+- **Commit message:**
+  ```
+  docs: record decisions for security analysis gaps C-1..H-3
+
+  Add ADR 0008-0012 and status notes in FURTHER_ANALYSIS.md for the
+  six remaining findings: same-user trust boundary, daemon hardening
+  scope, namespace isolation scope, seccomp scope, grant audit and
+  D-Bus notification approval integrity.
+  ```
+
+---
+
+## Item 1 (C-3a) — Emit production audit records for grant request/approval
+
+**Goal:** every grant request and grant approval produces an audit record. Today
+`GrantRequestBuilder` and `GrantApproveBuilder` exist in
+`cmd/passless/src/agent/audit_events.rs:1445-1484` but are used only in tests; only
+revocations are audited (via `AdminGrantRevokeBuilder` at `runtime.rs:4475`).
+
+**Files:**
+- `cmd/passless/src/agent/grant.rs` — hook `approve_grant` (line ~564) and the request
+  creation path (`request_grant` / dynamic variant) to build + emit audit events.
+- `cmd/passless/src/agent/audit_events.rs` — builders already exist; only add fields if
+  genuinely missing (principal identity, decision).
+- `cmd/passless/src/agent/runtime/browser_ensure.rs` and `runtime.rs` (~5125-5133) —
+  grant issuance call sites that flow through the `GrantManager`; ideally the events are
+  emitted inside `grant.rs` so all call sites benefit without call-site changes.
+- Tests: extend the existing tests in `audit_events.rs` / `grant.rs` to assert events
+  are actually emitted into the audit sink in production code paths (not just test
+  helper usage).
+
+**Acceptance criteria:**
+1. Approving a grant emits a `GrantApprove` audit record with: request ID, RP IDs,
+   principal/profile identity, TTL applied, decision.
+2. Submitting a grant request emits a `GrantRequest` audit record.
+3. No change to the approval model itself (self-approval remains as designed).
+4. Existing audit tests still pass; new test(s) cover the production emission path.
+
+**Verification:**
+```bash
+cargo fmt --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test grant
+cargo test audit
+```
+
+**Commit message:**
+```
+feat: audit grant request and approval events in production
+
+Wire GrantRequestBuilder and GrantApproveBuilder into the GrantManager
+so grant lifecycle events are recorded outside of tests. Closes the
+observability gap identified in the C-3 review (ADR 0012). Approval
+behavior is unchanged; this is purely observability.
+```
+
+**Subagent prompt outline:** implement item 1 as specified above; discover the audit
+sink plumbing by following how `AdminGrantRevokeBuilder` is emitted at
+`runtime.rs:4475`; keep the change minimal; run the verification commands; report diff
+summary and test results. Do NOT commit — the orchestrator commits after review.
+
+---
+
+## Item 2 (C-1 residuals) — Same-user spawn hygiene: FD closure, PDEATHSIG, rlimits
+
+**Goal:** close the resilience-only leftovers from ADR 0008 for the trusted same-user
+port-mode spawn:
+
+1. **Close inherited FDs** in the same-user port spawn path (uses
+   `pre_exec` that skips `HardenedChildSetup::apply()` entirely — see
+   `browser.rs:2241-2254`). Only `setsid()` runs today, so the child inherits all
+   daemon FDs (sockets, audit files, UHID). Apply FD closure preserving only the FDs
+   the spawn legitimately needs. Reuse `close_range_preserving()` from
+   `launcher.rs:692` — do not write a second implementation.
+2. **`PR_SET_PDEATHSIG`** on the same-user spawn so the browser is reaped if the
+   daemon dies unexpectedly (currently it can be orphaned silently — inconsistent with
+   the hardened path at `launcher.rs:699`).
+3. **Optional rlimits** (`RLIMIT_NOFILE`, `RLIMIT_NPROC`, `RLIMIT_CORE`) on same-user
+   spawns for damage containment. Keep generous values; Chromium and the profile dir
+   must keep working. `RLIMIT_AS` excluded — too risky for Chromium.
+
+**Explicitly NOT in scope:** `PR_SET_NO_NEW_PRIVS` on the same-user path (Chromium's
+setuid sandbox helper may need it — see comment at `browser.rs:2244-2247`, recorded in
+ADR 0008).
+
+**Files:**
+- `cmd/passless/src/agent/browser.rs` — same-user port spawn pre_exec (line ~2241).
+- `cmd/passless/src/agent/launcher.rs` — reuse existing helpers; only touch if a small
+  refactor is needed to make `close_range_preserving()` callable from the same-user
+  pre_exec without invoking the rest of `apply()`.
+
+**Acceptance criteria:**
+1. Browser spawned in same-user port mode inherits no daemon FDs beyond the intended
+   ones.
+2. Browser receives SIGTERM if the daemon exits.
+3. `PR_SET_NO_NEW_PRIVS` remains unset on the same-user path.
+4. Chromium's setuid sandbox is not broken (guard via the existing warning comment;
+   verified at runtime by the user, not by unit tests).
+5. e2e login to idm.grigri.cloud still works (ask the user to re-verify, or run the
+   existing trace script `/tmp/opencode/fresh_idm_trace.py`).
+
+**Verification:**
+```bash
+cargo fmt --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test browser
+# runtime smoke: restart passless, re-run the idm.grigri.cloud login trace
+```
+
+**Commit message:**
+```
+fix: close inherited FDs and set PDEATHSIG on same-user browser spawn
+
+Same-user port-mode spawns skipped all pre_exec hardening including FD
+closure and PDEATHSIG, letting the browser inherit daemon FDs and
+survive daemon death as an orphan. Apply FD closure and PR_SET_PDEATHSIG
+on the same-user path, keeping PR_SET_NO_NEW_PRIVS unset to preserve
+Chromium's setuid sandbox helper (per ADR 0008). Resilience hygiene
+only — same-UID processes are inside the trust boundary.
+```
+
+**Subagent prompt outline:** implement item 2 as specified; reuse
+`close_range_preserving()`; keep the NNP exclusion; run the build/test verification
+commands; note that runtime verification is done by the orchestrator/user; report diff
+summary. Do NOT commit.
+
+---
+
+## Item 3 (H-1a) — Validate the D-Bus sender of `ActionInvoked`
+
+**Goal:** a confirmation/UV prompt only honors an `approve` action that came from the
+actual notification server. Today `prompt.rs:627` (`handle.wait_for_action(...)`)
+receives only the action string from notify-rust 4.18 and cannot authenticate the
+sender — any same-session process can forge `ActionInvoked("approve")` (see
+`prompt.rs:1529-1538` test helper doing exactly this).
+
+**Approach:** bypass `wait_for_action` for the action-waiting part:
+
+1. At `show()`, resolve the notification server's well-known-name owner
+   (`org.freedesktop.Notifications` → unique `:1.x` name) via zbus on the session bus.
+2. Install a zbus match rule for
+   `org.freedesktop.Notifications.ActionInvoked`, filtering the arrival loop by
+   (a) the notification ID returned from `Notify` and (b) **sender == the owner
+   resolved at step 1**.
+3. Reject/ignore anything else (`ActionAmbiguous`/timeout path is fail-closed already).
+4. Keep all existing mitigations (`min_review_delay_ms`, server-capability gate,
+   action-string validation).
+
+**Files:**
+- `cmd/passless/src/agent/prompt.rs` — the main change (around lines 552-666 and the
+  `wait_for_action` closure at ~627).
+- `cmd/passless/src/agent/notification.rs` — same `wait_for_action` pattern at lines
+  163, 265; apply the same sender check only if this path gates a security decision
+  (evaluate — informational notifications don't need it; note decision in the commit).
+- `Cargo.toml` — zbus is already a transitive dep via notify-rust 4.18; add it as a
+  direct dependency matching the version notify-rust uses, to avoid a second zbus in
+  the tree.
+- Tests: the existing synthetic-injection helper at `prompt.rs:1529-1538` must now
+  only be able to trigger actions from the test-owned bus name, and the positive test
+  path must demonstrate that a message from a wrong sender is ignored.
+
+**Acceptance criteria:**
+1. A forged `ActionInvoked("approve")` from any bus name other than the notification
+   server's owner is ignored.
+2. A valid action from the notification server still works (approval flow for
+   `authorization="confirm"` profiles remains functional).
+3. `min_review_delay_ms`, capability gating, and action validation unchanged.
+4. No second zbus version pulled in.
+
+**Verification:**
+```bash
+cargo fmt --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test prompt
+cargo tree -d zbus   # single version
+# runtime: trigger a real confirm prompt and approve it from the UI
+```
+
+**Commit message:**
+```
+fix: validate D-Bus sender of notification ActionInvoked signals
+
+Replace notify-rust wait_for_action with a raw zbus match that verifies
+the ActionInvoked sender matches the notification server's unique bus
+name resolved at notify time. Prevents any same-session process other
+than the notification server from forging approval (H-1, ADR 0012).
+Existing timing heuristic and capability gating are retained as-is.
+```
+
+**Subagent prompt outline:** implement item 3 as specified; inspect how `Handle` in
+notify-rust 4.18 handles the zbus connection so we subscribe on the same connection or
+appropriately; keep the API surface of `prompt()` unchanged; update the test helper so
+the test-mode injection path can still drive the flow but production requires the
+correct sender; run verification; report diff. Do NOT commit.
+
+---
+
+## Sequencing and hand-off rules
+
+- Execute strictly in order. Do not start item N+1 until item N is committed green.
+- Orchestrator reviews each subagent diff **before** committing.
+- Subagents must not `git commit` / `git push`.
+- Branch: `fix/security-toctou-url-validation-sign-server`.
+- Conventional commits enforced (each message above satisfies commitlint).
+- After all items: full suites — `cargo clippy --all-targets --all-features -- -D
+  warnings`, `cargo test`, plus a full-login regression (e2e trace).
+
+## Risks / watch-outs
+
+- **Item 2:** PDEATHSIG makes browser lifetime bound to the daemon; if any flow
+  intentionally lets the browser outlive the daemon, flag it before merging.
+- **Item 3:** the notification server can restart between `show()` and action arrival;
+  the unique-name owner check naturally fails then (fail-closed) — acceptable; log it.
+- **Item 3:** notify-rust version upgrades might change the zbus version — pin-match
+  to `notify-rust`'s zbus to avoid duplication (check `Cargo.lock`).
+
+## Open items for the user before kicking off
+
+1. Commit Phase 0 docs now, or fold into the batch end?
+2. Item 2 runtime verification (browser compile/restart) — should the orchestrator
+   pause after item 2's commit so you can re-run the login trace manually?
+3. Item 3: include `notification.rs` only if it gates a security decision — subagent
+   to evaluate and report before committing; OK?

--- a/docs/security/FURTHER_ANALYSIS.md
+++ b/docs/security/FURTHER_ANALYSIS.md
@@ -1,0 +1,687 @@
+# Security Analysis: Critical Issues Requiring Further Investigation
+
+## Overview
+
+This document catalogs critical and high-severity security issues identified in the Passless agent architecture that require deeper architectural analysis before remediation. These issues span three attack surfaces:
+
+1. **Same-user browser hardening** — When the daemon and browser run under the same UID, the hardening path is intentionally bypassed to accommodate Chromium's setuid sandbox helper. This creates a privilege inheritance chain where a compromised browser inherits the daemon's full privilege context.
+
+2. **Authorization model** — The agent internally requests and approves its own authentication grants using a sealed `AdminAuthority` token that can be constructed by any code path within the process, effectively making the agent both requester and approver.
+
+3. **Notification-based approval** — User verification relies on D-Bus desktop notifications whose action signals can be synthetically injected by any process on the same session bus.
+
+Each issue is analyzed with current state, attack scenarios, proposed solutions, and an implementation plan. These are not theoretical concerns — they represent concrete gaps between the documented security architecture and the actual implementation.
+
+---
+
+## Priority 1: Same-User Browser Hardening
+
+### C-1: Same-User Port-Mode Browser Spawns with Zero Hardening
+
+**File:** `cmd/passless/src/agent/browser.rs:1998-2035`
+
+**Current State:**
+
+When `is_trusted_same_user_port_launch()` returns `true` (daemon UID != 0, and target UID/GID match daemon UID/GID), the `pre_exec` closure in `spawn_browser_port_mode()` skips `setup.apply()` entirely:
+
+```rust
+// browser.rs:2020-2034
+unsafe {
+    cmd.pre_exec(move || {
+        if trusted_same_user {
+            // Do not set PR_SET_NO_NEW_PRIVS before exec in trusted
+            // same-user mode. Chromium may need its setuid sandbox helper
+            // during startup.
+            if libc::setsid() < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        } else {
+            setup.apply(&[0, 1, 2])
+        }
+    });
+}
+```
+
+The `HardenedChildSetup::apply()` method (`launcher.rs:690-756`) provides:
+- `PR_SET_NO_NEW_PRIVS` — prevents privilege escalation via setuid binaries
+- `close_range` — closes all inherited file descriptors
+- `setuid`/`setgid` — drops to target identity
+- Resource limits (`RLIMIT_NOFILE`, `RLIMIT_NPROC`, `RLIMIT_CORE`, `RLIMIT_AS`)
+
+**None of these are applied** in same-user port mode. The browser child inherits:
+- All open file descriptors from the daemon (including `/dev/uhid`, any storage backend handles, pipe endpoints)
+- The daemon's full resource limits
+- No `PR_SET_NO_NEW_PRIVS` — can exec setuid binaries
+- The daemon's complete privilege context
+
+**Attack Scenarios:**
+
+1. **Browser exploit → daemon compromise:** A vulnerability in Chromium (renderer, V8, GPU process) allows arbitrary code execution. The exploited process inherits the daemon's UID, open file descriptors to `/dev/uhid`, credential storage, and any other daemon resources. The attacker gains the daemon's full privilege context.
+
+2. **FD leakage to renderer:** Without `close_range`, any file descriptors the daemon has open (credential storage files, UHID device handles, log sockets) are accessible to the browser's renderer process through `/proc/self/fd/`.
+
+3. **Setuid escalation:** Without `PR_SET_NO_NEW_PRIVS`, the browser process can exec setuid-root binaries (e.g., `sudo`, `pkexec`) to attempt privilege escalation.
+
+**Why the bypass exists:**
+
+The comment states Chromium may need its setuid sandbox helper (`chrome-sandbox`) during startup. Chromium's sandbox requires either:
+- A setuid-root helper binary, or
+- An unprivileged user namespace (`user_namespaces(7)`)
+
+When `PR_SET_NO_NEW_PRIVS` is set, the setuid sandbox helper cannot elevate privileges. However, modern Chromium (>= 120) can fall back to unprivileged user namespaces if available, making the NNP bypass unnecessary on most current distributions.
+
+---
+
+### C-2: Daemon Runs as Root with NoNewPrivileges=false and Full /dev Access
+
+**File:** `contrib/systemd/passless-agent.service:37,42`
+
+**Current State:**
+
+The systemd service file explicitly disables two critical hardening directives:
+
+```ini
+# Process
+NoNewPrivileges=false
+# Note: NoNewPrivileges=false is required because the daemon uses setuid to
+# launch principal and browser processes under separate Unix identities.
+
+# Namespaces
+PrivateDevices=false
+# PrivateDevices cannot be enabled: Chromium enumerates dynamically created host
+# hidraw nodes after service startup, so static bind mounts are insufficient.
+```
+
+The daemon **must** run as root for:
+- Creating UHID endpoints (`/dev/uhid`)
+- `setuid`/`setgid` to launch principal processes under separate UIDs
+- Managing per-profile device policy via hidraw udev rules
+
+**Impact:**
+
+If the daemon process itself is compromised (e.g., through a vulnerability in CTAP command parsing, CBOR deserialization, or the credential storage backend), the attacker has:
+- Root access to the entire system
+- Access to `/dev/uhid` — can create arbitrary HID devices
+- Access to all hidraw devices — can intercept security key communications
+- Ability to read/write any file on the system
+- Ability to load kernel modules (unless `ProtectKernelModules` blocks it, which it does — see line 61)
+
+**Mitigations already in place:**
+- `ProtectSystem=strict` — read-only `/usr`, `/boot`, `/efi`
+- `ProtectHome=read-only` — read-only home directories
+- `PrivateTmp=true` — isolated `/tmp`
+- `ProtectKernelTunables=true` — read-only `/proc/sys`, `/sys`
+- `ProtectControlGroups=true` — read-only cgroup hierarchy
+- `ProtectKernelModules=true` — cannot load kernel modules
+- `RestrictSUIDSGID=true` — cannot create setuid/setgid files
+
+**Missing hardening directives that should be evaluated:**
+- `ProtectHostname=true` — prevents hostname changes
+- `ProtectClock=true` — prevents system clock changes
+- `ProtectKernelLogs=true` — prevents access to kernel log ring buffer
+- `RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6` — limits socket families
+- `RestrictNamespaces=true` — prevents creating new namespaces
+- `LockPersonality=true` — prevents changing execution domain
+- `MemoryDenyWriteExecute=true` — prevents W^X memory mappings (may conflict with JIT)
+- `RestrictRealtime=true` — prevents realtime scheduling
+- `SystemCallFilter=` — seccomp-BPF syscall whitelist
+
+---
+
+### H-2: No Namespace Isolation for Browser Processes
+
+**File:** `cmd/passless/src/agent/browser.rs:1869-1912, 2000-2035`
+
+**Current State:**
+
+Neither `spawn_browser_hardened()` nor `spawn_browser_port_mode()` create any Linux namespaces for the browser child process. The `HardenedChildSetup::apply()` method (`launcher.rs:690-756`) performs:
+- `setsid()` — new session
+- `prctl(PR_SET_PDEATHSIG)` — parent death signal
+- `setgroups`/`setgid`/`setuid` — identity change (cross-user only)
+- `prctl(PR_SET_NO_NEW_PRIVS)` — no new privileges (cross-user only)
+- `setrlimit` — resource limits (cross-user only)
+
+**No `unshare()` calls are made.** The browser process runs in the same:
+- Mount namespace as the daemon — full view of daemon's filesystem mounts
+- PID namespace — can see and signal daemon processes
+- Network namespace — shares daemon's network stack
+- User namespace — same UID/GID mapping
+- IPC namespace — shares daemon's IPC objects
+
+The architecture documentation describes namespace isolation as a design goal, but the implementation does not create any namespaces. The `read_namespace_inodes()` function (`launcher.rs:314`) reads namespace inodes for **verification** of principal identity, not for **enforcement** of isolation.
+
+**Attack Scenarios:**
+
+1. **Filesystem access:** A compromised browser can traverse the daemon's mount namespace and access any file the daemon can read, including credential storage, configuration files, and other principals' data.
+
+2. **Process interaction:** The browser can send signals to daemon processes (same PID namespace), potentially disrupting service or exploiting signal handlers.
+
+3. **Network access:** The browser shares the daemon's network namespace and can access any network service the daemon can reach, including internal services.
+
+---
+
+### H-3: No seccomp-BPF Filter on Any Spawned Process
+
+**File:** `cmd/passless/src/agent/browser.rs:1880-1907, launcher.rs:690-756`
+
+**Current State:**
+
+No seccomp-BPF (Berkeley Packet Filter) syscall filter is installed on any spawned process — neither the browser nor principal processes. The `HardenedChildSetup::apply()` method does not call `prctl(PR_SET_SECCOMP)` or use `seccomp_init()`/`seccomp_rule_add()`/`seccomp_load()`.
+
+The only syscall-related restriction is `PR_SET_NO_NEW_PRIVS`, which prevents privilege escalation but does not restrict which syscalls the process can invoke.
+
+**Impact:**
+
+A compromised browser or principal process has access to the full kernel syscall surface, including:
+- `ptrace` — can trace and manipulate other processes (same UID)
+- `mount` — can mount filesystems (if root)
+- `bpf` — can load BPF programs (if CAP_SYS_ADMIN)
+- `init_module`/`finit_module` — can load kernel modules (if CAP_SYS_MODULE)
+- `kexec_load` — can load a new kernel (if CAP_SYS_BOOT)
+- File creation, network access, process spawning — unrestricted
+
+**Comparison with similar projects:**
+
+- **Firejail:** Applies seccomp-BPF with a default blacklist of ~150 dangerous syscalls
+- **Flatpak:** Applies seccomp-BPF with architecture-specific whitelists
+- **systemd --user:** Can apply `SystemCallFilter=` per service
+- **Chromium's own sandbox:** Applies seccomp-BPF to renderer and GPU processes
+
+---
+
+## Priority 2: Authorization Model
+
+### C-3: Self-Approval of Authentication Grants
+
+**File:** `cmd/passless/src/agent/runtime/browser_ensure.rs:398-409`
+
+**Current State:**
+
+When a principal requests a browser authentication session, the agent:
+
+1. Creates a grant request via `admin_request_grant()` or `admin_request_dynamic_grant()` (`policy_engine.rs:1426-1448`)
+2. Immediately approves it via `admin_approve_grant()` with `admin_authority()` (`policy_engine.rs:1450-1462`)
+
+```rust
+// browser_ensure.rs:398-409
+// This is an internal approval, not admin IPC. The request reached this point only
+// after principal capability/peer/process verification and explicit trusted port mode.
+let grant_id = self
+    .policy_runtime
+    .admin_approve_grant(&request_id, &crate::agent::intent::admin_authority())
+    .map_err(|e| { ... })?;
+```
+
+The `AdminAuthority` struct (`intent.rs:212-223`) is a zero-sized type with a private constructor:
+
+```rust
+pub struct AdminAuthority {
+    _sealed: std::marker::PhantomData<()>,
+}
+
+impl AdminAuthority {
+    fn new() -> Self {
+        Self { _sealed: std::marker::PhantomData }
+    }
+}
+
+pub(crate) fn admin_authority() -> AdminAuthority {
+    ADMIN_AUTHORITY_TOKEN.fetch_add(1, Ordering::Relaxed);
+    AdminAuthority::new()
+}
+```
+
+The `ADMIN_AUTHORITY_TOKEN` is an `AtomicU64` counter that increments on each call but is never checked or validated. Any code within the crate can call `admin_authority()` to obtain an `AdminAuthority` token. There is no cryptographic binding, no external verification, and no separation of concerns.
+
+**The comment says:** "This is an internal approval, not admin IPC. The request reached this point only after principal capability/peer/process verification and explicit trusted port mode."
+
+**Impact:**
+
+The self-approval pattern means:
+1. **No independent authorization check:** The same process that receives the principal's request also approves the grant. There is no second party, no human-in-the-loop, and no external policy decision point.
+2. **Grant = signing authority:** Once approved, the grant enables the browser to sign assertions for the requested RP IDs. The agent will sign any authentication challenge for any credential in the grant scope.
+3. **No rate limiting or throttling:** Each grant request is immediately approved. A malicious principal that passes the initial verification can request unlimited grants.
+4. **No audit trail of independent approval:** The approval is logged, but it is self-generated — it does not represent an independent decision.
+
+**Trust model analysis:**
+
+The current design relies on the assumption that the initial verification steps (principal capability, peer identity, process identity digest, trusted port mode) are sufficient to authorize all subsequent signing operations. This is equivalent to a "once verified, always trusted" model with no session-level re-authorization.
+
+---
+
+### H-1: D-Bus Notification Action Injection
+
+**File:** `cmd/passless/src/agent/prompt.rs:616-633`
+
+**Current State:**
+
+User verification for authentication and registration operations is performed through desktop notifications via the `notify-rust` crate, which communicates over the session D-Bus:
+
+```rust
+// prompt.rs:606-633
+let mut notification = Notification::new();
+notification
+    .summary(&title)
+    .body(&body)
+    .icon("security-high")
+    .timeout(Timeout::Milliseconds((self.timeout_secs * 1000) as u32))
+    .urgency(Urgency::Critical)
+    .action("approve", "Approve")
+    .action("deny", "Deny");
+
+let handle = match notification.show() { ... };
+
+handle.wait_for_action(|action| {
+    let mut result = action_result_clone.lock().expect("...");
+    *result = Some(action.to_string());
+});
+```
+
+The notification server is queried for capabilities (`prompt.rs:479-499`), and servers that only support default actions (notify-osd, mako, quickshell) are rejected. Only servers reporting `FullActions` capability are accepted.
+
+**The D-Bus notification protocol:**
+
+The Desktop Notifications Specification (`org.freedesktop.Notifications`) operates over the session D-Bus. The `ActionInvoked` signal is sent by the notification server when the user clicks an action button. However:
+
+1. **Session D-Bus is shared:** Any process running as the same user on the same D-Bus session can send arbitrary messages to any service, including the notification server.
+2. **No sender authentication:** The notification server does not cryptographically prove that an `ActionInvoked` signal corresponds to a physical user action. Any process can call `org.freedesktop.Notifications.ActionInvoked` on the server's bus name.
+3. **Synthetic signals:** A malicious process can:
+   - Send a `NotificationClosed` signal to dismiss the notification
+   - Send an `ActionInvoked` signal with action `"approve"` to simulate user approval
+   - Do this without any user interaction
+
+**Mitigations already in place:**
+- `min_review_delay_ms` — rejects approvals that arrive too quickly (default 1000ms)
+- Server capability check — rejects servers that don't support full actions
+- Action string validation — only `"approve"`, `"deny"`, and `"__closed"` are accepted
+
+**Attack Scenarios:**
+
+1. **Malicious process auto-approves:** A compromised process on the same user session sends a synthetic `ActionInvoked` signal with `"approve"` after the `min_review_delay_ms` has elapsed. The agent grants the authentication request without human interaction.
+
+2. **Notification server compromise:** If the notification daemon itself has a vulnerability, an attacker can inject action signals.
+
+3. **D-Bus policy bypass:** On some distributions, D-Bus policy rules may not restrict `ActionInvoked` signals to the notification server's bus name, allowing any process to inject them.
+
+---
+
+## Architectural Considerations
+
+### Trade-offs Between Security and Usability
+
+| Concern | Security Impact | Usability Impact |
+|---------|----------------|-----------------|
+| `PR_SET_NO_NEW_PRIVS` on same-user browser | Prevents setuid sandbox helper | Chromium may fail to start on systems without user namespaces |
+| Mount namespace for browser | Isolates filesystem view | Breaks access to user's X11/Wayland socket, fonts, themes |
+| seccomp-BPF on browser | Limits syscall surface | May break Chromium features (GPU, audio, DRM) |
+| External approval for grants | Prevents self-approval | Requires separate approval mechanism or device |
+| D-Bus notification hardening | Prevents action injection | May require custom notification daemon |
+
+### Chromium Sandbox Requirements
+
+Chromium requires one of two sandboxing mechanisms:
+
+1. **Setuid sandbox (`chrome-sandbox`):** Requires a setuid-root helper binary. Blocked by `PR_SET_NO_NEW_PRIVS`. This is the legacy approach.
+
+2. **Unprivileged user namespace sandbox:** Uses `CLONE_NEWUSER` to create a user namespace where Chromium can set up its sandbox without root. This is the modern approach (default since Chromium 120+). Requires:
+   - `kernel.unprivileged_userns_clone=1` (Debian/Ubuntu) or `kernel.apparmor_restrict_unprivileged_userns=0` (Ubuntu 23.10+)
+   - No `PR_SET_NO_NEW_PRIVS` before the namespace is created (Chromium sets NNP internally after sandbox setup)
+
+**Key insight:** Chromium sets `PR_SET_NO_NEW_PRIVS` internally **after** its sandbox is established. The daemon's `pre_exec` NNP setting prevents Chromium from creating its own user namespace sandbox. This is the fundamental tension.
+
+**Resolution path:** Instead of setting NNP in `pre_exec`, allow Chromium to create its own user namespace sandbox, then apply NNP via a different mechanism (e.g., systemd service for the browser, or a wrapper that sets NNP after Chromium has initialized its sandbox).
+
+---
+
+## Proposed Solutions
+
+### Priority 1: Same-User Browser Hardening
+
+#### C-1: Same-User Port-Mode Zero Hardening
+
+**Solution A: Selective hardening (skip only NNP)**
+- Apply `close_range`, `setsid`, `PR_SET_PDEATHSIG`, and resource limits in same-user mode
+- Skip only `PR_SET_NO_NEW_PRIVS` and `setuid`/`setgid`
+- **Pros:** Minimal change, preserves Chromium compatibility, closes FD leakage
+- **Cons:** Still allows setuid escalation, no identity separation
+- **Complexity:** Low
+
+**Solution B: Deferred NNP via wrapper**
+- Launch a small wrapper binary that:
+  1. execs Chromium
+  2. After Chromium's sandbox is initialized (detectable via a readiness signal), sets `PR_SET_NO_NEW_PRIVS` on itself
+- **Pros:** Full hardening, Chromium-compatible
+- **Cons:** Requires a new binary, complex synchronization
+- **Complexity:** High
+
+**Solution C: Rely on Chromium's user namespace sandbox**
+- Remove the NNP bypass entirely
+- Ensure the system has unprivileged user namespaces enabled
+- Let Chromium create its own sandbox
+- **Pros:** Simplest solution, uses Chromium's well-tested sandbox
+- **Cons:** Fails on systems with user namespaces disabled, requires documentation
+- **Complexity:** Low
+
+**Recommended approach:** Solution A immediately (close FDs, apply resource limits), then Solution C as the default with a fallback mechanism for systems without user namespaces.
+
+#### C-2: Systemd Hardening
+
+**Solution A: Add missing directives**
+- Add `ProtectHostname=true`, `ProtectClock=true`, `ProtectKernelLogs=true`
+- Add `RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6`
+- Add `RestrictNamespaces=true` (conflicts with browser launch — needs evaluation)
+- Add `LockPersonality=true`
+- **Pros:** Defense-in-depth, no code changes
+- **Cons:** Some directives may conflict with browser launch
+- **Complexity:** Low
+
+**Solution B: seccomp-BPF syscall filter for daemon**
+- Add `SystemCallFilter=` with a whitelist of syscalls the daemon actually uses
+- **Pros:** Significantly reduces daemon attack surface
+- **Cons:** Complex to maintain, may break on kernel updates
+- **Complexity:** Medium
+
+**Recommended approach:** Solution A immediately. Solution B requires profiling daemon syscall usage first.
+
+#### H-2: Namespace Isolation
+
+**Solution A: Mount namespace only**
+- Create a mount namespace for the browser
+- Bind-mount only required paths (`/usr`, browser profile dir, X11/Wayland socket, fonts)
+- **Pros:** Significant filesystem isolation
+- **Cons:** Complex to enumerate required paths, breaks with unusual desktop environments
+- **Complexity:** Medium
+
+**Solution B: Full namespace stack**
+- Create mount, PID, network, and user namespaces
+- **Pros:** Maximum isolation
+- **Cons:** Breaks X11/Wayland, networking, D-Bus; extremely complex
+- **Complexity:** Very High
+
+**Solution C: Filesystem namespacing via chroot**
+- Use `pivot_root` or `chroot` into a minimal filesystem for the browser
+- **Pros:** Simpler than full mount namespace
+- **Cons:** Requires maintaining a minimal rootfs, still complex
+- **Complexity:** High
+
+**Recommended approach:** Solution A with a configurable allowlist of bind mounts. Start with a minimal set and expand based on testing.
+
+#### H-3: seccomp-BPF
+
+**Solution A: Blacklist dangerous syscalls**
+- Block `ptrace`, `mount`, `umount`, `pivot_root`, `init_module`, `finit_module`, `kexec_load`, `bpf`, `perf_event_open`, etc.
+- **Pros:** Simple, low risk of breaking Chromium
+- **Cons:** Blacklists are inherently incomplete
+- **Complexity:** Low
+
+**Solution B: Whitelist based on Chromium's own filter**
+- Use Chromium's seccomp-BPF policy as a baseline
+- Adapt for the daemon's specific needs
+- **Pros:** Well-tested policy, Chromium-compatible
+- **Cons:** Chromium's policy is complex and version-dependent
+- **Complexity:** Medium
+
+**Solution C: libseccomp with architecture-specific profiles**
+- Use `libseccomp` to generate architecture-specific BPF filters
+- Different profiles for browser vs. principal processes
+- **Pros:** Most robust, architecture-aware
+- **Cons:** Requires `libseccomp` dependency, complex maintenance
+- **Complexity:** High
+
+**Recommended approach:** Solution A immediately (block obviously dangerous syscalls), then Solution B for the browser process specifically.
+
+---
+
+### Priority 2: Authorization Model
+
+#### C-3: Self-Approval of Grants
+
+**Solution A: Split approval into a separate code path with explicit audit**
+- Replace `admin_authority()` with a `BrowserApprovalAuthority` that requires:
+  - The principal's process identity digest
+  - The endpoint's security config
+  - A timestamp
+  - A cryptographic binding to the request
+- Log the approval with all context for post-hoc audit
+- **Pros:** Maintains current flow, adds auditability
+- **Cons:** Still self-approval, just better-documented
+- **Complexity:** Low
+
+**Solution B: Require human approval for grant activation**
+- Before approving a grant, show a desktop notification asking the user to approve
+- Wait for explicit user action (approve/deny)
+- **Pros:** True human-in-the-loop
+- **Cons:** Adds latency to every browser launch, notification injection risk (H-1)
+- **Complexity:** Medium
+
+**Solution C: Time-limited auto-approval with anomaly detection**
+- Auto-approve grants but with strict time limits
+- Track approval patterns and flag anomalies
+- Require re-verification if patterns change (new RP, new credential, unusual timing)
+- **Pros:** Balances security and usability
+- **Cons:** Complex state machine, false positives
+- **Complexity:** High
+
+**Recommended approach:** Solution A immediately (auditability), then Solution B for high-security profiles (configurable per-profile).
+
+#### H-1: D-Bus Notification Action Injection
+
+**Solution A: Use a dedicated D-Bus service with restricted policy**
+- Register a dedicated D-Bus well-known name for passless notifications
+- Install a D-Bus policy file that restricts `ActionInvoked` signals to the notification server's bus name
+- **Pros:** Prevents synthetic signal injection
+- **Cons:** Requires D-Bus policy file installation, may not work with all notification servers
+- **Complexity:** Medium
+
+**Solution B: Use a separate notification channel**
+- Replace D-Bus notifications with a direct terminal prompt or a custom GUI dialog
+- **Pros:** No D-Bus attack surface
+- **Cons:** Breaks headless operation, requires terminal or GUI access
+- **Complexity:** Medium
+
+**Solution C: Challenge-response verification**
+- Generate a random challenge code displayed in the notification
+- Require the user to enter the code in a separate channel (e.g., terminal, web interface)
+- **Pros:** Prevents automated injection, proves human presence
+- **Cons:** Significant UX impact, requires a second channel
+- **Complexity:** High
+
+**Solution D: Verify notification server identity**
+- Check the D-Bus sender of `ActionInvoked` matches the notification server's bus name
+- Reject actions from other senders
+- **Pros:** Minimal change, directly addresses the attack
+- **Cons:** Some notification servers may not forward sender information correctly
+- **Complexity:** Low
+
+**Recommended approach:** Solution D immediately (verify sender), then Solution A for defense-in-depth.
+
+---
+
+## Implementation Plan
+
+### Phase 1: Quick Wins (Immediate)
+
+These changes are low-risk, high-impact, and can be implemented without architectural changes:
+
+| Issue | Action | Files | Risk |
+|-------|--------|-------|------|
+| C-1 | Apply selective hardening in same-user mode (close_range, setsid, PDEATHSIG, rlimits) | `browser.rs:2020-2034` | Low |
+| C-2 | Add missing systemd hardening directives | `passless-agent.service` | Low |
+| H-3 | Add seccomp-BPF blacklist for obviously dangerous syscalls | `launcher.rs:690-756` | Low |
+| H-1 | Verify D-Bus signal sender matches notification server | `prompt.rs:627-633` | Low |
+| C-3 | Add structured audit logging for grant self-approval | `browser_ensure.rs:398-409` | Low |
+
+### Phase 2: Medium-Term (Requires Design Work)
+
+These changes require design decisions, testing infrastructure, and careful rollout:
+
+| Issue | Action | Dependencies |
+|-------|--------|-------------|
+| C-1 | Remove NNP bypass, rely on Chromium's user namespace sandbox | System compatibility testing |
+| H-3 | Implement Chromium-specific seccomp-BPF whitelist | Syscall profiling |
+| H-1 | Install D-Bus policy file for notification sender restriction | Packaging changes |
+| C-3 | Implement per-profile approval policy (auto vs. human) | Policy engine extension |
+
+### Phase 3: Long-Term (Architectural Changes)
+
+These changes require significant architectural work and may affect backward compatibility:
+
+| Issue | Action | Dependencies |
+|-------|--------|-------------|
+| H-2 | Implement mount namespace isolation for browser | Filesystem allowlist design |
+| H-2 | Implement PID namespace isolation | Process lifecycle redesign |
+| C-2 | Evaluate running daemon as non-root with capability dropping | UHID access model redesign |
+| C-3 | Implement external approval mechanism (hardware token, separate service) | Protocol design |
+
+---
+
+## Testing Strategy
+
+### Verification Tests
+
+1. **FD leakage test:** After browser launch, verify `/proc/<browser_pid>/fd/` contains only expected FDs (stdin, stdout, stderr, CDP pipes). Assert no `/dev/uhid`, no storage file handles.
+
+2. **Namespace verification test:** After browser launch, verify `/proc/<browser_pid>/ns/` shows expected namespace inodes. For mount namespace: verify the browser cannot access daemon-only paths.
+
+3. **seccomp verification test:** After browser launch, verify `/proc/<browser_pid>/status` shows `Seccomp: 2` (SECCOMP_MODE_FILTER). Attempt blocked syscalls and verify they return `EPERM` or are killed.
+
+4. **Systemd hardening test:** Run `systemd-analyze security passless-agent.service` and verify the exposure score improves. Target: < 5.0 (currently likely > 6.0 due to root + NoNewPrivileges=false).
+
+5. **D-Bus sender verification test:** Attempt to inject a synthetic `ActionInvoked` signal from a test process. Verify the agent rejects it.
+
+6. **Grant audit test:** Verify that every grant approval is logged with: request ID, principal digest, endpoint ID, RP IDs, credentials, timestamp, and approval authority token.
+
+### Regression Testing
+
+- **Browser launch compatibility:** Test browser launch on:
+  - Systems with unprivileged user namespaces enabled (default on most distros)
+  - Systems with user namespaces disabled (Debian with `sysctl kernel.unprivileged_userns_clone=0`)
+  - Systems with AppArmor user namespace restrictions (Ubuntu 23.10+)
+  - Systems without user namespace support (older kernels)
+
+- **Notification compatibility:** Test notification flow with:
+  - dunst
+  - mako
+  - notify-osd
+  - xfce4-notifyd
+  - GNOME Shell notification daemon
+
+### Performance Benchmarking
+
+- Measure browser launch latency with and without namespace isolation
+- Measure seccomp-BPF overhead on CDP pipe I/O
+- Measure FD close_range overhead on daemon with many open handles
+
+---
+
+## Risks and Mitigations
+
+### Backward Compatibility
+
+| Change | Risk | Mitigation |
+|--------|------|-----------|
+| Remove NNP bypass | Browser fails to start on systems without user namespaces | Feature detection: check `/proc/sys/kernel/unprivileged_userns_clone` before removing bypass. Fall back to current behavior if unavailable. |
+| Mount namespace | Browser cannot find fonts, themes, X11 socket | Configurable bind-mount allowlist with sensible defaults. Test against major desktop environments. |
+| seccomp-BPF | Chromium feature breaks (GPU, audio, DRM) | Start with blacklist (low risk). Use Chromium's own seccomp policy as reference. Provide escape hatch for testing. |
+| D-Bus sender check | Notification server doesn't forward sender info | Log warning and fall back to current behavior if sender cannot be verified. |
+
+### Migration Path
+
+1. All Phase 1 changes are backward-compatible (additive hardening)
+2. Phase 2 changes should be opt-in via configuration flags initially
+3. Phase 3 changes require a deprecation period with clear migration documentation
+
+### What Could Go Wrong
+
+1. **Chromium sandbox breakage:** The most significant risk. Chromium's sandbox initialization is complex and version-dependent. Any change to the process environment (namespaces, seccomp, NNP) can break it.
+   - **Mitigation:** Extensive testing across Chromium versions. Fallback to current behavior if sandbox initialization fails (detectable via CDP timeout).
+
+2. **Desktop environment fragmentation:** Linux desktop environments vary widely in notification server implementation, D-Bus policy, and namespace support.
+   - **Mitigation:** Configuration-driven approach with sensible defaults. Document tested configurations.
+
+3. **Performance regression:** Namespace creation, seccomp-BPF, and FD closing add latency to browser launch.
+   - **Mitigation:** Benchmark before and after. Target: < 100ms additional latency.
+
+---
+
+## Dependencies Between Issues
+
+```
+C-1 (same-user hardening)
+  ├── H-3 (seccomp-BPF) — seccomp should be applied in same-user mode too
+  └── H-2 (namespace isolation) — namespaces provide additional isolation beyond hardening
+
+C-2 (systemd hardening)
+  └── Independent — can be implemented in parallel
+
+C-3 (self-approval)
+  └── H-1 (D-Bus injection) — if human approval is added to C-3, H-1 becomes critical
+                                because the approval notification becomes the attack target
+
+H-1 (D-Bus injection)
+  └── C-3 (self-approval) — if grants require human approval, the notification
+                             channel becomes the primary attack surface
+```
+
+**Recommended implementation order:**
+
+1. C-2 (systemd hardening) — zero code risk, immediate defense-in-depth
+2. C-1 + H-3 (selective hardening + seccomp blacklist) — close FD leakage and block dangerous syscalls
+3. H-1 (D-Bus sender verification) — prevent notification injection
+4. C-3 (grant audit logging) — improve observability
+5. C-1 (remove NNP bypass) — requires Chromium compatibility testing
+6. H-2 (namespace isolation) — requires significant design work
+7. C-3 (external approval) — requires protocol design
+
+---
+
+## References
+
+### Code References
+
+| Issue | Primary File | Key Lines |
+|-------|-------------|-----------|
+| C-1 | `cmd/passless/src/agent/browser.rs` | 1998-2035 (same-user bypass), 302-313 (hardening config) |
+| C-2 | `contrib/systemd/passless-agent.service` | 37 (NoNewPrivileges), 42 (PrivateDevices) |
+| H-2 | `cmd/passless/src/agent/browser.rs` | 1869-1912 (hardened spawn), 2000-2035 (port mode spawn) |
+| H-3 | `cmd/passless/src/agent/launcher.rs` | 690-756 (apply method), 646-656 (HardenedChildSetup) |
+| C-3 | `cmd/passless/src/agent/runtime/browser_ensure.rs` | 398-409 (self-approval) |
+| C-3 | `cmd/passless/src/agent/intent.rs` | 212-230 (AdminAuthority) |
+| C-3 | `cmd/passless/src/agent/policy_engine.rs` | 1426-1462 (grant request/approve) |
+| H-1 | `cmd/passless/src/agent/prompt.rs` | 606-633 (notification), 479-499 (server capability) |
+
+### Related Security Research
+
+- **Chromium sandboxing:** https://chromium.googlesource.com/chromium/src/+/main/docs/linux/sandboxing.md
+- **seccomp-BPF:** https://www.kernel.org/doc/html/latest/userspace-api/seccomp_filter.html
+- **Linux namespaces:** https://man7.org/linux/man-pages/man7/namespaces.7.html
+- **D-Bus security:** https://dbus.freedesktop.org/doc/dbus-specification.html#auth-mechanisms
+- **Desktop Notifications Specification:** https://specifications.freedesktop.org/notification-spec/latest/
+
+### Similar Implementations
+
+- **Firejail:** https://github.com/netblue30/firejail — Application sandboxing using namespaces, seccomp, and capabilities
+- **Flatpak:** https://github.com/flatpak/flatpak — Application sandboxing with Bubblewrap (unprivileged namespaces)
+- **Bubblewrap:** https://github.com/containers/bubblewrap — Unprivileged sandboxing tool (used by Flatpak)
+- **systemd service hardening:** https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Sandboxing
+
+---
+
+## Open Questions
+
+1. **Chromium user namespace compatibility:** What is the minimum Chromium version that reliably falls back to user namespace sandboxing? Can we detect sandbox initialization failure and fall back gracefully?
+
+2. **Daemon non-root operation:** Can the daemon be restructured to drop root after UHID endpoint creation? This would eliminate the need for `NoNewPrivileges=false` and significantly reduce the impact of daemon compromise. What UHID operations require root beyond initial device creation?
+
+3. **Grant approval model:** Should the approval model be per-profile configurable? Some profiles (e.g., development/testing) may want auto-approval, while production profiles should require human interaction. What is the right granularity?
+
+4. **Notification channel replacement:** Is there a viable alternative to D-Bus notifications that works across all Linux desktop environments? A custom GUI dialog (GTK/Qt) would avoid D-Bus but adds dependencies. A terminal prompt would break headless operation.
+
+5. **Namespace isolation scope:** For mount namespace isolation, what is the minimum set of paths that must be bind-mounted for Chromium to function? This varies by desktop environment (X11 vs Wayland, GNOME vs KDE vs Sway). Can we auto-detect the required paths?
+
+6. **seccomp-BPF maintenance:** How do we maintain a seccomp-BPF whitelist across Chromium versions? Chromium's own sandbox policy changes with each release. Do we vendor Chromium's policy, or do we maintain our own?
+
+7. **D-Bus policy distribution:** How do we distribute a D-Bus policy file that restricts `ActionInvoked` signals? This requires installation in `/etc/dbus-1/system.d/` or `/usr/share/dbus-1/services/`, which varies by distribution.
+
+8. **Audit log integrity:** If the daemon is compromised, audit logs are also compromised. Should audit logs be sent to an external collector (e.g., journald, syslog, remote SIEM) for tamper resistance?

--- a/docs/security/FURTHER_ANALYSIS.md
+++ b/docs/security/FURTHER_ANALYSIS.md
@@ -18,6 +18,13 @@ Each issue is analyzed with current state, attack scenarios, proposed solutions,
 
 ### C-1: Same-User Port-Mode Browser Spawns with Zero Hardening
 
+> **Status: Accepted — by design.** Superseded by
+> [ADR 0008](../decisions/0008-same-user-trust-boundary.md). In same-user mode the browser
+> and daemon share a UID, so no kernel boundary exists regardless of spawn-time hardening;
+> the security controls live in the policy layer. The analysis below is kept for
+> historical context but its severity framing no longer applies. Residual items (FD
+> hygiene, PDEATHSIG, rlimits) are resilience follow-ups, not security fixes.
+
 **File:** `cmd/passless/src/agent/browser.rs:1998-2035`
 
 **Current State:**
@@ -75,6 +82,13 @@ When `PR_SET_NO_NEW_PRIVS` is set, the setuid sandbox helper cannot elevate priv
 
 ### C-2: Daemon Runs as Root with NoNewPrivileges=false and Full /dev Access
 
+> **Status: Open — re-scoped to root multi-principal deployment only.** See
+> [ADR 0009](../decisions/0009-daemon-hardening-scope.md). Same-user deployments are out
+> of scope (daemon is unprivileged there; trust boundary is the session per ADR 0008).
+> Open items are an implementation backlog for the isolated mode: C-2a additive systemd
+> directives, C-2b evaluated directives (`CapabilityBoundingSet`, `SystemCallFilter`),
+> and the deferred question of running with a bounded capability set instead of root.
+
 **File:** `contrib/systemd/passless-agent.service:37,42`
 
 **Current State:**
@@ -131,6 +145,12 @@ If the daemon process itself is compromised (e.g., through a vulnerability in CT
 
 ### H-2: No Namespace Isolation for Browser Processes
 
+> **Status: Open — re-scoped to isolated (cross-user) deployment mode only.** See
+> [ADR 0010](../decisions/0010-namespace-isolation-scope.md). Out of scope for same-user
+> mode (ADR 0008). Deferred backlog: mount namespace first with bind-mount allowlist,
+> PID namespace as stretch, network namespace only in pipe mode (port mode incompatible).
+> Terminology: `AgentMode::Isolated` means credential isolation, not OS namespaces.
+
 **File:** `cmd/passless/src/agent/browser.rs:1869-1912, 2000-2035`
 
 **Current State:**
@@ -163,6 +183,12 @@ The architecture documentation describes namespace isolation as a design goal, b
 
 ### H-3: No seccomp-BPF Filter on Any Spawned Process
 
+> **Status: Open — re-scoped to isolated (cross-user) mode only.** See
+> [ADR 0011](../decisions/0011-seccomp-scope.md). Out of scope for same-user mode
+> (ADR 0008). Deferred backlog: H-3a principal-process seccomp blacklist (early,
+> maintainable — our own binary), H-3b browser chrome seccomp (deferred, requires
+> per-version syscall profiling; Chromium version fragility risk).
+
 **File:** `cmd/passless/src/agent/browser.rs:1880-1907, launcher.rs:690-756`
 
 **Current State:**
@@ -193,6 +219,12 @@ A compromised browser or principal process has access to the full kernel syscall
 ## Priority 2: Authorization Model
 
 ### C-3: Self-Approval of Authentication Grants
+
+> **Status: Accepted (approval mechanism) / Open backlog (audit).** See
+> [ADR 0012](../decisions/0012-grant-audit-and-notification-approval-integrity.md). Self-approval within
+> configured policy is the designed autonomous behavior (ADR 0001/0007); the
+> `AdminAuthority` seal is cosmetic and accepted as such. Open item: grant
+> request/approval are not audited in production despite builders existing — backlog fix.
 
 **File:** `cmd/passless/src/agent/runtime/browser_ensure.rs:398-409`
 
@@ -251,6 +283,13 @@ The current design relies on the assumption that the initial verification steps 
 ---
 
 ### H-1: D-Bus Notification Action Injection
+
+> **Status: Open backlog — in scope for same-user mode.** See
+> [ADR 0012](../decisions/0012-grant-audit-and-notification-approval-integrity.md). Injection collapses
+> the human/agent distinction that `authorization="confirm"` relies on, so ADR 0008's
+> trust-boundary reasoning does not exempt it. Planned fix: raw zbus signal handling that
+> validates the `ActionInvoked` sender against the notification server's bus name
+> (notify-rust 4.x `wait_for_action` does not expose the sender).
 
 **File:** `cmd/passless/src/agent/prompt.rs:616-633`
 

--- a/passless-core/src/agent/config.rs
+++ b/passless-core/src/agent/config.rs
@@ -908,13 +908,19 @@ impl AgentProfileConfig {
             }
         }
 
-        if let Some(ref url) = self.start_url
-            && url.is_empty()
-        {
-            return Err(Error::Config(format!(
-                "agent profile '{}': start_url must not be empty",
-                profile_id
-            )));
+        if let Some(ref url) = self.start_url {
+            if url.is_empty() {
+                return Err(Error::Config(format!(
+                    "agent profile '{}': start_url must not be empty",
+                    profile_id
+                )));
+            }
+            if !url.starts_with("https://") && !url.starts_with("http://") {
+                return Err(Error::Config(format!(
+                    "agent profile '{}': start_url must use http or https scheme, got '{}'",
+                    profile_id, url
+                )));
+            }
         }
 
         Ok(())

--- a/passless-core/src/config.rs
+++ b/passless-core/src/config.rs
@@ -952,6 +952,20 @@ pub enum AgentAdminAction {
         #[arg(long)]
         force: bool,
     },
+    /// Install native messaging manifest for browser extension
+    InstallNativeMessaging {
+        /// Browser executable path (e.g., /usr/bin/chromium)
+        #[arg(long)]
+        browser: String,
+
+        /// Extension directory path
+        #[arg(long)]
+        ext_dir: PathBuf,
+
+        /// Sign proxy binary path
+        #[arg(long, default_value = "/usr/bin/sign-proxy")]
+        sign_proxy: PathBuf,
+    },
     /// Profile management
     Profile {
         #[command(subcommand)]


### PR DESCRIPTION
## Summary

Fixes the agent browser WebAuthn flow end-to-end against `https://idm.grigri.cloud` and hardens the sign pipeline:

**Phase 1 — security fixes from FURTHER_ANALYSIS:**
- Resolve TOCTOU races (atomic writes) and add `validate_loopback_ws_url`
- Migrate sign server to Unix socket + native messaging `sign-proxy` bridge
- Stable extension ID via `manifest.json` key field; MV3 `host_permissions`
- Auto-install native messaging manifest in browser profile; install `sign-proxy` and `agent-prompt-probe` binaries
- Allow Chromium to read extension files (0755)

**Phase 2 — replay / duplicate-idempotency fix (the login blocker):**
- Deduplicate duplicate WebAuthn sign requests: in-flight dedup (WaitFor/Condvar), completed-outcome cache (120 s TTL), `RequestClaim` states, `request_id` coalescing in `worker.js`, duplicate-injection guard in `broker.js`. No re-sign / no counter increment on replays; post-TTL replay → `replayed_operation`.

**Same-user hardening batch (per ADR 0008–0012):**
- C-3a: production grant request/approval audit records
- C-1 residuals: FD closure + `PR_SET_PDEATHSIG` on same-user browser spawn
- H-1a: D-Bus `ActionInvoked` sender validation via raw zbus

## Documentation

- 6 findings from `FURTHER_ANALYSIS.md` (C-1..H-3) resolved / recorded as ADR 0008–0012 + status notes
- Implementation plan at `docs/plans/same-user-hardening-batch.md`

## Test plan

- [x] `cargo fmt --check` / `cargo clippy --all-targets --all-features -D warnings`
- [x] Full suite: 2318 passed, 0 failed
- [x] grant / audit / browser / prompt test subsets pass
- [x] E2E login to `https://idm.grigri.cloud` succeeds (trace `/ui/apps`, "Sign out")