### PR TITLE
fix: launch playwright MCP browser lazily on first CDP connection

### DIFF
--- a/cmd/passless/Cargo.toml
+++ b/cmd/passless/Cargo.toml
@@ -71,6 +71,7 @@ hkdf = { version = "0.13", optional = true }
 aes = { version = "0.9", optional = true }
 cipher = { version = "0.5", optional = true }
 rsa = { version = "0.9", default-features = false, features = ["std", "pem"] }
+toml.workspace = true
 
 [dev-dependencies]
 base64 = "0.23"

--- a/cmd/passless/src/commands/playwright_mcp.rs
+++ b/cmd/passless/src/commands/playwright_mcp.rs
@@ -1,8 +1,11 @@
+use std::fs::File;
+use std::io::BufReader;
 use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
 use std::process::Command;
 
 use passless_core::agent::protocol::{PrincipalRequest, PrincipalResponse};
+use passless_core::agent::{AgentConfig, BrowserScope};
 use passless_core::{Error, Result};
 
 use crate::agent::cdp_bootstrap::CdpBootstrap;
@@ -46,8 +49,7 @@ fn run_as_principal(profile: &str, url: Option<&str>, command: &[PathBuf]) -> Re
         .map_err(|e| Error::Other(format!("failed to generate CDP bootstrap token: {e}")))?;
     let profile_owned = profile.to_string();
     let start_url = url.map(ToOwned::to_owned);
-    let (_, shared_browser) =
-        ensure_browser(&profile_owned, start_url.as_deref()).map_err(Error::Other)?;
+    let shared_browser = profile_uses_shared_browser(profile);
     let profile_for_bootstrap = profile_owned.clone();
     let bootstrap = CdpBootstrap::start(token.clone(), move || {
         let (endpoint, _) = ensure_browser(&profile_for_bootstrap, start_url.as_deref())?;
@@ -134,6 +136,32 @@ fn ensure_browser(
         }
         _ => Err("agent returned an unexpected EnsureBrowser response".to_string()),
     }
+}
+
+fn profile_uses_shared_browser(profile: &str) -> bool {
+    load_agent_config()
+        .and_then(|config| config.get_profile(profile).cloned())
+        .is_some_and(|p| p.browser_scope == BrowserScope::Profile)
+}
+
+fn load_agent_config() -> Option<AgentConfig> {
+    let config_path = std::env::var("PASSLESS_CONFIG")
+        .ok()
+        .map(PathBuf::from)
+        .or_else(|| dirs::config_dir().map(|p| p.join("passless/config.toml")))?;
+
+    if !config_path.exists() {
+        return None;
+    }
+
+    let file = File::open(&config_path).ok()?;
+    let reader = BufReader::new(file);
+    let content = std::io::read_to_string(reader).ok()?;
+    let table: toml::Table = toml::from_str(&content).ok()?;
+
+    table
+        .get("agents")
+        .and_then(|v| serde::Deserialize::deserialize(v.clone()).ok())
 }
 
 fn client_error(error: ClientError) -> Error {


### PR DESCRIPTION
## Problem

The `passless agent playwright-mcp` wrapper called `ensure_browser()` eagerly at startup in `run_as_principal()`. Since opencode (or any MCP client) starts local MCP servers at session start, Chromium was launched immediately — with the profile's `start_url` — even when no Playwright tool was ever used.

## Fix

- Remove the eager `ensure_browser()` call; the browser now launches only through the `CdpBootstrap` lazy closure, which fires on the first `/json/version` CDP request from `@playwright/mcp` (i.e., the first actual browser tool call).
- The `--shared-browser-context` flag, previously learned from the eager `EnsureBrowser` response, is now derived client-side from the profile's `browser_scope` in the config file — the exact same expression the daemon uses (`browser_scope == BrowserScope::Profile` in `browser_ensure.rs`).

## Verification

- `cargo check`, `cargo fmt --check`, `cargo clippy` (no warnings), `cargo test` (75 tests pass)
- Lazy-path already covered by `health_does_not_start_browser` in `cdp_bootstrap.rs`
- Manual: restart opencode — browser should stay closed until a Playwright MCP tool is first invoked