### PR TITLE
fix: make pass Git SSH agent socket explicit

### DIFF
--- a/.ci/PKGBUILD-bin.j2
+++ b/.ci/PKGBUILD-bin.j2
@@ -23,6 +23,7 @@ sha256sums=('{{ checksum }}'
 
 package() {
 	install -Dm755 passless "${pkgdir}/usr/bin/passless"
+	install -Dm755 passless-git-sync "${pkgdir}/usr/bin/passless-git-sync"
 	install -Dm755 sign-proxy "${pkgdir}/usr/bin/sign-proxy"
 	install -Dm755 agent-prompt-probe "${pkgdir}/usr/bin/agent-prompt-probe"
 

--- a/.ci/PKGBUILD.j2
+++ b/.ci/PKGBUILD.j2
@@ -53,6 +53,7 @@ check() {
 package() {
     cd "$srcdir/passless"
     install -Dm0755 -t "$pkgdir/usr/bin/" "target/release/passless"
+    install -Dm0755 -t "$pkgdir/usr/bin/" "target/release/passless-git-sync"
     install -Dm0755 -t "$pkgdir/usr/bin/" "target/release/sign-proxy"
     install -Dm0755 -t "$pkgdir/usr/bin/" "target/release/agent-prompt-probe"
 

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ release:	## generate vendor.tar.gz, $(PKG_BASE_NAME).tar.gz, and completions
 	cargo vendor
 	tar -czf vendor.tar.gz vendor
 	cargo build --frozen --release --all-features --target ${CARGO_TARGET}
-	tar -czf $(PKG_BASE_NAME).tar.gz -C $(CARGO_TARGET_DIR)/$(CARGO_TARGET)/release passless sign-proxy agent-prompt-probe
+	tar -czf $(PKG_BASE_NAME).tar.gz -C $(CARGO_TARGET_DIR)/$(CARGO_TARGET)/release passless passless-git-sync sign-proxy agent-prompt-probe
 	@# Create completions tarball
 	@COMPLETION_DIR=$$(find $(CARGO_TARGET_DIR)/$(CARGO_TARGET)/release/build/passless-*/out/completions -type d 2>/dev/null | head -1); \
 	if [ -n "$$COMPLETION_DIR" ]; then \
@@ -100,7 +100,7 @@ release:	## generate vendor.tar.gz, $(PKG_BASE_NAME).tar.gz, and completions
 	else \
 		echo "Warning: Completions directory not found"; \
 	fi
-	@echo Released binaries in $(CARGO_TARGET_DIR)/$(CARGO_TARGET)/release/: passless, sign-proxy, agent-prompt-probe
+	@echo Released binaries in $(CARGO_TARGET_DIR)/$(CARGO_TARGET)/release/: passless, passless-git-sync, sign-proxy, agent-prompt-probe
 
 .PHONY: update-version
 update-version: ## update version from VERSION file in all Cargo.toml manifests

--- a/cmd/passless/Cargo.toml
+++ b/cmd/passless/Cargo.toml
@@ -16,6 +16,10 @@ name = "passless"
 path = "src/main.rs"
 
 [[bin]]
+name = "passless-git-sync"
+path = "src/bin/passless-git-sync.rs"
+
+[[bin]]
 name = "agent-prompt-probe"
 path = "src/bin/agent-prompt-probe.rs"
 required-features = ["agent-validation"]

--- a/cmd/passless/src/bin/passless-git-sync.rs
+++ b/cmd/passless/src/bin/passless-git-sync.rs
@@ -1,0 +1,76 @@
+use prs_lib::Store;
+use std::ffi::OsString;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("{error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> Result<(), String> {
+    let mut args = std::env::args_os().skip(1);
+    let action = required_arg(&mut args, "action")?;
+    let store_path = required_arg(&mut args, "store path")?;
+
+    let store = Store::open(store_path.to_string_lossy().as_ref())
+        .map_err(|error| format!("failed to open password store: {error:?}"))?;
+
+    match action.to_str() {
+        Some("prepare") => {
+            reject_extra_args(&mut args)?;
+            store
+                .sync()
+                .prepare()
+                .map_err(|error| format!("prepare failed: {error:?}"))
+        }
+        Some("finalize") => {
+            let message = required_arg(&mut args, "commit message")?;
+            reject_extra_args(&mut args)?;
+            let message = message
+                .into_string()
+                .map_err(|_| "commit message is not valid UTF-8".to_string())?;
+            store
+                .sync()
+                .finalize(message)
+                .map_err(|error| format!("finalize failed: {error:?}"))
+        }
+        _ => Err("action must be either 'prepare' or 'finalize'".to_string()),
+    }
+}
+
+fn required_arg(
+    args: &mut impl Iterator<Item = OsString>,
+    name: &str,
+) -> Result<OsString, String> {
+    args.next().ok_or_else(|| format!("missing {name}"))
+}
+
+fn reject_extra_args(args: &mut impl Iterator<Item = OsString>) -> Result<(), String> {
+    if args.next().is_some() {
+        Err("unexpected extra argument".to_string())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn required_arg_rejects_missing_value() {
+        let mut args = Vec::<OsString>::new().into_iter();
+        assert_eq!(required_arg(&mut args, "store path").unwrap_err(), "missing store path");
+    }
+
+    #[test]
+    fn reject_extra_args_accepts_empty_iterator() {
+        let mut args = Vec::<OsString>::new().into_iter();
+        assert!(reject_extra_args(&mut args).is_ok());
+    }
+}

--- a/cmd/passless/src/bin/passless-git-sync.rs
+++ b/cmd/passless/src/bin/passless-git-sync.rs
@@ -43,10 +43,7 @@ fn run() -> Result<(), String> {
     }
 }
 
-fn required_arg(
-    args: &mut impl Iterator<Item = OsString>,
-    name: &str,
-) -> Result<OsString, String> {
+fn required_arg(args: &mut impl Iterator<Item = OsString>, name: &str) -> Result<OsString, String> {
     args.next().ok_or_else(|| format!("missing {name}"))
 }
 
@@ -65,7 +62,10 @@ mod tests {
     #[test]
     fn required_arg_rejects_missing_value() {
         let mut args = Vec::<OsString>::new().into_iter();
-        assert_eq!(required_arg(&mut args, "store path").unwrap_err(), "missing store path");
+        assert_eq!(
+            required_arg(&mut args, "store path").unwrap_err(),
+            "missing store path"
+        );
     }
 
     #[test]

--- a/cmd/passless/src/storage/pass/sync.rs
+++ b/cmd/passless/src/storage/pass/sync.rs
@@ -322,20 +322,14 @@ fn run_sync_helper(
     ssh_auth_sock: &OsStr,
 ) -> Result<(), String> {
     let helper_path = sync_helper_path()?;
-    let output = sync_helper_command(
-        &helper_path,
-        store_path,
-        action,
-        message,
-        ssh_auth_sock,
-    )
-    .output()
-    .map_err(|error| {
-        format!(
-            "failed to invoke {}: {error}",
-            helper_path.to_string_lossy()
-        )
-    })?;
+    let output = sync_helper_command(&helper_path, store_path, action, message, ssh_auth_sock)
+        .output()
+        .map_err(|error| {
+            format!(
+                "failed to invoke {}: {error}",
+                helper_path.to_string_lossy()
+            )
+        })?;
 
     if output.status.success() {
         return Ok(());
@@ -417,7 +411,10 @@ mod tests {
             OsStr::new("/tmp/passless-agent.sock"),
         );
 
-        assert_eq!(command.get_program(), OsStr::new("/usr/bin/passless-git-sync"));
+        assert_eq!(
+            command.get_program(),
+            OsStr::new("/usr/bin/passless-git-sync")
+        );
         assert!(command.get_envs().any(|(key, value)| {
             key == OsStr::new(SSH_AUTH_SOCK_ENV)
                 && value == Some(OsStr::new("/tmp/passless-agent.sock"))

--- a/cmd/passless/src/storage/pass/sync.rs
+++ b/cmd/passless/src/storage/pass/sync.rs
@@ -8,9 +8,18 @@
 use git2::Repository;
 use log::{debug, warn};
 use prs_lib::Store;
+use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
 use std::sync::{Arc, Mutex};
+
+const PASS_GIT_SSH_AUTH_SOCK_ENV: &str = "PASSLESS_PASS_GIT_SSH_AUTH_SOCK";
+const SSH_AUTH_SOCK_ENV: &str = "SSH_AUTH_SOCK";
+#[cfg(not(windows))]
+const PASS_GIT_SYNC_HELPER_BIN: &str = "passless-git-sync";
+#[cfg(windows)]
+const PASS_GIT_SYNC_HELPER_BIN: &str = "passless-git-sync.exe";
 
 #[derive(Debug, Clone)]
 pub struct PassGitSync {
@@ -224,6 +233,15 @@ impl PassGitSync {
 
     fn prepare_store(store_path: &Path) -> Result<(), String> {
         debug!("Preparing password-store Git sync");
+        if let Some(ssh_auth_sock) = configured_ssh_auth_sock() {
+            return run_sync_helper(
+                store_path,
+                SyncHelperAction::Prepare,
+                None,
+                ssh_auth_sock.as_os_str(),
+            );
+        }
+
         let store = Store::open(store_path.to_string_lossy().as_ref())
             .map_err(|error| format!("failed to open store: {error:?}"))?;
         store
@@ -234,12 +252,112 @@ impl PassGitSync {
 
     fn finalize_store(store_path: &Path, message: &str) -> Result<(), String> {
         debug!("Finalizing password-store Git sync: {message}");
+        if let Some(ssh_auth_sock) = configured_ssh_auth_sock() {
+            return run_sync_helper(
+                store_path,
+                SyncHelperAction::Finalize,
+                Some(message),
+                ssh_auth_sock.as_os_str(),
+            );
+        }
+
         let store = Store::open(store_path.to_string_lossy().as_ref())
             .map_err(|error| format!("failed to open store: {error:?}"))?;
         store
             .sync()
             .finalize(message)
             .map_err(|error| format!("finalize failed: {error:?}"))
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum SyncHelperAction {
+    Prepare,
+    Finalize,
+}
+
+impl SyncHelperAction {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Prepare => "prepare",
+            Self::Finalize => "finalize",
+        }
+    }
+}
+
+fn configured_ssh_auth_sock() -> Option<OsString> {
+    std::env::var_os(PASS_GIT_SSH_AUTH_SOCK_ENV).filter(|value| !value.is_empty())
+}
+
+fn sync_helper_path() -> Result<PathBuf, String> {
+    let current_exe = std::env::current_exe()
+        .map_err(|error| format!("failed to resolve Passless executable: {error}"))?;
+    Ok(sync_helper_path_from_exe(&current_exe))
+}
+
+fn sync_helper_path_from_exe(current_exe: &Path) -> PathBuf {
+    current_exe.with_file_name(PASS_GIT_SYNC_HELPER_BIN)
+}
+
+fn sync_helper_command(
+    helper_path: &Path,
+    store_path: &Path,
+    action: SyncHelperAction,
+    message: Option<&str>,
+    ssh_auth_sock: &OsStr,
+) -> Command {
+    let mut command = Command::new(helper_path);
+    command.arg(action.as_str()).arg(store_path);
+    if let Some(message) = message {
+        command.arg(message);
+    }
+    command.env(SSH_AUTH_SOCK_ENV, ssh_auth_sock);
+    command
+}
+
+fn run_sync_helper(
+    store_path: &Path,
+    action: SyncHelperAction,
+    message: Option<&str>,
+    ssh_auth_sock: &OsStr,
+) -> Result<(), String> {
+    let helper_path = sync_helper_path()?;
+    let output = sync_helper_command(
+        &helper_path,
+        store_path,
+        action,
+        message,
+        ssh_auth_sock,
+    )
+    .output()
+    .map_err(|error| {
+        format!(
+            "failed to invoke {}: {error}",
+            helper_path.to_string_lossy()
+        )
+    })?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    Err(sync_helper_failure(&helper_path, &output))
+}
+
+fn sync_helper_failure(helper_path: &Path, output: &Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if stderr.is_empty() {
+        format!(
+            "{} exited with {}",
+            helper_path.to_string_lossy(),
+            output.status
+        )
+    } else {
+        format!(
+            "{} exited with {}: {stderr}",
+            helper_path.to_string_lossy(),
+            output.status
+        )
     }
 }
 
@@ -277,6 +395,40 @@ mod tests {
             exclude
                 .lines()
                 .any(|line| line == "/fido2/pin_retries.local.gpg")
+        );
+    }
+
+    #[test]
+    fn helper_is_resolved_next_to_passless_binary() {
+        let current = Path::new("/usr/bin/passless");
+        assert_eq!(
+            sync_helper_path_from_exe(current),
+            Path::new("/usr/bin").join(PASS_GIT_SYNC_HELPER_BIN)
+        );
+    }
+
+    #[test]
+    fn helper_command_scopes_ssh_auth_sock_to_child() {
+        let command = sync_helper_command(
+            Path::new("/usr/bin/passless-git-sync"),
+            Path::new("/tmp/password-store"),
+            SyncHelperAction::Finalize,
+            Some("Update credential"),
+            OsStr::new("/tmp/passless-agent.sock"),
+        );
+
+        assert_eq!(command.get_program(), OsStr::new("/usr/bin/passless-git-sync"));
+        assert!(command.get_envs().any(|(key, value)| {
+            key == OsStr::new(SSH_AUTH_SOCK_ENV)
+                && value == Some(OsStr::new("/tmp/passless-agent.sock"))
+        }));
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            vec![
+                OsStr::new("finalize"),
+                OsStr::new("/tmp/password-store"),
+                OsStr::new("Update credential"),
+            ]
         );
     }
 }


### PR DESCRIPTION
Fixes #467.

## Problem

A long-running Passless daemon cannot assume that an SSH-agent socket exported by an interactive session will be present in its inherited environment. Ordering Passless after a specific agent unit is not a general solution: it is provider/distro-specific and does not update an already-started process environment.

## Fix

- add `PASSLESS_PASS_GIT_SSH_AUTH_SOCK` as an explicit, stable SSH-agent socket override for pass Git synchronization
- leave the existing behavior completely unchanged when the override is unset: `prs-lib` runs in-process and uses the inherited environment as before
- when the override is set, run `prs-lib` synchronization in a small packaged `passless-git-sync` helper process and set `SSH_AUTH_SOCK` only for that child
- keep `prs-lib` as the sole owner of pull/push/upstream/commit behavior, including its SSH connection-reuse configuration
- package the helper in release archives and the Arch package

The helper avoids mutating Passless's process-wide environment, which would be racy in the multithreaded daemon, without copying `prs-lib`'s private Git synchronization state machine into Passless.

## Configuration

The override is intentionally agent-agnostic. Configure it to the stable socket exposed by the SSH agent used for the password-store remote, for example with a systemd user-service drop-in:

```ini
[Service]
Environment=PASSLESS_PASS_GIT_SSH_AUTH_SOCK=/path/to/agent.sock
```

Then reload/restart the user service. If the override is not configured, Passless continues to use its inherited `SSH_AUTH_SOCK` through `prs-lib` exactly as before.

This works with gpg-agent, OpenSSH ssh-agent, gcr, KeePassXC, 1Password, or any other provider exposing an SSH-agent socket; Passless does not depend on a provider-specific systemd unit.