### PR TITLE
fix: increase default max_concurrent_sessions to maximum

### DIFF
--- a/passless-core/src/agent/config.rs
+++ b/passless-core/src/agent/config.rs
@@ -30,7 +30,7 @@ pub const ANY_RP_ID: &str = "*";
 
 const DEFAULT_MAX_OPERATIONS: u16 = 64;
 const MAX_OPERATIONS: u16 = 4096;
-const DEFAULT_MAX_CONCURRENT_SESSIONS: u16 = 1;
+const DEFAULT_MAX_CONCURRENT_SESSIONS: u16 = MAX_CONCURRENT_SESSIONS;
 const MAX_CONCURRENT_SESSIONS: u16 = 64;
 
 fn default_max_operations() -> u16 {


### PR DESCRIPTION
The default value for `max_concurrent_sessions` was hardcoded to `1`, which unnecessarily limited concurrent agent sessions. This change sets the default to `MAX_CONCURRENT_SESSIONS` (64), allowing the maximum allowed number of concurrent sessions by default.